### PR TITLE
Remodelación de las páginas de TvTropes y mejor tratamiento de errores y docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,7 +314,7 @@ typings/
 !tropestogo/service/scraper/resources/*.html
 
 # ignore .idea folder
-tropestogo/.idea/*
+.idea/
 
 # Ignore all generated datasets
 *.csv

--- a/tropestogo/media/csv_dataset/csv_dataset.go
+++ b/tropestogo/media/csv_dataset/csv_dataset.go
@@ -47,7 +47,6 @@ func NewCSVRepository(name string) (*CSVRepository, error) {
 		writer: writer,
 	}
 
-	// Add headers to the CSV file
 	repository.writer.Write([]string{"title", "year", "lastupdated", "url", "mediatype", "tropes", "tropes_index"})
 	repository.writer.Flush()
 
@@ -65,14 +64,12 @@ func (repository *CSVRepository) GetReader() (*csv.Reader, error) {
 }
 
 func (repository *CSVRepository) AddMedia(newMedia media.Media) error {
-	// Check if the new Media is a duplicate or not by checking its title and year
 	for _, mediaData := range repository.data {
 		if mediaData.GetWork().Title == newMedia.GetWork().Title && mediaData.GetWork().Year == newMedia.GetWork().Year {
 			return Error("Title: "+newMedia.GetWork().Title, ErrDuplicatedMedia, nil)
 		}
 	}
 
-	// Add Media to the repository in memory
 	repository.data = append(repository.data, newMedia)
 
 	return nil
@@ -90,7 +87,6 @@ func (repository *CSVRepository) UpdateMedia(title string, year string, media me
 		return Error(repository.name, ErrReadCsv, errReadAll)
 	}
 
-	// Look for the line that holds the record that needs to be updated
 	updateLine := -1
 	for pos, record := range records {
 		if record[0] == title && record[1] == year {
@@ -99,7 +95,6 @@ func (repository *CSVRepository) UpdateMedia(title string, year string, media me
 		}
 	}
 
-	// Update record
 	input, _ := os.ReadFile(repository.name)
 	lines := strings.Split(string(input), "\n")
 	for linePos := range lines {
@@ -120,10 +115,8 @@ func (repository *CSVRepository) UpdateMedia(title string, year string, media me
 }
 
 func (repository *CSVRepository) RemoveAll() error {
-	// Empty the in-memory data
 	repository.data = []media.Media{}
 
-	// Empty the in-file data
 	if _, err := os.Stat(repository.name); err == nil {
 		csvFile, errRemove := os.Create(repository.name)
 		if errRemove != nil {
@@ -132,7 +125,6 @@ func (repository *CSVRepository) RemoveAll() error {
 
 		repository.writer = csv.NewWriter(csvFile)
 
-		// Add headers to the CSV file
 		repository.writer.Write([]string{"title", "year", "lastupdated", "url", "mediatype", "tropes", "tropes_index"})
 		repository.writer.Flush()
 
@@ -160,7 +152,6 @@ func (repository *CSVRepository) Persist() error {
 	}
 
 	for _, mediaData := range repository.data {
-		// Search if the value already exists on the dataset
 		exists := false
 		for _, record := range records {
 			if record[0] == mediaData.GetWork().Title && record[1] == mediaData.GetWork().Year {
@@ -169,7 +160,6 @@ func (repository *CSVRepository) Persist() error {
 			}
 		}
 
-		// Add record to the CSV file without repeating
 		if !exists {
 			record := CreateMediaRecord(mediaData)
 
@@ -181,7 +171,6 @@ func (repository *CSVRepository) Persist() error {
 		}
 	}
 
-	// Empty in-memory data, because it has been persisted on the dataset file
 	repository.data = []media.Media{}
 
 	return nil
@@ -201,7 +190,6 @@ func CreateMediaRecord(media media.Media) []string {
 		}
 	}
 
-	// A record consists of the following fields: title,year,lastupdated,url,mediatype,tropes
 	record := []string{media.GetWork().Title, media.GetWork().Year, media.GetWork().LastUpdated.Format("2006-01-02 15:04:05"),
 		media.GetPage().GetUrl().String(), media.GetMediaType().String(), strings.Join(tropes, ";"), strings.Join(indexes, ";")}
 

--- a/tropestogo/media/csv_dataset/csv_dataset.go
+++ b/tropestogo/media/csv_dataset/csv_dataset.go
@@ -203,7 +203,7 @@ func CreateMediaRecord(media media.Media) []string {
 
 	// A record consists of the following fields: title,year,lastupdated,url,mediatype,tropes
 	record := []string{media.GetWork().Title, media.GetWork().Year, media.GetWork().LastUpdated.Format("2006-01-02 15:04:05"),
-		media.GetPage().URL.String(), media.GetMediaType().String(), strings.Join(tropes, ";"), strings.Join(indexes, ";")}
+		media.GetPage().GetUrl().String(), media.GetMediaType().String(), strings.Join(tropes, ";"), strings.Join(indexes, ";")}
 
 	return record
 }

--- a/tropestogo/media/csv_dataset/csv_dataset.go
+++ b/tropestogo/media/csv_dataset/csv_dataset.go
@@ -64,16 +64,16 @@ func (repository *CSVRepository) GetReader() (*csv.Reader, error) {
 	return reader, nil
 }
 
-func (repository *CSVRepository) AddMedia(med media.Media) error {
+func (repository *CSVRepository) AddMedia(newMedia media.Media) error {
 	// Check if the new Media is a duplicate or not by checking its title and year
 	for _, mediaData := range repository.data {
-		if mediaData.GetWork().Title == med.GetWork().Title && mediaData.GetWork().Year == med.GetWork().Year {
-			return Error("Title: "+med.GetWork().Title, ErrDuplicatedMedia, nil)
+		if mediaData.GetWork().Title == newMedia.GetWork().Title && mediaData.GetWork().Year == newMedia.GetWork().Year {
+			return Error("Title: "+newMedia.GetWork().Title, ErrDuplicatedMedia, nil)
 		}
 	}
 
 	// Add Media to the repository in memory
-	repository.data = append(repository.data, med)
+	repository.data = append(repository.data, newMedia)
 
 	return nil
 }

--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -156,7 +156,7 @@ var _ = Describe("CsvDataset", func() {
 			repository, errorRepository = csv_dataset.NewCSVRepository("dataset")
 		})
 
-		It("Shouldn't exist a CSV file", func() {
+		It("A CSV file shouldn't exist", func() {
 			Expect("dataset.csv").To(Not(BeAnExistingFile()))
 		})
 

--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -14,6 +14,10 @@ import (
 	"time"
 )
 
+const (
+	oldboyUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
+)
+
 var repository *csv_dataset.CSVRepository
 var errorRepository, errRemoveAll, errAddMedia, errPersist error
 var mediaEntry media.Media
@@ -30,7 +34,7 @@ var _ = BeforeSuite(func() {
 	tropes[trope1] = struct{}{}
 	tropes[trope2] = struct{}{}
 	tropes[trope3] = struct{}{}
-	tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
+	tvTropesUrl, _ := url.Parse(oldboyUrl)
 	tvTropesPage, _ := tropestogo.NewPage(tvTropesUrl)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
@@ -84,7 +88,7 @@ var _ = Describe("CsvDataset", func() {
 			Expect(len(records[1])).To(Equal(7))
 			Expect(records[1][0]).To(Equal("Oldboy"))
 			Expect(records[1][1]).To(Equal("2003"))
-			Expect(records[1][3]).To(Equal("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"))
+			Expect(records[1][3]).To(Equal(oldboyUrl))
 			Expect(records[1][4]).To(Equal("Film"))
 			Expect(len(strings.Split(records[1][5], ";"))).To(Equal(3))
 			Expect(strings.Contains(records[1][5], "AdaptationalLocationChange")).To(BeTrue())
@@ -176,7 +180,7 @@ var _ = Describe("CsvDataset", func() {
 			tropes[trope1] = struct{}{}
 			tropes[trope2] = struct{}{}
 
-			updatedUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2013")
+			updatedUrl, _ := url.Parse(oldboyUrl)
 			tvTropesPage, _ := tropestogo.NewPage(updatedUrl)
 
 			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), tropes, tvTropesPage, media.Film)
@@ -193,7 +197,7 @@ var _ = Describe("CsvDataset", func() {
 			Expect(records[0]).To(Equal([]string{"title", "year", "lastupdated", "url", "mediatype", "tropes", "tropes_index"}))
 			Expect(records[1][0]).To(Equal("Oldboy"))
 			Expect(records[1][1]).To(Equal("2013"))
-			Expect(records[1][3]).To(Equal("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2013"))
+			Expect(records[1][3]).To(Equal(oldboyUrl))
 			Expect(records[1][4]).To(Equal("Film"))
 			Expect(len(strings.Split(records[1][5], ";"))).To(Equal(2))
 			Expect(strings.Contains(records[1][5], "AdaptationalComicRelief")).To(BeTrue())

--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -31,10 +31,7 @@ var _ = BeforeSuite(func() {
 	tropes[trope2] = struct{}{}
 	tropes[trope3] = struct{}{}
 	tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
-	tvTropesPage := &tropestogo.Page{
-		URL:         tvTropesUrl,
-		LastUpdated: time.Now(),
-	}
+	tvTropesPage, _ := tropestogo.NewPage(tvTropesUrl)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
 
@@ -180,10 +177,7 @@ var _ = Describe("CsvDataset", func() {
 			tropes[trope2] = struct{}{}
 
 			updatedUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2013")
-			tvTropesPage := &tropestogo.Page{
-				URL:         updatedUrl,
-				LastUpdated: time.Now(),
-			}
+			tvTropesPage, _ := tropestogo.NewPage(updatedUrl)
 
 			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), tropes, tvTropesPage, media.Film)
 

--- a/tropestogo/media/json_dataset/json_dataset.go
+++ b/tropestogo/media/json_dataset/json_dataset.go
@@ -89,7 +89,7 @@ func (repository *JSONRepository) UpdateMedia(title string, year string, updateM
 			dataset.Tropestogo[pos].Year = updateMedia.GetWork().Year
 			dataset.Tropestogo[pos].MediaType = updateMedia.GetMediaType().String()
 			dataset.Tropestogo[pos].LastUpdated = updateMedia.GetWork().LastUpdated.Format("2006-01-02 15:04:05")
-			dataset.Tropestogo[pos].URL = updateMedia.GetPage().URL.String()
+			dataset.Tropestogo[pos].URL = updateMedia.GetPage().GetUrl().String()
 			dataset.Tropestogo[pos].Tropes = tropes
 
 			break
@@ -168,7 +168,7 @@ func (repository *JSONRepository) Persist() error {
 				Year:        mediaData.GetWork().Year,
 				MediaType:   mediaData.GetMediaType().String(),
 				LastUpdated: mediaData.GetWork().LastUpdated.Format("2006-01-02 15:04:05"),
-				URL:         mediaData.GetPage().URL.String(),
+				URL:         mediaData.GetPage().GetUrl().String(),
 				Tropes:      tropes,
 			}
 

--- a/tropestogo/media/json_dataset/json_dataset.go
+++ b/tropestogo/media/json_dataset/json_dataset.go
@@ -54,14 +54,12 @@ func NewJSONRepository(name string) (*JSONRepository, error) {
 }
 
 func (repository *JSONRepository) AddMedia(newMedia media.Media) error {
-	// Check if the new Media is a duplicate or not by checking its title and year
 	for _, mediaData := range repository.data {
 		if mediaData.GetWork().Title == newMedia.GetWork().Title && mediaData.GetWork().Year == newMedia.GetWork().Year {
 			return Error("Title: "+newMedia.GetWork().Title, ErrDuplicatedMedia, nil)
 		}
 	}
 
-	// Add Media to the repository in memory
 	repository.data = append(repository.data, newMedia)
 
 	return nil
@@ -75,13 +73,11 @@ func (repository *JSONRepository) UpdateMedia(title string, year string, updateM
 		return Error(repository.name, ErrReadJson, errReadDataset)
 	}
 
-	// Get the dataset on structs
 	errUnmarshal := json.Unmarshal(fileContents, &dataset)
 	if errUnmarshal != nil {
 		return Error(repository.name, ErrUnmarshalJson, errUnmarshal)
 	}
 
-	// Look for the record that needs to be updated
 	for pos, record := range dataset.Tropestogo {
 		if record.Title == title && record.Year == year {
 			tropes := media.GetJsonTropes(updateMedia)
@@ -96,7 +92,6 @@ func (repository *JSONRepository) UpdateMedia(title string, year string, updateM
 		}
 	}
 
-	// Update the record and marshal to the file
 	jsonBytes, err := json.Marshal(dataset)
 	if err != nil {
 		return Error("", ErrMarshalJson, err)
@@ -114,7 +109,6 @@ func (repository *JSONRepository) RemoveAll() error {
 	var err error
 	var f *os.File
 
-	// Empty the in-memory data
 	repository.data = []media.Media{}
 
 	if _, err = os.Stat(repository.name); err == nil {
@@ -144,14 +138,12 @@ func (repository *JSONRepository) Persist() error {
 		return Error(repository.name, ErrReadJson, errReadDataset)
 	}
 
-	// Get the JSON array and append the new Media object
 	errUnmarshal := json.Unmarshal(fileContents, &dataset)
 	if errUnmarshal != nil {
 		return Error(repository.name, ErrUnmarshalJson, errUnmarshal)
 	}
 
 	for _, mediaData := range repository.data {
-		// Search if the value already exists on the dataset
 		exists := false
 		for _, datasetMedia := range dataset.Tropestogo {
 			if datasetMedia.Title == mediaData.GetWork().Title && datasetMedia.Year == mediaData.GetWork().Year {
@@ -160,7 +152,6 @@ func (repository *JSONRepository) Persist() error {
 			}
 		}
 
-		// Append without repeating
 		if !exists {
 			tropes := media.GetJsonTropes(mediaData)
 			record := media.JsonResponse{
@@ -176,10 +167,8 @@ func (repository *JSONRepository) Persist() error {
 		}
 	}
 
-	// Empty in-memory data, because it has been persisted on the dataset file
 	repository.data = []media.Media{}
-
-	// Persist the old data + the new data in the JSON file
+	
 	jsonBytes, err := json.Marshal(dataset)
 	if err != nil {
 		return Error("", ErrMarshalJson, err)

--- a/tropestogo/media/json_dataset/json_dataset.go
+++ b/tropestogo/media/json_dataset/json_dataset.go
@@ -53,21 +53,21 @@ func NewJSONRepository(name string) (*JSONRepository, error) {
 	return repository, nil
 }
 
-func (repository *JSONRepository) AddMedia(med media.Media) error {
+func (repository *JSONRepository) AddMedia(newMedia media.Media) error {
 	// Check if the new Media is a duplicate or not by checking its title and year
 	for _, mediaData := range repository.data {
-		if mediaData.GetWork().Title == med.GetWork().Title && mediaData.GetWork().Year == med.GetWork().Year {
-			return Error("Title: "+med.GetWork().Title, ErrDuplicatedMedia, nil)
+		if mediaData.GetWork().Title == newMedia.GetWork().Title && mediaData.GetWork().Year == newMedia.GetWork().Year {
+			return Error("Title: "+newMedia.GetWork().Title, ErrDuplicatedMedia, nil)
 		}
 	}
 
 	// Add Media to the repository in memory
-	repository.data = append(repository.data, med)
+	repository.data = append(repository.data, newMedia)
 
 	return nil
 }
 
-func (repository *JSONRepository) UpdateMedia(title string, year string, med media.Media) error {
+func (repository *JSONRepository) UpdateMedia(title string, year string, updateMedia media.Media) error {
 	var dataset JSONDataset
 
 	fileContents, errReadDataset := os.ReadFile(repository.name)
@@ -84,12 +84,12 @@ func (repository *JSONRepository) UpdateMedia(title string, year string, med med
 	// Look for the record that needs to be updated
 	for pos, record := range dataset.Tropestogo {
 		if record.Title == title && record.Year == year {
-			tropes := media.GetJsonTropes(med)
-			dataset.Tropestogo[pos].Title = med.GetWork().Title
-			dataset.Tropestogo[pos].Year = med.GetWork().Year
-			dataset.Tropestogo[pos].MediaType = med.GetMediaType().String()
-			dataset.Tropestogo[pos].LastUpdated = med.GetWork().LastUpdated.Format("2006-01-02 15:04:05")
-			dataset.Tropestogo[pos].URL = med.GetPage().URL.String()
+			tropes := media.GetJsonTropes(updateMedia)
+			dataset.Tropestogo[pos].Title = updateMedia.GetWork().Title
+			dataset.Tropestogo[pos].Year = updateMedia.GetWork().Year
+			dataset.Tropestogo[pos].MediaType = updateMedia.GetMediaType().String()
+			dataset.Tropestogo[pos].LastUpdated = updateMedia.GetWork().LastUpdated.Format("2006-01-02 15:04:05")
+			dataset.Tropestogo[pos].URL = updateMedia.GetPage().URL.String()
 			dataset.Tropestogo[pos].Tropes = tropes
 
 			break

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -28,10 +28,7 @@ var _ = BeforeSuite(func() {
 	tropes[trope2] = struct{}{}
 	tropes[trope3] = struct{}{}
 	tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
-	tvTropesPage := &tropestogo.Page{
-		URL:         tvTropesUrl,
-		LastUpdated: time.Now(),
-	}
+	tvTropesPage, _ := tropestogo.NewPage(tvTropesUrl)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
 
@@ -168,10 +165,7 @@ var _ = Describe("JsonDataset", func() {
 			tropes[trope2] = struct{}{}
 
 			updatedUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2013")
-			tvTropesPage := &tropestogo.Page{
-				URL:         updatedUrl,
-				LastUpdated: time.Now(),
-			}
+			tvTropesPage, _ := tropestogo.NewPage(updatedUrl)
 
 			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), tropes, tvTropesPage, media.Film)
 

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -14,6 +14,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	oldboyUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
+)
+
 var repository *json_dataset.JSONRepository
 var errorRepository, errRemoveAll, errAddMedia, errPersist error
 var mediaEntry media.Media
@@ -27,7 +31,7 @@ var _ = BeforeSuite(func() {
 	tropes[trope1] = struct{}{}
 	tropes[trope2] = struct{}{}
 	tropes[trope3] = struct{}{}
-	tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
+	tvTropesUrl, _ := url.Parse(oldboyUrl)
 	tvTropesPage, _ := tropestogo.NewPage(tvTropesUrl)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
@@ -75,7 +79,7 @@ var _ = Describe("JsonDataset", func() {
 			Expect(err).To(BeNil())
 			Expect(dataset.Tropestogo[0].Title).To(Equal("Oldboy"))
 			Expect(dataset.Tropestogo[0].Year).To(Equal("2003"))
-			Expect(dataset.Tropestogo[0].URL).To(Equal("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"))
+			Expect(dataset.Tropestogo[0].URL).To(Equal(oldboyUrl))
 			Expect(dataset.Tropestogo[0].MediaType).To(Equal("Film"))
 			Expect(len(dataset.Tropestogo[0].Tropes)).To(Equal(3))
 		})
@@ -164,7 +168,7 @@ var _ = Describe("JsonDataset", func() {
 			tropes[trope1] = struct{}{}
 			tropes[trope2] = struct{}{}
 
-			updatedUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2013")
+			updatedUrl, _ := url.Parse(oldboyUrl)
 			tvTropesPage, _ := tropestogo.NewPage(updatedUrl)
 
 			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), tropes, tvTropesPage, media.Film)
@@ -182,7 +186,7 @@ var _ = Describe("JsonDataset", func() {
 			Expect(len(dataset.Tropestogo)).To(Equal(1))
 			Expect(dataset.Tropestogo[0].Title).To(Equal("Oldboy"))
 			Expect(dataset.Tropestogo[0].Year).To(Equal("2013"))
-			Expect(dataset.Tropestogo[0].URL).To(Equal("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2013"))
+			Expect(dataset.Tropestogo[0].URL).To(Equal(oldboyUrl))
 			Expect(dataset.Tropestogo[0].MediaType).To(Equal("Film"))
 			Expect(len(dataset.Tropestogo[0].Tropes)).To(Equal(2))
 		})

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -144,7 +144,7 @@ var _ = Describe("JsonDataset", func() {
 			repository, errorRepository = json_dataset.NewJSONRepository("dataset")
 		})
 
-		It("Shouldn't exist a JSON file", func() {
+		It("A JSON file shouldn't exist", func() {
 			Expect("dataset.json").To(Not(BeAnExistingFile()))
 		})
 

--- a/tropestogo/media/media.go
+++ b/tropestogo/media/media.go
@@ -26,7 +26,7 @@ const (
 	VideoGames
 )
 
-// Implement Stringer interface for comparing string media types and avoid using literals
+// String is an implementation of the Stringer interface for comparing string media types and avoid using literals
 func (mediatype MediaType) String() string {
 	switch mediatype {
 	case Film:
@@ -42,6 +42,7 @@ func (mediatype MediaType) String() string {
 	}
 }
 
+// IsValid checks whether a MediaType is known or not
 func (mediatype MediaType) IsValid() bool {
 	switch mediatype {
 	case Film, Series, Anime, VideoGames:
@@ -52,6 +53,7 @@ func (mediatype MediaType) IsValid() bool {
 }
 
 // ToMediaType converts a string to a MediaType
+// It returns an ErrUnknownMediaType if the MediaType isn't recognized
 func ToMediaType(mediaTypeString string) (MediaType, error) {
 	for mediatype := UnknownMediaType + 1; mediatype <= VideoGames; mediatype++ {
 		if mediaTypeString == mediatype.String() {
@@ -74,6 +76,7 @@ type Media struct {
 	mediaType MediaType
 }
 
+// JsonResponse is an object for marshaling/unmarshalling a single Media object in Json
 type JsonResponse struct {
 	Title       string      `json:"title"`
 	Year        string      `json:"year"`
@@ -83,11 +86,14 @@ type JsonResponse struct {
 	Tropes      []JsonTrope `json:"tropes"`
 }
 
+// JsonTrope is part of JsonResponse, and represent a trope with the index to which it belongs
 type JsonTrope struct {
 	Title string `json:"title"`
 	Index string `json:"index"`
 }
 
+// MarshalJSON implements Marshaller interface for custom marshalling of Media objects
+// Returns a byte array that can be marshalled into a JSON file
 func (media Media) MarshalJSON() ([]byte, error) {
 	tropes := GetJsonTropes(media)
 
@@ -101,6 +107,7 @@ func (media Media) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// GetJsonTropes receives a media object and transforms it into a JsonTrope array with all its tropes for correct marshalling
 func GetJsonTropes(media Media) []JsonTrope {
 	var tropes []JsonTrope
 	for trope := range media.GetWork().Tropes {
@@ -118,7 +125,9 @@ func GetJsonTropes(media Media) []JsonTrope {
 	return tropes
 }
 
-// NewMedia is a factory that creates a Media aggregate with validations
+// NewMedia is a factory that creates a Media aggregate with validations from a title, year, a set of tropes, a page object and a media type object
+// It returns a correctly formed Media object and an error of type ErrMissingValues if the title or page are empty
+// an ErrInvalidYear if the year isn't real or an ErrUnknownMediaType if the received media type isn't known
 func NewMedia(title, year string, lastUpdated time.Time, tropes map[tropestogo.Trope]struct{}, page tropestogo.Page, mediaType MediaType) (Media, error) {
 	if page.GetUrl() == nil {
 		return Media{}, ErrMissingValues
@@ -154,14 +163,17 @@ func NewMedia(title, year string, lastUpdated time.Time, tropes map[tropestogo.T
 	}, nil
 }
 
+// GetWork returns the Work object that this media object manages
 func (media Media) GetWork() *tropestogo.Work {
 	return media.work
 }
 
+// GetPage returns the Page object that this media object manages
 func (media Media) GetPage() tropestogo.Page {
 	return media.page
 }
 
+// GetMediaType return the type this media belongs to
 func (media Media) GetMediaType() MediaType {
 	return media.mediaType
 }

--- a/tropestogo/media/media.go
+++ b/tropestogo/media/media.go
@@ -124,12 +124,10 @@ func NewMedia(title, year string, lastUpdated time.Time, tropes map[tropestogo.T
 		return Media{}, ErrMissingValues
 	}
 
-	// Check if there's a title. A year can be empty, because not all media will have it extracted
 	if len(title) == 0 {
 		return Media{}, ErrMissingValues
 	}
 
-	// Check if the Year string represents a valid year number (4 digits between 0 and 9)
 	if len(year) > 0 {
 		r, _ := regexp.Compile("^[0-9]{4}$")
 

--- a/tropestogo/media/media.go
+++ b/tropestogo/media/media.go
@@ -68,7 +68,7 @@ type Media struct {
 	work *tropestogo.Work
 
 	// page is the TvTropes webpage from where the Work information is extracted
-	page *tropestogo.Page
+	page tropestogo.Page
 
 	// MediaType is the media index that this work belongs to
 	mediaType MediaType
@@ -96,7 +96,7 @@ func (media Media) MarshalJSON() ([]byte, error) {
 		Year:        media.work.Year,
 		MediaType:   media.mediaType.String(),
 		LastUpdated: media.work.LastUpdated.Format("2006-01-02 15:04:05"),
-		URL:         media.page.URL.String(),
+		URL:         media.page.GetUrl().String(),
 		Tropes:      tropes,
 	})
 }
@@ -119,8 +119,8 @@ func GetJsonTropes(media Media) []JsonTrope {
 }
 
 // NewMedia is a factory that creates a Media aggregate with validations
-func NewMedia(title, year string, lastUpdated time.Time, tropes map[tropestogo.Trope]struct{}, page *tropestogo.Page, mediaType MediaType) (Media, error) {
-	if page == nil {
+func NewMedia(title, year string, lastUpdated time.Time, tropes map[tropestogo.Trope]struct{}, page tropestogo.Page, mediaType MediaType) (Media, error) {
+	if page.GetUrl() == nil {
 		return Media{}, ErrMissingValues
 	}
 
@@ -160,7 +160,7 @@ func (media Media) GetWork() *tropestogo.Work {
 	return media.work
 }
 
-func (media Media) GetPage() *tropestogo.Page {
+func (media Media) GetPage() tropestogo.Page {
 	return media.page
 }
 

--- a/tropestogo/media/media_test.go
+++ b/tropestogo/media/media_test.go
@@ -11,6 +11,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	avengersUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012"
+)
+
 var _ = Describe("Media", func() {
 	var tvTropesPage *tropestogo.Page
 	var lastUpdated time.Time
@@ -23,7 +27,7 @@ var _ = Describe("Media", func() {
 		tropes[trope2] = struct{}{}
 		lastUpdated = time.Now()
 
-		tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012")
+		tvTropesUrl, _ := url.Parse(avengersUrl)
 		tvTropesPage, _ = tropestogo.NewPage(tvTropesUrl)
 	})
 

--- a/tropestogo/media/media_test.go
+++ b/tropestogo/media/media_test.go
@@ -24,10 +24,7 @@ var _ = Describe("Media", func() {
 		lastUpdated = time.Now()
 
 		tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012")
-		tvTropesPage = &tropestogo.Page{
-			URL:         tvTropesUrl,
-			LastUpdated: time.Now(),
-		}
+		tvTropesPage, _ = tropestogo.NewPage(tvTropesUrl)
 	})
 
 	Describe("Create Media", func() {

--- a/tropestogo/media/media_test.go
+++ b/tropestogo/media/media_test.go
@@ -16,7 +16,7 @@ const (
 )
 
 var _ = Describe("Media", func() {
-	var tvTropesPage *tropestogo.Page
+	var tvTropesPage tropestogo.Page
 	var lastUpdated time.Time
 	tropes := make(map[tropestogo.Trope]struct{})
 
@@ -61,12 +61,13 @@ var _ = Describe("Media", func() {
 			var errMediaNoPage error
 
 			BeforeEach(func() {
-				mediaNoPage, errMediaNoPage = media.NewMedia("TheAvengers", "2012", lastUpdated, tropes, nil, media.Film)
+				mediaNoPage, errMediaNoPage = media.NewMedia("TheAvengers", "2012", lastUpdated, tropes, tropestogo.Page{}, media.Film)
 			})
 
 			It("Should return an empty object", func() {
 				Expect(mediaNoPage.GetWork()).To(BeNil())
-				Expect(mediaNoPage.GetPage()).To(BeNil())
+				Expect(mediaNoPage.GetPage().GetUrl()).To(BeNil())
+				Expect(mediaNoPage.GetPage().GetPageType()).To(BeZero())
 				Expect(mediaNoPage.GetMediaType()).To(Equal(media.MediaType(0)))
 			})
 
@@ -80,12 +81,13 @@ var _ = Describe("Media", func() {
 			var errMediaNoTitle error
 
 			BeforeEach(func() {
-				mediaNoTitle, errMediaNoTitle = media.NewMedia("", "2012", lastUpdated, tropes, nil, media.Film)
+				mediaNoTitle, errMediaNoTitle = media.NewMedia("", "2012", lastUpdated, tropes, tropestogo.Page{}, media.Film)
 			})
 
 			It("Should return an empty object", func() {
 				Expect(mediaNoTitle.GetWork()).To(BeNil())
-				Expect(mediaNoTitle.GetPage()).To(BeNil())
+				Expect(mediaNoTitle.GetPage().GetUrl()).To(BeNil())
+				Expect(mediaNoTitle.GetPage().GetPageType()).To(BeZero())
 				Expect(mediaNoTitle.GetMediaType()).To(Equal(media.MediaType(0)))
 			})
 
@@ -104,7 +106,8 @@ var _ = Describe("Media", func() {
 
 			It("Should return an empty object", func() {
 				Expect(mediaNoType.GetWork()).To(BeNil())
-				Expect(mediaNoType.GetPage()).To(BeNil())
+				Expect(mediaNoType.GetPage().GetUrl()).To(BeNil())
+				Expect(mediaNoType.GetPage().GetPageType()).To(BeZero())
 				Expect(mediaNoType.GetMediaType()).To(Equal(media.MediaType(0)))
 			})
 
@@ -123,7 +126,8 @@ var _ = Describe("Media", func() {
 
 			It("Should return an empty object", func() {
 				Expect(mediaWrongYear.GetWork()).To(BeNil())
-				Expect(mediaWrongYear.GetPage()).To(BeNil())
+				Expect(mediaWrongYear.GetPage().GetUrl()).To(BeNil())
+				Expect(mediaWrongYear.GetPage().GetPageType()).To(BeZero())
 				Expect(mediaWrongYear.GetMediaType()).To(Equal(media.MediaType(0)))
 			})
 

--- a/tropestogo/page.go
+++ b/tropestogo/page.go
@@ -10,7 +10,7 @@ import (
 const (
 	TvTropesHostname  = "tvtropes.org"
 	TvTropesPmwiki    = "/pmwiki/pmwiki.php/"
-	TvTropesMainPath  = TvTropesPmwiki + "/Main/"
+	TvTropesMainPath  = TvTropesPmwiki + "Main/"
 	TvTropesIndexPath = "/pmwiki/pagelist_having_pagetype_in_namespace.php"
 )
 

--- a/tropestogo/page.go
+++ b/tropestogo/page.go
@@ -19,6 +19,7 @@ var (
 	ErrBadUrl      = errors.New("invalid URL")
 )
 
+// PageType represents all the relevant types a TvTropes Page can be, so the scraper can know what it is traversing
 type PageType int64
 
 const (
@@ -66,10 +67,12 @@ func NewPage(URL *url.URL) (Page, error) {
 	}, nil
 }
 
+// GetUrl returns the inmutable URL object that defines the Page
 func (page Page) GetUrl() *url.URL {
 	return page.url
 }
 
+// GetPageType returns the PageType enum that represents the type of the Page
 func (page Page) GetPageType() PageType {
 	return page.pageType
 }

--- a/tropestogo/page.go
+++ b/tropestogo/page.go
@@ -1,8 +1,17 @@
 package tropestogo
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 	"time"
+)
+
+const TvTropesHostname = "tvtropes.org"
+
+var (
+	ErrNotTvTropes = errors.New("the URL does not belong to a TvTropes web page")
+	ErrBadUrl      = errors.New("invalid URL")
 )
 
 // Page is a TvTropes Work page for later scraping
@@ -12,4 +21,19 @@ type Page struct {
 
 	// LastUpdated is the last time the page was updated, for helping with maintaining information updated
 	LastUpdated time.Time
+}
+
+func NewPage(URL *url.URL) (*Page, error) {
+	if URL == nil {
+		return nil, fmt.Errorf("%w: URL object is null", ErrBadUrl)
+	}
+
+	if URL.Hostname() != TvTropesHostname {
+		return nil, ErrNotTvTropes
+	}
+
+	return &Page{
+		URL:         URL,
+		LastUpdated: time.Now(),
+	}, nil
 }

--- a/tropestogo/page_test.go
+++ b/tropestogo/page_test.go
@@ -8,6 +8,10 @@ import (
 	"net/url"
 )
 
+const (
+	oldboyUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
+)
+
 var _ = Describe("Page", func() {
 	var validPage, invalidPage, nullPage *tropestogo.Page
 	var validUrl, invalidUrl *url.URL
@@ -15,7 +19,7 @@ var _ = Describe("Page", func() {
 
 	Context("Create a TvTropes Page object", func() {
 		BeforeEach(func() {
-			validUrl, _ = url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
+			validUrl, _ = url.Parse(oldboyUrl)
 			validPage, errValidPage = tropestogo.NewPage(validUrl)
 		})
 

--- a/tropestogo/page_test.go
+++ b/tropestogo/page_test.go
@@ -1,0 +1,60 @@
+package tropestogo_test
+
+import (
+	"errors"
+	tropestogo "github.com/jlgallego99/TropesToGo"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net/url"
+)
+
+var _ = Describe("Page", func() {
+	var validPage, invalidPage, nullPage *tropestogo.Page
+	var validUrl, invalidUrl *url.URL
+	var errValidPage, errInvalidPage, errNullPage error
+
+	Context("Create a TvTropes Page object", func() {
+		BeforeEach(func() {
+			validUrl, _ = url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
+			validPage, errValidPage = tropestogo.NewPage(validUrl)
+		})
+
+		It("Shouldn't return an error", func() {
+			Expect(errValidPage).To(BeNil())
+		})
+
+		It("Should return a correct Page object", func() {
+			Expect(validPage.URL).To(Equal(validUrl))
+			Expect(validPage.LastUpdated).To(Not(BeZero()))
+		})
+	})
+
+	Context("Create a Page object of a web that isn't TvTropes", func() {
+		BeforeEach(func() {
+			invalidUrl, _ = url.Parse("htttps://google.com")
+			invalidPage, errInvalidPage = tropestogo.NewPage(invalidUrl)
+		})
+
+		It("Should return an error", func() {
+			Expect(errors.Is(errInvalidPage, tropestogo.ErrNotTvTropes)).To(BeTrue())
+		})
+
+		It("Shouldn't return a Page object", func() {
+			Expect(invalidPage).To(BeNil())
+		})
+	})
+
+	Context("Create a Page with a null URL", func() {
+		BeforeEach(func() {
+			nullPage, errNullPage = tropestogo.NewPage(nil)
+		})
+
+		It("Should return an error", func() {
+			Expect(errors.Is(errNullPage, tropestogo.ErrBadUrl)).To(BeTrue())
+		})
+
+		It("Shouldn't return a Page object", func() {
+			Expect(nullPage).To(BeNil())
+		})
+	})
+})

--- a/tropestogo/page_test.go
+++ b/tropestogo/page_test.go
@@ -10,14 +10,17 @@ import (
 
 const (
 	oldboyUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
+	tropeUrl  = "https://tvtropes.org/pmwiki/pmwiki.php/Main/AboveGoodAndEvil"
+	googleUrl = "https://www.google.com/"
+	indexUrl  = "https://tvtropes.org/pmwiki/pagelist_having_pagetype_in_namespace.php?n=Film&t=work"
 )
 
 var _ = Describe("Page", func() {
-	var validPage, invalidPage, nullPage *tropestogo.Page
+	var validPage, invalidPage, nullPage tropestogo.Page
 	var validUrl, invalidUrl *url.URL
 	var errValidPage, errInvalidPage, errNullPage error
 
-	Context("Create a TvTropes Page object", func() {
+	Context("Create a TvTropes Page object of a Film page", func() {
 		BeforeEach(func() {
 			validUrl, _ = url.Parse(oldboyUrl)
 			validPage, errValidPage = tropestogo.NewPage(validUrl)
@@ -28,14 +31,61 @@ var _ = Describe("Page", func() {
 		})
 
 		It("Should return a correct Page object", func() {
-			Expect(validPage.URL).To(Equal(validUrl))
-			Expect(validPage.LastUpdated).To(Not(BeZero()))
+			Expect(validPage.GetUrl()).To(Not(BeNil()))
+			Expect(validPage.GetPageType()).To(Not(BeZero()))
+			Expect(validPage.GetUrl()).To(Equal(validUrl))
+		})
+
+		It("Should be of type WorkPage", func() {
+			Expect(validPage.GetPageType()).To(Equal(tropestogo.WorkPage))
+		})
+	})
+
+	Context("Create a TvTropes Page object of a Trope page", func() {
+		BeforeEach(func() {
+			validUrl, _ = url.Parse(tropeUrl)
+			validPage, errValidPage = tropestogo.NewPage(validUrl)
+		})
+
+		It("Shouldn't return an error", func() {
+			Expect(errValidPage).To(BeNil())
+		})
+
+		It("Should return a correct Page object", func() {
+			Expect(validPage.GetUrl()).To(Not(BeNil()))
+			Expect(validPage.GetPageType()).To(Not(BeZero()))
+			Expect(validPage.GetUrl()).To(Equal(validUrl))
+		})
+
+		It("Should be of type MainPage", func() {
+			Expect(validPage.GetPageType()).To(Equal(tropestogo.MainPage))
+		})
+	})
+
+	Context("Create a TvTropes Page object of a Index page", func() {
+		BeforeEach(func() {
+			validUrl, _ = url.Parse(indexUrl)
+			validPage, errValidPage = tropestogo.NewPage(validUrl)
+		})
+
+		It("Shouldn't return an error", func() {
+			Expect(errValidPage).To(BeNil())
+		})
+
+		It("Should return a correct Page object", func() {
+			Expect(validPage.GetUrl()).To(Not(BeNil()))
+			Expect(validPage.GetPageType()).To(Not(BeZero()))
+			Expect(validPage.GetUrl()).To(Equal(validUrl))
+		})
+
+		It("Should be of type MainPage", func() {
+			Expect(validPage.GetPageType()).To(Equal(tropestogo.IndexPage))
 		})
 	})
 
 	Context("Create a Page object of a web that isn't TvTropes", func() {
 		BeforeEach(func() {
-			invalidUrl, _ = url.Parse("htttps://google.com")
+			invalidUrl, _ = url.Parse(googleUrl)
 			invalidPage, errInvalidPage = tropestogo.NewPage(invalidUrl)
 		})
 
@@ -43,8 +93,9 @@ var _ = Describe("Page", func() {
 			Expect(errors.Is(errInvalidPage, tropestogo.ErrNotTvTropes)).To(BeTrue())
 		})
 
-		It("Shouldn't return a Page object", func() {
-			Expect(invalidPage).To(BeNil())
+		It("Should return an empty Page object", func() {
+			Expect(invalidPage.GetUrl()).To(BeNil())
+			Expect(invalidPage.GetPageType()).To(BeZero())
 		})
 	})
 
@@ -57,8 +108,9 @@ var _ = Describe("Page", func() {
 			Expect(errors.Is(errNullPage, tropestogo.ErrBadUrl)).To(BeTrue())
 		})
 
-		It("Shouldn't return a Page object", func() {
-			Expect(nullPage).To(BeNil())
+		It("Should return an empty Page object", func() {
+			Expect(nullPage.GetUrl()).To(BeNil())
+			Expect(nullPage.GetPageType()).To(BeZero())
 		})
 	})
 })

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -221,6 +221,10 @@ func (scraper *ServiceScraper) ScrapeTvTropesPage(page *tropestogo.Page) (media.
 // ScrapeWorkPage accepts a reader with a TvTropes Work Page contens and extracts all the relevant information from it
 func (scraper *ServiceScraper) ScrapeWorkPage(reader io.Reader, tvtropesUrl *url.URL) (media.Media, error) {
 	doc, _ := goquery.NewDocumentFromReader(reader)
+	page, errNewPage := tropestogo.NewPage(tvtropesUrl)
+	if errNewPage != nil {
+		return media.Media{}, fmt.Errorf("Error creating Page object \n%w", errNewPage)
+	}
 
 	title, year, mediaIndex, errMediaIndex := scraper.ScrapeWorkTitleAndYear(doc)
 	if errMediaIndex != nil {
@@ -232,10 +236,6 @@ func (scraper *ServiceScraper) ScrapeWorkPage(reader io.Reader, tvtropesUrl *url
 		return media.Media{}, errTropes
 	}
 
-	page := &tropestogo.Page{
-		URL:         tvtropesUrl,
-		LastUpdated: time.Now(),
-	}
 	newMedia, errNewMedia := media.NewMedia(title, year, time.Now(), tropes, page, mediaIndex)
 	if errNewMedia != nil {
 		return media.Media{}, errNewMedia

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -93,13 +93,13 @@ func ConfigMediaRepository(mr media.RepositoryMedia) ScraperConfig {
 }
 
 // CheckTvTropesPage makes an HTTP request to a TvTropes page and checks if it's valid for scraping
-func (scraper *ServiceScraper) CheckTvTropesPage(page *tropestogo.Page) (bool, error) {
-	res, err := http.Get(page.URL.String())
+func (scraper *ServiceScraper) CheckTvTropesPage(page tropestogo.Page) (bool, error) {
+	res, err := http.Get(page.GetUrl().String())
 	if err != nil {
-		return false, fmt.Errorf("%w: "+page.URL.String(), ErrNotFound)
+		return false, fmt.Errorf("%w: "+page.GetUrl().String(), ErrNotFound)
 	}
 
-	return scraper.CheckValidWorkPage(res.Body, page.URL)
+	return scraper.CheckValidWorkPage(res.Body, page.GetUrl())
 }
 
 // CheckValidWorkPage accepts a reader with a webpage contents and checks if it's a valid TvTropes Work page
@@ -209,13 +209,13 @@ func (scraper *ServiceScraper) CheckTropesOnFolders(doc *goquery.Document) bool 
 }
 
 // ScrapeTvTropesPage makes an HTTP request to a TvTropes page and scrapes its contents
-func (scraper *ServiceScraper) ScrapeTvTropesPage(page *tropestogo.Page) (media.Media, error) {
-	res, err := http.Get(page.URL.String())
+func (scraper *ServiceScraper) ScrapeTvTropesPage(page tropestogo.Page) (media.Media, error) {
+	res, err := http.Get(page.GetUrl().String())
 	if err != nil {
-		return media.Media{}, fmt.Errorf("%w: "+page.URL.String(), ErrNotFound)
+		return media.Media{}, fmt.Errorf("%w: "+page.GetUrl().String(), ErrNotFound)
 	}
 
-	return scraper.ScrapeWorkPage(res.Body, page.URL)
+	return scraper.ScrapeWorkPage(res.Body, page.GetUrl())
 }
 
 // ScrapeWorkPage accepts a reader with a TvTropes Work Page contens and extracts all the relevant information from it

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -48,6 +48,8 @@ const (
 // Each function acts as one configuration for the scraper
 type ScraperConfig func(ss *ServiceScraper) error
 
+// ServiceScraper manages the TropesToGo scraper for checking TvTropes pages, extracting/cleaning its information
+// and persisting the data on a RepositoryMedia
 type ServiceScraper struct {
 	// TvTropes index
 	index index.RepositoryIndex
@@ -55,7 +57,7 @@ type ServiceScraper struct {
 	data media.RepositoryMedia
 }
 
-// NewServiceScraper takes a variable amount of configuration functions and returns a ServiceScraper with all configs passed
+// NewServiceScraper takes a variable amount of configuration functions, applies them and returns a ServiceScraper with all configs passed
 func NewServiceScraper(cfgs ...ScraperConfig) (*ServiceScraper, error) {
 	ss := &ServiceScraper{}
 	for _, cfg := range cfgs {
@@ -68,6 +70,7 @@ func NewServiceScraper(cfgs ...ScraperConfig) (*ServiceScraper, error) {
 	return ss, nil
 }
 
+// ConfigIndexRepository defines a function that applies a RepositoryIndex so it can be used as a config when creating a ServiceScraper
 func ConfigIndexRepository(ir index.RepositoryIndex) ScraperConfig {
 	return func(ss *ServiceScraper) error {
 		if ir == nil {
@@ -79,6 +82,8 @@ func ConfigIndexRepository(ir index.RepositoryIndex) ScraperConfig {
 	}
 }
 
+// ConfigMediaRepository defines a function that applies a RepositoryMedia so it can be used as a config when creating a ServiceScraper
+// It accepts any implementation of a RepositoryMedia, so it can accept either a CSVRepository or a JSONRepository for defining the persistence model
 func ConfigMediaRepository(mr media.RepositoryMedia) ScraperConfig {
 	return func(ss *ServiceScraper) error {
 		if mr == nil {
@@ -90,7 +95,9 @@ func ConfigMediaRepository(mr media.RepositoryMedia) ScraperConfig {
 	}
 }
 
-// CheckTvTropesPage makes an HTTP request to a TvTropes page and checks if it's valid for scraping
+// CheckTvTropesPage makes an HTTP request to a TvTropes web page and checks if it's valid for scraping
+// If the page doesn't exist, it returns an ErrNotFound error
+// It returns true if all checks passes
 func (scraper *ServiceScraper) CheckTvTropesPage(page tropestogo.Page) (bool, error) {
 	res, err := http.Get(page.GetUrl().String())
 	if err != nil {
@@ -100,8 +107,12 @@ func (scraper *ServiceScraper) CheckTvTropesPage(page tropestogo.Page) (bool, er
 	return scraper.CheckValidWorkPage(res.Body, page.GetUrl())
 }
 
-// CheckValidWorkPage accepts a reader with a webpage contents and checks if it's a valid TvTropes Work page
+// CheckValidWorkPage accepts any reader (whether it's from an URL or a local HTML file) with a webpage contents
+// and checks if it's a valid TvTropes Work page
 // This allows the scraper to check if TvTropes template has somewhat changed and if the scraper can extract its data
+// It full-checks a TvTropes page, validating if its url is one of a TvTropes Work Page,
+// if it's main article has a known structure that can be scraped and if trope section can also be scraped and contains valid tropes
+// It returns true if all checks passes
 func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, url *url.URL) (bool, error) {
 	doc, err := goquery.NewDocumentFromReader(reader)
 	if err != nil {
@@ -126,7 +137,9 @@ func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, url *url.URL
 	return true, nil
 }
 
-// CheckIsWorkPage checks if the received page belongs to a tvtropes.org Work page
+// CheckIsWorkPage checks if the received url belongs to a tvtropes.org Work Page
+// It returns an ErrNotTvTropes error if it doesn't belong to TvTropes or a ErrNotWorkPage if it's from TvTropes but of any other type
+// It returns true if all checks passes
 func (scraper *ServiceScraper) CheckIsWorkPage(url *url.URL) (bool, error) {
 	if url.Hostname() != TvTropesHostname {
 		return false, fmt.Errorf("%w: "+url.String(), ErrNotTvTropes)
@@ -140,7 +153,10 @@ func (scraper *ServiceScraper) CheckIsWorkPage(url *url.URL) (bool, error) {
 	return true, nil
 }
 
-// CheckMainArticle checks if the tvtropes work main article page has a known structure which can be extracted later
+// CheckMainArticle checks the received goquery Document DOM Tree
+// and validates if the work main article page has a known structure which can be extracted later
+// If it doesn't recognize something in it, it returns an ErrUnknownPageStructure or an ErrNotWorkPage, so it can't be scraped
+// It returns true if all checks passes
 func (scraper *ServiceScraper) CheckMainArticle(doc *goquery.Document) (bool, error) {
 	if doc.Find(MainArticleSelector).Length() == 0 ||
 		doc.Find(SubPagesNavSelector).Find(SubPageListSelector).Find(SubPageLinkSelector).Length() == 0 {
@@ -155,7 +171,10 @@ func (scraper *ServiceScraper) CheckMainArticle(doc *goquery.Document) (bool, er
 	return true, nil
 }
 
-// CheckTropeSection check if the tropes on the TvTropes Work Page are arranged in a known way that can be scraped
+// CheckTropeSection checks the received goquery Document DOM Tree
+// and validates if the tropes on the TvTropes Work Page are arranged in a known way that can be scraped
+// If the trope section isn't of the recognized types, it returns an ErrUnknownPageStructure, so it can't be scraped
+// It returns true if all checks passes
 func (scraper *ServiceScraper) CheckTropeSection(doc *goquery.Document) (bool, error) {
 	if doc.Find(TropeListSelector).Length() != 0 {
 		if doc.Find(TropeLinkSelector).Length() != 0 {
@@ -183,7 +202,8 @@ func (scraper *ServiceScraper) CheckTropeSection(doc *goquery.Document) (bool, e
 	return false, ErrUnknownPageStructure
 }
 
-// CheckTropesOnFolders validates whether tropes are presented on folders
+// CheckTropesOnFolders checks the received goquery Document DOM Tree and validates whether tropes are presented on folders
+// It returns true if all checks passes
 func (scraper *ServiceScraper) CheckTropesOnFolders(doc *goquery.Document) bool {
 	folderFunctionName, existsFolderButton := doc.Find(TropeFolderSelector).Attr("onclick")
 	if existsFolderButton && folderFunctionName == FolderToggleFunction {
@@ -193,7 +213,8 @@ func (scraper *ServiceScraper) CheckTropesOnFolders(doc *goquery.Document) bool 
 	return false
 }
 
-// ScrapeTvTropesPage makes an HTTP request to a TvTropes page and scrapes its contents
+// ScrapeTvTropesPage makes an HTTP request to a TvTropes page and fully scrapes its contents, calling all sub functions and returning a valid Media object
+// If the url of the page isn't found, it returns an ErrNotFound error
 func (scraper *ServiceScraper) ScrapeTvTropesPage(page tropestogo.Page) (media.Media, error) {
 	res, err := http.Get(page.GetUrl().String())
 	if err != nil {
@@ -203,7 +224,10 @@ func (scraper *ServiceScraper) ScrapeTvTropesPage(page tropestogo.Page) (media.M
 	return scraper.ScrapeWorkPage(res.Body, page.GetUrl())
 }
 
-// ScrapeWorkPage accepts a reader with a TvTropes Work Page contens and extracts all the relevant information from it
+// ScrapeWorkPage accepts a reader with a TvTropes Work Page contents and extracts all the relevant information from it
+// and the url from the second parameter
+// It scrapes the title, year, media type and all tropes, finally returning a correctly formed media object with all the data
+// It calls sub functions for scraping the multiple parts and returns an error if some scraping has failed
 func (scraper *ServiceScraper) ScrapeWorkPage(reader io.Reader, url *url.URL) (media.Media, error) {
 	doc, _ := goquery.NewDocumentFromReader(reader)
 	page, errNewPage := tropestogo.NewPage(url)
@@ -230,7 +254,9 @@ func (scraper *ServiceScraper) ScrapeWorkPage(reader io.Reader, url *url.URL) (m
 	return newMedia, errAddMedia
 }
 
-// ScrapeWorkTitleAndYear extracts the title, the year on the title/URL if it's there and the media index from the HTML document of a Work Page
+// ScrapeWorkTitleAndYear traverses the received goquery Document DOM Tree and extracts
+// the title, the year and the media index from the title section of the article of a Work Page
+// It returns the title, the year, the media type and an ErrUnknownMediaType error if the media type isn't known
 func (scraper *ServiceScraper) ScrapeWorkTitleAndYear(doc *goquery.Document) (string, string, media.MediaType, error) {
 	var title, year string
 	var mediaIndex media.MediaType
@@ -258,7 +284,8 @@ func (scraper *ServiceScraper) ScrapeWorkTitleAndYear(doc *goquery.Document) (st
 	return title, year, mediaIndex, errMediaIndex
 }
 
-// ScrapeWorkTropes extracts all the tropes from the HTML document of a Work Page
+// ScrapeWorkTropes traverses the received goquery Document DOM Tree and extracts all the tropes from the main trope section of a Work Page
+// It returns a set (map of trope keys and empty values) of all the unique tropes found on the web page
 func (scraper *ServiceScraper) ScrapeWorkTropes(doc *goquery.Document) (map[tropestogo.Trope]struct{}, error) {
 	tropes := make(map[tropestogo.Trope]struct{}, 0)
 	var newTrope tropestogo.Trope
@@ -294,7 +321,9 @@ func (scraper *ServiceScraper) ScrapeWorkTropes(doc *goquery.Document) (map[trop
 	return tropes, nil
 }
 
-// Persist writes all scraped data in the repository
+// Persist calls the same method on the RepositoryMedia that is defined for the scraper and writes all data in the repository file
+// If the internal data structure is empty, it will do nothing and return an ErrPersist error
+// or return the proper Reading/Writing errors depending on the implementation
 func (scraper *ServiceScraper) Persist() error {
 	return scraper.data.Persist()
 }

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -104,13 +104,13 @@ func (scraper *ServiceScraper) CheckTvTropesPage(page *tropestogo.Page) (bool, e
 
 // CheckValidWorkPage accepts a reader with a webpage contents and checks if it's a valid TvTropes Work page
 // This allows the scraper to check if TvTropes template has somewhat changed and if the scraper can extract its data
-func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, tvtropesUrl *url.URL) (bool, error) {
+func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, url *url.URL) (bool, error) {
 	doc, err := goquery.NewDocumentFromReader(reader)
 	if err != nil {
 		return false, ErrNotTvTropes
 	}
 
-	validWorkPage, errWorkPage := scraper.CheckIsWorkPage(tvtropesUrl)
+	validWorkPage, errWorkPage := scraper.CheckIsWorkPage(url)
 	if !validWorkPage {
 		return false, errWorkPage
 	}
@@ -129,16 +129,16 @@ func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, tvtropesUrl 
 }
 
 // CheckIsWorkPage checks if the received page belongs to a tvtropes.org Work page
-func (scraper *ServiceScraper) CheckIsWorkPage(tvtropesUrl *url.URL) (bool, error) {
+func (scraper *ServiceScraper) CheckIsWorkPage(url *url.URL) (bool, error) {
 	// First check if the domain is TvTropes
-	if tvtropesUrl.Hostname() != TvTropesHostname {
-		return false, fmt.Errorf("%w: "+tvtropesUrl.String(), ErrNotTvTropes)
+	if url.Hostname() != TvTropesHostname {
+		return false, fmt.Errorf("%w: "+url.String(), ErrNotTvTropes)
 	}
 
 	// Check if it's a Film Work page
-	splitPath := strings.Split(tvtropesUrl.Path, "/")
-	if !strings.HasPrefix(tvtropesUrl.Path, TvTropesPmwiki) || splitPath[3] != media.Film.String() {
-		return false, fmt.Errorf("%w: "+tvtropesUrl.String(), ErrNotWorkPage)
+	splitPath := strings.Split(url.Path, "/")
+	if !strings.HasPrefix(url.Path, TvTropesPmwiki) || splitPath[3] != media.Film.String() {
+		return false, fmt.Errorf("%w: "+url.String(), ErrNotWorkPage)
 	}
 
 	return true, nil
@@ -219,9 +219,9 @@ func (scraper *ServiceScraper) ScrapeTvTropesPage(page *tropestogo.Page) (media.
 }
 
 // ScrapeWorkPage accepts a reader with a TvTropes Work Page contens and extracts all the relevant information from it
-func (scraper *ServiceScraper) ScrapeWorkPage(reader io.Reader, tvtropesUrl *url.URL) (media.Media, error) {
+func (scraper *ServiceScraper) ScrapeWorkPage(reader io.Reader, url *url.URL) (media.Media, error) {
 	doc, _ := goquery.NewDocumentFromReader(reader)
-	page, errNewPage := tropestogo.NewPage(tvtropesUrl)
+	page, errNewPage := tropestogo.NewPage(url)
 	if errNewPage != nil {
 		return media.Media{}, fmt.Errorf("Error creating Page object \n%w", errNewPage)
 	}

--- a/tropestogo/service/scraper/scraper_test.go
+++ b/tropestogo/service/scraper/scraper_test.go
@@ -18,6 +18,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	oldboyUrl        = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
+	anewhopeUrl      = "https://tvtropes.org/pmwiki/pmwiki.php/Film/ANewHope"
+	avengersUrl      = "https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012"
+	mediaUrl         = "https://tvtropes.org/pmwiki/pmwiki.php/Main/Media"
+	googleUrl        = "https://www.google.com/"
+	attackontitanUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Manga/AttackOnTitan"
+)
+
 // A scraper service for test purposes
 var serviceScraperJson, serviceScraperCsv, invalidScraper *scraper.ServiceScraper
 var newScraperJsonErr, newScraperCsvErr, invalidScraperErr, errPersistJson, errPersistCsv error
@@ -67,7 +76,7 @@ var _ = Describe("Scraper", func() {
 			var errTvTropesCsv, errTvTropesJson error
 
 			BeforeEach(func() {
-				tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
+				tvTropesUrl, _ := url.Parse(oldboyUrl)
 				pageReaderJson, _ = os.Open("resources/oldboy2003.html")
 				pageReaderCsv, _ = os.Open("resources/oldboy2003.html")
 
@@ -96,7 +105,7 @@ var _ = Describe("Scraper", func() {
 			var errTvTropes2Csv, errTvTropes2Json error
 
 			BeforeEach(func() {
-				tvTropesUrl2, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012")
+				tvTropesUrl2, _ := url.Parse(avengersUrl)
 				pageReaderJson, _ = os.Open("resources/theavengers2012.html")
 				pageReaderCsv, _ = os.Open("resources/theavengers2012.html")
 
@@ -125,7 +134,7 @@ var _ = Describe("Scraper", func() {
 			var errTvTropes3Csv, errTvTropes3Json error
 
 			BeforeEach(func() {
-				tvTropesUrl3, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/ANewHope")
+				tvTropesUrl3, _ := url.Parse(anewhopeUrl)
 				pageReaderCsv, _ = os.Open("resources/anewhope.html")
 				pageReaderJson, _ = os.Open("resources/anewhope.html")
 
@@ -154,7 +163,7 @@ var _ = Describe("Scraper", func() {
 			var errNotWorkPageCsv, errNotWorkPageJson error
 
 			BeforeEach(func() {
-				notWorkUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Main/Media")
+				notWorkUrl, _ := url.Parse(mediaUrl)
 
 				validNotWorkPageJson, errNotWorkPageJson = serviceScraperJson.CheckIsWorkPage(notWorkUrl)
 				validNotWorkPageCsv, errNotWorkPageCsv = serviceScraperCsv.CheckIsWorkPage(notWorkUrl)
@@ -176,7 +185,7 @@ var _ = Describe("Scraper", func() {
 			var errDifferentCsv, errDifferentJson error
 
 			BeforeEach(func() {
-				differentUrl, _ := url.Parse("https://www.google.com/")
+				differentUrl, _ := url.Parse(googleUrl)
 				validDifferentPageJson, errDifferentJson = serviceScraperJson.CheckIsWorkPage(differentUrl)
 				validDifferentPageCsv, errDifferentCsv = serviceScraperCsv.CheckIsWorkPage(differentUrl)
 			})
@@ -199,7 +208,7 @@ var _ = Describe("Scraper", func() {
 			var errorfilm1Csv, errorfilm1Json error
 
 			BeforeEach(func() {
-				tvTropesUrl, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003")
+				tvTropesUrl, _ := url.Parse(oldboyUrl)
 				pageReaderCsv, _ = os.Open("resources/oldboy2003.html")
 				pageReaderJson, _ = os.Open("resources/oldboy2003.html")
 
@@ -242,7 +251,7 @@ var _ = Describe("Scraper", func() {
 				Expect(err).To(BeNil())
 				Expect(dataset.Tropestogo[0].Title).To(Equal("Oldboy"))
 				Expect(dataset.Tropestogo[0].Year).To(Equal("2003"))
-				Expect(dataset.Tropestogo[0].URL).To(Equal("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"))
+				Expect(dataset.Tropestogo[0].URL).To(Equal(oldboyUrl))
 				Expect(dataset.Tropestogo[0].MediaType).To(Equal("Film"))
 				Expect(len(dataset.Tropestogo[0].Tropes) > 0).To(BeTrue())
 			})
@@ -259,7 +268,7 @@ var _ = Describe("Scraper", func() {
 				Expect(len(records[1])).To(Equal(7))
 				Expect(records[1][0]).To(Equal("Oldboy"))
 				Expect(records[1][1]).To(Equal("2003"))
-				Expect(records[1][3]).To(Equal("https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"))
+				Expect(records[1][3]).To(Equal(oldboyUrl))
 				Expect(records[1][4]).To(Equal("Film"))
 				Expect(len(strings.Split(records[1][5], ";")) > 0).To(BeTrue())
 			})
@@ -270,7 +279,7 @@ var _ = Describe("Scraper", func() {
 			var errorfilm3Csv, errorfilm3Json error
 
 			BeforeEach(func() {
-				tvTropesUrl3, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/ANewHope")
+				tvTropesUrl3, _ := url.Parse(anewhopeUrl)
 				pageReaderCsv, _ = os.Open("resources/anewhope.html")
 				pageReaderJson, _ = os.Open("resources/anewhope.html")
 
@@ -311,7 +320,7 @@ var _ = Describe("Scraper", func() {
 			var errorfilminvalidtypeJson, errorfilminvalidtypeCsv error
 
 			BeforeEach(func() {
-				tvTropesUrlUnknown, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Manga/AttackOnTitan")
+				tvTropesUrlUnknown, _ := url.Parse(attackontitanUrl)
 				pageReaderCsv, _ = os.Open("resources/attackontitan.html")
 				pageReaderJson, _ = os.Open("resources/attackontitan.html")
 

--- a/tropestogo/service/scraper/scraper_test.go
+++ b/tropestogo/service/scraper/scraper_test.go
@@ -337,11 +337,13 @@ var _ = Describe("Scraper", func() {
 
 			It("Should return an empty media object", func() {
 				Expect(filminvalidtypeJson.GetWork()).To(BeNil())
-				Expect(filminvalidtypeJson.GetPage()).To(BeNil())
+				Expect(filminvalidtypeJson.GetPage().GetUrl()).To(BeNil())
+				Expect(filminvalidtypeJson.GetPage().GetPageType()).To(BeZero())
 				Expect(filminvalidtypeJson.GetMediaType()).To(Equal(media.UnknownMediaType))
 
 				Expect(filminvalidtypeCsv.GetWork()).To(BeNil())
-				Expect(filminvalidtypeCsv.GetPage()).To(BeNil())
+				Expect(filminvalidtypeCsv.GetPage().GetUrl()).To(BeNil())
+				Expect(filminvalidtypeCsv.GetPage().GetPageType()).To(BeZero())
 				Expect(filminvalidtypeCsv.GetMediaType()).To(Equal(media.UnknownMediaType))
 			})
 

--- a/tropestogo/trope.go
+++ b/tropestogo/trope.go
@@ -62,7 +62,8 @@ type Trope struct {
 	index TropeIndex
 }
 
-// NewTrope is a factory that creates a valid Trope value object
+// NewTrope is a factory that creates a valid Trope value object by receiving its name and the index to which it belongs
+// It checks if the index is valid and returns an ErrUnknownIndex if it's not
 func NewTrope(title string, index TropeIndex) (Trope, error) {
 	if len(title) == 0 {
 		return Trope{}, ErrMissingValues
@@ -78,10 +79,12 @@ func NewTrope(title string, index TropeIndex) (Trope, error) {
 	}, nil
 }
 
+// GetTitle returns the main identifier of the trope: its title
 func (trope Trope) GetTitle() string {
 	return trope.title
 }
 
+// GetIndex returns the main category this trope belongs to in narratives
 func (trope Trope) GetIndex() TropeIndex {
 	return trope.index
 }

--- a/tropestogo/tvtropespages.go
+++ b/tropestogo/tvtropespages.go
@@ -1,0 +1,50 @@
+package tropestogo
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+var (
+	ErrDuplicatedPage = errors.New("the page already exists")
+)
+
+// TvTropesPages is an entity that manages all relevant pages in TvTropes for its extraction
+// Each Page has a last updated date, for checking future TvTropes updates on its Pages
+type TvTropesPages struct {
+	Pages map[Page]time.Time
+}
+
+// NewTvTropesPages creates an empty object to which we can add valid Pages
+func NewTvTropesPages() *TvTropesPages {
+	return &TvTropesPages{
+		Pages: make(map[Page]time.Time, 0),
+	}
+}
+
+// AddTvTropesPage creates a valid TvTropes Page from a string pageUrl and adds it to the internal structure of all pages
+// except if the page has already been added before, then it will return an ErrDuplicatedPage error
+// If the url is empty or has an invalid format, it will return an ErrBadUrl error
+// If the url does not belong to a TvTropes page, it will return an ErrNotTvTropes error
+func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string) error {
+	newUrl, errParse := url.Parse(pageUrl)
+	if errParse != nil {
+		return fmt.Errorf("%w: "+pageUrl+"\n%w", ErrBadUrl, errParse)
+	}
+
+	newPage, errNewPage := NewPage(newUrl)
+	if errNewPage != nil {
+		return errNewPage
+	}
+
+	for tvtropesPage := range tvtropespages.Pages {
+		if tvtropesPage.GetUrl() == newUrl {
+			return fmt.Errorf("%w: "+pageUrl, ErrDuplicatedPage)
+		}
+	}
+
+	tvtropespages.Pages[newPage] = time.Now()
+	return nil
+}

--- a/tropestogo/tvtropespages.go
+++ b/tropestogo/tvtropespages.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	ErrDuplicatedPage = errors.New("the page already exists")
+	ErrEmptyUrl       = errors.New("the provided URL string is empty")
 )
 
 // TvTropesPages is an entity that manages all relevant pages in TvTropes for its extraction
@@ -29,6 +30,10 @@ func NewTvTropesPages() *TvTropesPages {
 // If the url is empty or has an invalid format, it will return an ErrBadUrl error
 // If the url does not belong to a TvTropes page, it will return an ErrNotTvTropes error
 func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string) error {
+	if pageUrl == "" {
+		return ErrEmptyUrl
+	}
+
 	newUrl, errParse := url.Parse(pageUrl)
 	if errParse != nil {
 		return fmt.Errorf("%w: "+pageUrl+"\n%w", ErrBadUrl, errParse)
@@ -40,7 +45,7 @@ func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string) error {
 	}
 
 	for tvtropesPage := range tvtropespages.Pages {
-		if tvtropesPage.GetUrl() == newUrl {
+		if tvtropesPage.GetUrl().String() == pageUrl {
 			return fmt.Errorf("%w: "+pageUrl, ErrDuplicatedPage)
 		}
 	}

--- a/tropestogo/tvtropespages_test.go
+++ b/tropestogo/tvtropespages_test.go
@@ -1,0 +1,111 @@
+package tropestogo_test
+
+import (
+	"errors"
+	"fmt"
+	tropestogo "github.com/jlgallego99/TropesToGo"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"net/url"
+	"time"
+)
+
+var tvtropespages *tropestogo.TvTropesPages
+
+var _ = BeforeSuite(func() {
+	tvtropespages = tropestogo.NewTvTropesPages()
+})
+
+var _ = Describe("Tvtropespages", func() {
+	AfterEach(func() {
+		tvtropespages.Pages = make(map[tropestogo.Page]time.Time, 0)
+	})
+
+	Context("Add a Film, Trope and Index Pages to the entity", func() {
+		var errAddValid, errAddValid2, errAddValid3 error
+
+		BeforeEach(func() {
+			errAddValid = tvtropespages.AddTvTropesPage(oldboyUrl)
+			errAddValid2 = tvtropespages.AddTvTropesPage(tropeUrl)
+			errAddValid3 = tvtropespages.AddTvTropesPage(indexUrl)
+		})
+
+		It("Shouldn't return an error", func() {
+			Expect(errAddValid).To(BeNil())
+			Expect(errAddValid2).To(BeNil())
+			Expect(errAddValid3).To(BeNil())
+		})
+
+		It("Should have three Pages", func() {
+			Expect(len(tvtropespages.Pages)).To(Equal(3))
+		})
+
+		It("Should have added the correct Pages", func() {
+			var urls []*url.URL
+			var pageTypes []tropestogo.PageType
+			for page, lastUpdated := range tvtropespages.Pages {
+				urls = append(urls, page.GetUrl())
+				pageTypes = append(pageTypes, page.GetPageType())
+
+				Expect(lastUpdated).To(Not(BeNil()))
+			}
+
+			Expect(urls[0].String()).To(Equal(oldboyUrl))
+			Expect(pageTypes[0]).To(Equal(tropestogo.WorkPage))
+			Expect(urls[1].String()).To(Equal(tropeUrl))
+			Expect(pageTypes[1]).To(Equal(tropestogo.MainPage))
+			Expect(urls[2].String()).To(Equal(indexUrl))
+			Expect(pageTypes[2]).To(Equal(tropestogo.IndexPage))
+		})
+	})
+
+	Context("Add a duplicated Page", func() {
+		var errAddDuplicated error
+
+		BeforeEach(func() {
+			errAddDuplicated = tvtropespages.AddTvTropesPage(oldboyUrl)
+			errAddDuplicated = tvtropespages.AddTvTropesPage(oldboyUrl)
+		})
+
+		It("Should return an error", func() {
+			Expect(errors.Is(errAddDuplicated, tropestogo.ErrDuplicatedPage)).To(BeTrue())
+		})
+
+		It("Shouldn't have added the second Page", func() {
+			Expect(len(tvtropespages.Pages)).To(Equal(1))
+		})
+	})
+
+	Context("Add and empty string url", func() {
+		var errAddEmpty error
+
+		BeforeEach(func() {
+			errAddEmpty = tvtropespages.AddTvTropesPage("")
+		})
+
+		It("Should return an error", func() {
+			Expect(errors.Is(errAddEmpty, tropestogo.ErrEmptyUrl)).To(BeTrue())
+		})
+
+		It("Shouldn't have added anything", func() {
+			Expect(len(tvtropespages.Pages)).To(Equal(0))
+		})
+	})
+
+	Context("Add a badly formated url", func() {
+		var errAddEmpty error
+
+		BeforeEach(func() {
+			errAddEmpty = tvtropespages.AddTvTropesPage("htp$p%^^^&&***!!!!!")
+		})
+
+		It("Should return an error", func() {
+			fmt.Println(errAddEmpty)
+			Expect(errors.Is(errAddEmpty, tropestogo.ErrBadUrl)).To(BeTrue())
+		})
+
+		It("Shouldn't have added anything", func() {
+			Expect(len(tvtropespages.Pages)).To(Equal(0))
+		})
+	})
+})

--- a/tropestogo/tvtropespages_test.go
+++ b/tropestogo/tvtropespages_test.go
@@ -2,7 +2,6 @@ package tropestogo_test
 
 import (
 	"errors"
-	"fmt"
 	tropestogo "github.com/jlgallego99/TropesToGo"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -100,7 +99,6 @@ var _ = Describe("Tvtropespages", func() {
 		})
 
 		It("Should return an error", func() {
-			fmt.Println(errAddEmpty)
 			Expect(errors.Is(errAddEmpty, tropestogo.ErrBadUrl)).To(BeTrue())
 		})
 


### PR DESCRIPTION
Este PR se crea para resolver ciertos aspectos concretos necesarios antes de resolver el anterior PR #74 y se resuelve lo siguiente:

- Se remodelan las páginas de TvTropes. Ahora se tiene un objeto valor que define únicamente una página de tvtropes por su url y por su tipo, que permite identificar si es de un tropo, de una pelicula o de un índice, para poder luego extraer su información mejor
- Se crea una entidad TvTropesPages que gestiona todos los objetos valor de página, relacionándolos en una estructura map con su correspondiente última actualización, la cual puede cambiar en caso de que la pagina de tvtropes se actualice. La entidad se encarga de crear objetos valor pagina correctamente, sin embargo, la entidad en sí no se utiliza aún al estar este PMV centrado en extraer de una sola página individual, la cual usa únicamente los objetos valor porque el scraper necesita su URL (closes #79 closes #80)
- Se hacen ajustes para tener un código más limpio, con variables menos ambiguas, solucionando errores gramaticales y utilizando valores constantes para testear las páginas
- Se documentan todas las funciones correctamente, utilizando docstrings y eliminando cualquier comentario inline, pudiendo ahora saber qué hace cada función, qué recibe y qué devuelve (closes #81)