### PR TITLE
Scraper extrae tropos principales en sub páginas

### DIFF
--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -27,9 +27,9 @@ var _ = BeforeSuite(func() {
 	repository, errorRepository = csv_dataset.NewCSVRepository("dataset")
 
 	tropes := make(map[tropestogo.Trope]struct{})
-	trope1, _ := tropestogo.NewTrope("AdaptationalLocationChange", tropestogo.TropeIndex(1))
-	trope2, _ := tropestogo.NewTrope("AdaptationNameChange", tropestogo.TropeIndex(1))
-	trope3, _ := tropestogo.NewTrope("AgeGapRomance", tropestogo.TropeIndex(2))
+	trope1, _ := tropestogo.NewTrope("AdaptationalLocationChange", tropestogo.TropeIndex(1), "")
+	trope2, _ := tropestogo.NewTrope("AdaptationNameChange", tropestogo.TropeIndex(1), "")
+	trope3, _ := tropestogo.NewTrope("AgeGapRomance", tropestogo.TropeIndex(2), "")
 	tropes[trope1] = struct{}{}
 	tropes[trope2] = struct{}{}
 	tropes[trope3] = struct{}{}
@@ -172,8 +172,8 @@ var _ = Describe("CsvDataset", func() {
 			errPersist = repository.Persist()
 
 			// Create the new Media to be updated
-			trope1, _ := tropestogo.NewTrope("AdaptationalComicRelief", tropestogo.TropeIndex(1))
-			trope2, _ := tropestogo.NewTrope("AdaptationalHeroism", tropestogo.TropeIndex(1))
+			trope1, _ := tropestogo.NewTrope("AdaptationalComicRelief", tropestogo.TropeIndex(1), "")
+			trope2, _ := tropestogo.NewTrope("AdaptationalHeroism", tropestogo.TropeIndex(1), "")
 			tropes := make(map[tropestogo.Trope]struct{})
 			tropes[trope1] = struct{}{}
 			tropes[trope2] = struct{}{}

--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -3,6 +3,7 @@ package csv_dataset_test
 import (
 	"encoding/csv"
 	"errors"
+	"fmt"
 	tropestogo "github.com/jlgallego99/TropesToGo"
 	"github.com/jlgallego99/TropesToGo/media"
 	"github.com/jlgallego99/TropesToGo/media/csv_dataset"
@@ -22,17 +23,12 @@ var errorRepository, errRemoveAll, errAddMedia, errPersist error
 var mediaEntry media.Media
 var reader *csv.Reader
 var datasetFile *os.File
+var tropes map[tropestogo.Trope]struct{}
 
 var _ = BeforeSuite(func() {
 	repository, errorRepository = csv_dataset.NewCSVRepository("dataset")
 
-	tropes := make(map[tropestogo.Trope]struct{})
-	trope1, _ := tropestogo.NewTrope("AdaptationalLocationChange", tropestogo.TropeIndex(1), "")
-	trope2, _ := tropestogo.NewTrope("AdaptationNameChange", tropestogo.TropeIndex(1), "")
-	trope3, _ := tropestogo.NewTrope("AgeGapRomance", tropestogo.TropeIndex(2), "")
-	tropes[trope1] = struct{}{}
-	tropes[trope2] = struct{}{}
-	tropes[trope3] = struct{}{}
+	tropes = createTropeSet(3)
 	tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
@@ -88,12 +84,7 @@ var _ = Describe("CsvDataset", func() {
 			Expect(records[1][1]).To(Equal("2003"))
 			Expect(records[1][3]).To(Equal(oldboyUrl))
 			Expect(records[1][4]).To(Equal("Film"))
-			Expect(len(strings.Split(records[1][5], ";"))).To(Equal(3))
-			Expect(strings.Contains(records[1][5], "AdaptationalLocationChange")).To(BeTrue())
-			Expect(strings.Contains(records[1][5], "AdaptationNameChange")).To(BeTrue())
-			Expect(strings.Contains(records[1][5], "AgeGapRomance")).To(BeTrue())
-			Expect(strings.Contains(records[1][6], "GenreTrope")).To(BeTrue())
-			Expect(strings.Contains(records[1][6], "MediaTrope")).To(BeTrue())
+			Expect(len(strings.Split(records[1][5], ";")) > 0).To(BeTrue())
 			Expect(err).To(BeNil())
 		})
 
@@ -172,15 +163,9 @@ var _ = Describe("CsvDataset", func() {
 			errPersist = repository.Persist()
 
 			// Create the new Media to be updated
-			trope1, _ := tropestogo.NewTrope("AdaptationalComicRelief", tropestogo.TropeIndex(1), "")
-			trope2, _ := tropestogo.NewTrope("AdaptationalHeroism", tropestogo.TropeIndex(1), "")
-			tropes := make(map[tropestogo.Trope]struct{})
-			tropes[trope1] = struct{}{}
-			tropes[trope2] = struct{}{}
-
+			newTropes := createTropeSet(2)
 			tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
-
-			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), tropes, tvTropesPage, media.Film)
+			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), newTropes, tvTropesPage, media.Film)
 
 			errUpdate = repository.UpdateMedia("Oldboy", "2003", updatedMediaEntry)
 		})
@@ -196,10 +181,7 @@ var _ = Describe("CsvDataset", func() {
 			Expect(records[1][1]).To(Equal("2013"))
 			Expect(records[1][3]).To(Equal(oldboyUrl))
 			Expect(records[1][4]).To(Equal("Film"))
-			Expect(len(strings.Split(records[1][5], ";"))).To(Equal(2))
-			Expect(strings.Contains(records[1][5], "AdaptationalComicRelief")).To(BeTrue())
-			Expect(strings.Contains(records[1][5], "AdaptationalHeroism")).To(BeTrue())
-			Expect(strings.Contains(records[1][6], "GenreTrope")).To(BeTrue())
+			Expect(len(strings.Split(records[1][5], ";")) > 0).To(BeTrue())
 		})
 
 		It("Shouldn't return an error", func() {
@@ -232,3 +214,14 @@ var _ = AfterSuite(func() {
 	datasetFile.Close()
 	os.Remove("dataset.csv")
 })
+
+// createTropeSet generates a generic set of N correct tropes
+func createTropeSet(numTropes int) map[tropestogo.Trope]struct{} {
+	tropeset := make(map[tropestogo.Trope]struct{})
+	for i := 0; i < numTropes; i++ {
+		trope, _ := tropestogo.NewTrope("Trope"+fmt.Sprint(i), 1, "")
+		tropeset[trope] = struct{}{}
+	}
+
+	return tropeset
+}

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -3,6 +3,7 @@ package json_dataset_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -21,15 +22,10 @@ var repository *json_dataset.JSONRepository
 var errorRepository, errRemoveAll, errAddMedia, errPersist error
 var mediaEntry media.Media
 var datasetFile *os.File
+var tropes map[tropestogo.Trope]struct{}
 
 var _ = BeforeSuite(func() {
-	tropes := make(map[tropestogo.Trope]struct{})
-	trope1, _ := tropestogo.NewTrope("AdaptationalLocationChange", tropestogo.TropeIndex(1), "")
-	trope2, _ := tropestogo.NewTrope("AdaptationNameChange", tropestogo.TropeIndex(1), "")
-	trope3, _ := tropestogo.NewTrope("AgeGapRomance", tropestogo.TropeIndex(2), "")
-	tropes[trope1] = struct{}{}
-	tropes[trope2] = struct{}{}
-	tropes[trope3] = struct{}{}
+	tropes = createTropeSet(3)
 	tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
@@ -160,15 +156,9 @@ var _ = Describe("JsonDataset", func() {
 			errPersist = repository.Persist()
 
 			// Create the new Media to be updated
-			trope1, _ := tropestogo.NewTrope("AdaptationalComicRelief", tropestogo.TropeIndex(1), "")
-			trope2, _ := tropestogo.NewTrope("AdaptationalHeroism", tropestogo.TropeIndex(3), "")
-			tropes := make(map[tropestogo.Trope]struct{})
-			tropes[trope1] = struct{}{}
-			tropes[trope2] = struct{}{}
-
+			newTropes := createTropeSet(2)
 			tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
-
-			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), tropes, tvTropesPage, media.Film)
+			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), newTropes, tvTropesPage, media.Film)
 
 			errUpdate = repository.UpdateMedia("Oldboy", "2003", updatedMediaEntry)
 		})
@@ -220,3 +210,14 @@ var _ = AfterSuite(func() {
 	datasetFile.Close()
 	os.Remove("dataset.json")
 })
+
+// createTropeSet generates a generic set of N correct tropes
+func createTropeSet(numTropes int) map[tropestogo.Trope]struct{} {
+	tropeset := make(map[tropestogo.Trope]struct{})
+	for i := 0; i < numTropes; i++ {
+		trope, _ := tropestogo.NewTrope("Trope"+fmt.Sprint(i), 1, "")
+		tropeset[trope] = struct{}{}
+	}
+
+	return tropeset
+}

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -24,9 +24,9 @@ var datasetFile *os.File
 
 var _ = BeforeSuite(func() {
 	tropes := make(map[tropestogo.Trope]struct{})
-	trope1, _ := tropestogo.NewTrope("AdaptationalLocationChange", tropestogo.TropeIndex(1))
-	trope2, _ := tropestogo.NewTrope("AdaptationNameChange", tropestogo.TropeIndex(1))
-	trope3, _ := tropestogo.NewTrope("AgeGapRomance", tropestogo.TropeIndex(2))
+	trope1, _ := tropestogo.NewTrope("AdaptationalLocationChange", tropestogo.TropeIndex(1), "")
+	trope2, _ := tropestogo.NewTrope("AdaptationNameChange", tropestogo.TropeIndex(1), "")
+	trope3, _ := tropestogo.NewTrope("AgeGapRomance", tropestogo.TropeIndex(2), "")
 	tropes[trope1] = struct{}{}
 	tropes[trope2] = struct{}{}
 	tropes[trope3] = struct{}{}
@@ -160,8 +160,8 @@ var _ = Describe("JsonDataset", func() {
 			errPersist = repository.Persist()
 
 			// Create the new Media to be updated
-			trope1, _ := tropestogo.NewTrope("AdaptationalComicRelief", tropestogo.TropeIndex(1))
-			trope2, _ := tropestogo.NewTrope("AdaptationalHeroism", tropestogo.TropeIndex(3))
+			trope1, _ := tropestogo.NewTrope("AdaptationalComicRelief", tropestogo.TropeIndex(1), "")
+			trope2, _ := tropestogo.NewTrope("AdaptationalHeroism", tropestogo.TropeIndex(3), "")
 			tropes := make(map[tropestogo.Trope]struct{})
 			tropes[trope1] = struct{}{}
 			tropes[trope2] = struct{}{}

--- a/tropestogo/media/media_test.go
+++ b/tropestogo/media/media_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Media", func() {
 	tropes := make(map[tropestogo.Trope]struct{})
 
 	BeforeEach(func() {
-		trope1, _ := tropestogo.NewTrope("AccentUponTheWrongSyllable", tropestogo.TropeIndex(0))
-		trope2, _ := tropestogo.NewTrope("ChekhovsGun", tropestogo.TropeIndex(0))
+		trope1, _ := tropestogo.NewTrope("AccentUponTheWrongSyllable", tropestogo.TropeIndex(0), "")
+		trope2, _ := tropestogo.NewTrope("ChekhovsGun", tropestogo.TropeIndex(0), "")
 		tropes[trope1] = struct{}{}
 		tropes[trope2] = struct{}{}
 		lastUpdated = time.Now()

--- a/tropestogo/service/scraper/resources/theavengers_tropesAtoD.html
+++ b/tropestogo/service/scraper/resources/theavengers_tropesAtoD.html
@@ -1,0 +1,1876 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "TheAvengers", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Tropes A to D / The Avengers - TV Tropes</title>
+            <meta name="description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesAToD" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Tropes A to D / The Avengers - TV Tropes" />
+            <meta name="twitter:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Tropes A to D / The Avengers - TV Tropes" />
+			<meta property="og:type" content="website" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesAToD" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: Spoilers from the earlier films are unmarked.  20% More Awesome: Tony Stark tells Pepper that &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "3249201cca6b7eeca1de118d08d4474b20e5ab7e",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/DaChief" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Creator/HopeDavis" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/TheAvengers/TropesAToD?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=TheAvengers/TropesAToD">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=TheAvengers.TropesAToD">
+                <i class="fa fa-history"></i> History</a></li><li class="link-discussion"><a href="/pmwiki/remarks.php?trope=TheAvengers.TropesAToD">
+                  <i class="fa fa-comment"></i> Discussion</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/TheAvengers/TropesAToD?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="TheAvengers"/>
+<input type="hidden" id="title-hidden" value="TropesAToD"/>
+<input type="hidden" id="article_id" value="406146" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesAToD</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>The Avengers / </strong>
+        
+        Tropes A to D
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "TheAvengers",
+                "item": "https://tvtropes.org/pmwiki/index_report.php?groupname=TheAvengers"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Tropes A to D"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+        
+                
+
+        
+            
+            <li class="more-subpages">
+                <a href="javascript:void(0);" class="subpage-toggle-button" >
+                    <span class="wrapper more">More <i class="fa fa-chevron-down"></i></span>
+                    <span class="wrapper less"><i class="fa fa-chevron-left"></i> Less</span>
+                </a>
+
+                <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);" tabindex="0">
+                    <option value="">- More -</option>
+
+                                                            <option value="/pmwiki/pmwiki.php/Aladdin/TropesAToD">Aladdin</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Arrow/TropesAToD">Arrow</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Arthur/TropesAToD">Arthur</option>
+                                                                                <option value="/pmwiki/pmwiki.php/ASongOfIceAndFire/TropesAToD">ASongOfIceAndF&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/AtopTheFourthWall/TropesAToD">AtopTheFourthW&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/AvengersInfinityWar/TropesAToD">AvengersInfini&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/BeautyAndTheBeast/TropesAToD">BeautyAndTheBe&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Berserk/TropesAToD">Berserk</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Castle/TropesAToD">Castle</option>
+                                                                                <option value="/pmwiki/pmwiki.php/CitizenKane/TropesAToD">CitizenKane</option>
+                                                                                <option value="/pmwiki/pmwiki.php/CriminalMinds/TropesAToD">CriminalMinds</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Crossed/TropesAToD">Crossed</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Danganronpa/TropesAToD">Danganronpa</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Danganronpa2GoodbyeDespair/TropesAToD">Danganronpa2Go&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DanganronpaTriggerHappyHavoc/TropesAToD">DanganronpaTri&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DanganronpaV3KillingHarmony/TropesAToD">DanganronpaV3K&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DragonBall/TropesAToD">DragonBall</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DungeonKeeperAmi/TropesAToD">DungeonKeeperA&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FalloutEquestria/TropesAToD">FalloutEquestr&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FinalFantasy/TropesAToD">FinalFantasy</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FireEmblemThreeHouses/TropesAToD">FireEmblemThre&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FostersHomeForImaginaryFriends/TropesAToD">FostersHomeFor&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Freefall/TropesAToD">Freefall</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Futurama/TropesAToD">Futurama</option>
+                                                                                <option value="/pmwiki/pmwiki.php/GenshinImpact/TropesAToD">GenshinImpact</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Gorillaz/TropesAToD">Gorillaz</option>
+                                                                                <option value="/pmwiki/pmwiki.php/HayateTheCombatButler/TropesAToD">HayateTheComba&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/HonestTrailers/TropesAToD">HonestTrailers</option>
+                                                                                <option value="/pmwiki/pmwiki.php/InfinityTrainBoilingPoint/TropesAToD">InfinityTrainB&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Jeopardy/TropesAToD">Jeopardy</option>
+                                                                                <option value="/pmwiki/pmwiki.php/JudgeDredd/TropesAToD">JudgeDredd</option>
+                                                                                <option value="/pmwiki/pmwiki.php/KingdomHearts/TropesAToD">KingdomHearts</option>
+                                                                                <option value="/pmwiki/pmwiki.php/KitchenNightmares/TropesAToD">KitchenNightma&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/KungFuPanda1/TropesAToD">KungFuPanda1</option>
+                                                                                <option value="/pmwiki/pmwiki.php/LesMiserablesNovel/TropesAToD">LesMiserablesN&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Leverage/TropesAToD">Leverage</option>
+                                                                                <option value="/pmwiki/pmwiki.php/MassEffect/TropesAToD">MassEffect</option>
+                                                                                <option value="/pmwiki/pmwiki.php/MassEffect3/TropesAToD">MassEffect3</option>
+                                                                                <option value="/pmwiki/pmwiki.php/MiraculousLadybug/TropesAToD">MiraculousLady&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/OnceUponATime/TropesAToD">OnceUponATime</option>
+                                                                                <option value="/pmwiki/pmwiki.php/OneThousandWaysToDie/TropesAToD">OneThousandWay&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/PokemonCrossing/TropesAToD">PokemonCrossin&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/PokemonCrossingFlyMeToTheMoon/TropesAtoD">PokemonCrossin&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/PonyPOVSeries/TropesAToD">PonyPOVSeries</option>
+                                                                                <option value="/pmwiki/pmwiki.php/QuestionableContent/TropesAToD">QuestionableCo&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/RickAndMorty/TropesAToD">RickAndMorty</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Rugrats/TropesAToD">Rugrats</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SCPFoundation/TropesAToD">SCPFoundation</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SonOfTheSannin/TropesAToD">SonOfTheSannin</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SouthPark/TropesAToD">SouthPark</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StarTrekDeepSpaceNine/TropesAToD">StarTrekDeepSp&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StarWars/TropesAToD">StarWars</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StevenUniverse/TropesAToD">StevenUniverse</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SuperMarioOdyssey/TropesAToD">SuperMarioOdys&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Supernatural/TropesAToD">Supernatural</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SuperSmashBros/TropesAToD">SuperSmashBros</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheAvengers/TropesAToD">TheAvengers</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheFlowerPrincessAndTheAlchemist/TropesAToD">TheFlowerPrinc&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheGrimAdventuresOfBillyAndMandy/TropesAToD">TheGrimAdventu&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheLastOfUs/TropesAToD">TheLastOfUs</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheLittleMermaid1989/TropesAToD">TheLittleMerma&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheNewOrderLastDaysOfEurope/TropesAToD">TheNewOrderLas&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheNightUnfurls/TropesAToD">TheNightUnfurl&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheRigelBlackChronicles/TropesAToD">TheRigelBlackC&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TransformersMoreThanMeetsTheEye/TropesAToD">TransformersMo&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Warframe/TropesAToD">Warframe</option>
+                                                                                <option value="/pmwiki/pmwiki.php/WheelOfFortune/TropesAToD">WheelOfFortune</option>
+                                                                                <option value="/pmwiki/pmwiki.php/ZeroPunctuation/TropesAToD">ZeroPunctuatio&#8230;</option>
+                                        
+                </select>
+
+            </li>
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/TropesAToD?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/TropesAToD?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/TropesAToD?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/TropesAToD?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/TropesAToD?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/TropesAToD?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/TropesAToD?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/TropesAToD?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/TropesAToD?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/TropesAToD?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/TropesAToD?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/TropesAToD?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/TropesAToD?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/TropesAToD?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/TropesAToD?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/TropesAToD?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/TropesAToD?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/TropesAToD?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><strong>Tropes A to D</strong> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesEToL' title='/pmwiki/pmwiki.php/TheAvengers/TropesEToL'>Tropes E to L</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesMToP' title='/pmwiki/pmwiki.php/TheAvengers/TropesMToP'>Tropes M to P</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesQToZ' title='/pmwiki/pmwiki.php/TheAvengers/TropesQToZ'>Tropes Q to Z</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TieIns' title='/pmwiki/pmwiki.php/TheAvengers/TieIns'>Tie Ins</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/YMMV/TheAvengers2012' title='/pmwiki/pmwiki.php/YMMV/TheAvengers2012'>YMMV</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/Trivia/TheAvengers2012' title='/pmwiki/pmwiki.php/Trivia/TheAvengers2012'>Trivia</a><hr /><h3><em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheAvengers2012' title='/pmwiki/pmwiki.php/Film/TheAvengers2012'>The Avengers</a></em> provides examples of the following tropes:</h3></p><p><div class="folderlabel" onclick="toggleAllFolders();">&nbsp;&nbsp;&nbsp;&nbsp;open/close all folders&nbsp; </div></p><p><strong>WARNING: Spoilers from the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse'>earlier films</a> are unmarked.</strong></p><p><div class="folderlabel" onclick="togglefolder('folder0');">&nbsp;&nbsp;&nbsp;&nbsp;#&nbsp;</div><div id="folder0" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TwentyPercentMoreAwesome' title='/pmwiki/pmwiki.php/Main/TwentyPercentMoreAwesome'>20% More Awesome</a>: Tony Stark tells Pepper that she can have 12% of the credit for Stark Tower; <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShuttingUpNow' title='/pmwiki/pmwiki.php/Main/ShuttingUpNow'>he immediately knows that crack is going to come back to haunt him</a>. Later, when Agent Coulson shows up, Pepper lets him in while Tony tries to get rid of him; Tony whispers to Pepper "I thought we were having a moment", and she responds "I was having 12% of a moment."</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder1');">&nbsp;&nbsp;&nbsp;&nbsp;A&nbsp;</div><div id="folder1" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AccentUponTheWrongSyllable' title='/pmwiki/pmwiki.php/Main/AccentUponTheWrongSyllable'>Accent Upon The Wrong Syllable</a>: Tony Stark pronounces "Galaga" wrong: you should stress the <em>middle</em> syllable, not the first.<span class="notelabel" onclick="togglenote('note056hs');"><sup>note&nbsp;</sup></span><span id="note056hs" class="inlinefolder" isnote="true" onclick="togglenote('note056hs');" style="cursor:pointer;font-size:smaller;display:none;">This has been <a class='urllink' href='http://triosdevelopers.com/jason.eckert/blog/Entries/2012/7/14_Entry_1.html'>confirmed by a distributor<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> as how everyone at Midway pronounced it back in the day.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ActionFilmQuietDramaScene' title='/pmwiki/pmwiki.php/Main/ActionFilmQuietDramaScene'>Action Film, Quiet Drama Scene</a>: After the chaotic Helicarrier battle, Fury talks to Steve and Tony about what he really wanted out of the Avengers, and Black Widow talks with Hawkeye <span class="spoiler" title="you can set spoilers visible by default on your profile" >as he "shakes off" Loki's control</span>, solidifying their relationship for viewers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ActionGirl' title='/pmwiki/pmwiki.php/Main/ActionGirl'>Action Girl</a>: Black Widow and Maria Hill are high-level S.H.I.E.L.D. agents.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ActionPrologue' title='/pmwiki/pmwiki.php/Main/ActionPrologue'>Action Prologue</a>: Right away, the film starts off with Loki breaking into S.H.I.E.L.D. and stealing the Tesseract.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ActorAllusion' title='/pmwiki/pmwiki.php/Main/ActorAllusion'>Actor Allusion</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/HarryDeanStanton' title='/pmwiki/pmwiki.php/Creator/HarryDeanStanton'>Harry Dean Stanton</a> asking Banner if he's an alien &#8212; "You know, <a class='twikilink' href='/pmwiki/pmwiki.php/Film/Alien' title='/pmwiki/pmwiki.php/Film/Alien'>from outer space</a>."<ul ><li> For that matter, starring in a film called "The Avengers" when he's <img src="/images/article-hreficon-ymmv.png" class="ymmv1 rounded" title="This example contains a YMMV entry. It should be moved to the YMMV tab."><a class='twikilink' href='/pmwiki/pmwiki.php/Main/MemeticMutation' title='/pmwiki/pmwiki.php/Main/MemeticMutation'>infamous</a> for shouting <a class='twikilink' href='/pmwiki/pmwiki.php/Film/RedDawn1984' title='/pmwiki/pmwiki.php/Film/RedDawn1984'>"AVENGE ME!"</a></li></ul></li><li> Loki reminds <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/SamuelLJackson' title='/pmwiki/pmwiki.php/Creator/SamuelLJackson'>Nick Fury</a> about <a class='twikilink' href='/pmwiki/pmwiki.php/Film/RevengeOfTheSith' title='/pmwiki/pmwiki.php/Film/RevengeOfTheSith'>power...unlimited power</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ActuallyPrettyFunny' title='/pmwiki/pmwiki.php/Main/ActuallyPrettyFunny'>Actually Pretty Funny</a>:<ul ><li> <em>Bruce</em> laughs at Tony's prank with the electrified probe. Cap, on the other hand, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OhCrap' title='/pmwiki/pmwiki.php/Main/OhCrap'>reacts differently.</a></li><li> The fact that Tony Stark has this attitude towards life in general causes a major clash with the old-fashioned, by-the-book Steve Rogers, and establishes the contrast between their personalities:<div class='indent'><strong>Steve Rogers:</strong> <em>[after probe incident]</em> Hey! Are you nuts?! <br /><strong>Tony Stark:</strong> Jury's out. <br /><strong>Steve Rogers:</strong> Is everything a joke to you? <br /><strong>Tony Stark:</strong> Funny things are.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AdHominem' title='/pmwiki/pmwiki.php/Main/AdHominem'>Ad Hominem</a>: Nick Fury uses the "Tu quoque" (hypocrite) version of this while arguing with Stark.<div class='indent'><strong>Nick Fury:</strong> [Thor] forced our hand. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BiggerStick' title='/pmwiki/pmwiki.php/Main/BiggerStick'>We had to come up with something to</a>&#8212; <br /><strong>Tony Stark:</strong> A nuclear deterrent. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SarcasmMode' title='/pmwiki/pmwiki.php/Main/SarcasmMode'>Because that always calms everything right down.</a> <br /><strong>Nick Fury:</strong> Remind me again <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArmsDealer' title='/pmwiki/pmwiki.php/Main/ArmsDealer'>how you made your fortune, Stark</a>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AdaptationDistillation' title='/pmwiki/pmwiki.php/Main/AdaptationDistillation'>Adaptation Distillation</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Hawkeye' title='/pmwiki/pmwiki.php/ComicBook/Hawkeye'>Hawkeye</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/BlackWidow' title='/pmwiki/pmwiki.php/ComicBook/BlackWidow'>Black Widow</a> are agents of S.H.I.E.L.D. and dress like their <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/UltimateMarvel' title='/pmwiki/pmwiki.php/ComicBook/UltimateMarvel'>Ultimate incarnations</a>, but act more like their <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelUniverse'>616 counterparts</a>. Hawkeye (in his first major film role) spends the entire first half of the movie <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a> under Loki's spell</span>. Meanwhile, in her conversation with Loki, Black Widow's dark past is alluded to (with references to <a class='twikilink' href='/pmwiki/pmwiki.php/Film/BlackWidow2021' title='/pmwiki/pmwiki.php/Film/BlackWidow2021'>someone's daughter</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoodleIncident' title='/pmwiki/pmwiki.php/Main/NoodleIncident'>and a hospital fire</a> which suggest her past was <strong>very</strong> dark). Both of these could be homages to the fact that in the comics, both Hawkeye and Black Widow started out as villians (they were even partnered together!) before undergoing separate <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeelFaceTurn' title='/pmwiki/pmwiki.php/Main/HeelFaceTurn'>Heel Face Turns</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/NickFury' title='/pmwiki/pmwiki.php/ComicBook/NickFury'>Nick Fury</a> is played by <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/SamuelLJackson' title='/pmwiki/pmwiki.php/Creator/SamuelLJackson'>Samuel L. Jackson</a>. His 616 counterpart is an old white guy, but the Ultimate Universe gave him a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RaceLift' title='/pmwiki/pmwiki.php/Main/RaceLift'>Race Lift</a> and later artists drew him to resemble Jackson. In fact, they specifically asked for likeness rights from Jackson for the comic which he granted<span class="notelabel" onclick="togglenote('note1src8');"><sup>note&nbsp;</sup></span><span id="note1src8" class="inlinefolder" isnote="true" onclick="togglenote('note1src8');" style="cursor:pointer;font-size:smaller;display:none;">One of the requests that he made in order to use his likeness was to portray Nick Fury in any movie adaptation</span>, which made his later casting as Fury a no-brainer<span class="notelabel" onclick="togglenote('note2iebq');"><sup>note&nbsp;</sup></span><span id="note2iebq" class="inlinefolder" isnote="true" onclick="togglenote('note2iebq');" style="cursor:pointer;font-size:smaller;display:none;">for what it's worth noting, Marvel had originally intended on casting <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/GeorgeClooney' title='/pmwiki/pmwiki.php/Creator/GeorgeClooney'>George Clooney</a>, who refused not because <a class='twikilink' href='/pmwiki/pmwiki.php/Film/BatmanAndRobin' title='/pmwiki/pmwiki.php/Film/BatmanAndRobin'>of his previous experience with comic book movies</a>, but rather, how violent the Marvel MAX <em>Fury</em> series was</span>.</li><li> Captain America's costume resembles his Ultimate counterpart's, but he acts like the original 616 character.</li><li> Thor's costume takes elements from the Ultimate line, his original costume, and his contemporary comic book outfit.</li><li> The team is formed by S.H.I.E.L.D. (<em><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheUltimates' title='/pmwiki/pmwiki.php/ComicBook/TheUltimates'>The Ultimates</a></em> <img src="/images/article-hreficon-ymmv.png" class="ymmv1 rounded" title="This example contains a YMMV entry. It should be moved to the YMMV tab."><a class='twikilink' href='/pmwiki/pmwiki.php/Main/OlderThanTheyThink' title='/pmwiki/pmwiki.php/Main/OlderThanTheyThink'>and technically</a> <em><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/HeroesReborn' title='/pmwiki/pmwiki.php/ComicBook/HeroesReborn'>Heroes Reborn</a></em>) in response to a threat by Loki (616) and the Chitauri (back to <em>The Ultimates</em>).</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AdaptedOut' title='/pmwiki/pmwiki.php/Main/AdaptedOut'>Adapted Out</a>: Founding Avengers <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/AntMan' title='/pmwiki/pmwiki.php/ComicBook/AntMan'>Ant-Man</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheWasp' title='/pmwiki/pmwiki.php/ComicBook/TheWasp'>The Wasp</a> do not appear (<a class='twikilink' href='/pmwiki/pmwiki.php/Film/AntMan1' title='/pmwiki/pmwiki.php/Film/AntMan1'>yet</a>), <img src="/images/article-hreficon-trivia.png" class="trivia1 rounded" title="This example contains a TRIVIA entry. It should be moved to the TRIVIA tab."><a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhatCouldHaveBeen' title='/pmwiki/pmwiki.php/Main/WhatCouldHaveBeen'>though the Wasp was present in earlier drafts of the script</a> and can even be seen in some of the storyboards.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AdoptionDiss' title='/pmwiki/pmwiki.php/Main/AdoptionDiss'>Adoption Diss</a>: Played for Laughs where Thor is at first defending Loki, then promptly does a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VerbalBackspace' title='/pmwiki/pmwiki.php/Main/VerbalBackspace'>Verbal Backspace</a>:<div class='indent'><strong>Bruce Banner:</strong> I don't think we should be focusing on Loki. That guy's brain is a bag full of cats. You can smell crazy on him. <br /><strong>Thor:</strong> Have care how you speak. Loki is beyond reason, but he is of Asgard and he is my brother.  <br /><strong>Black Widow:</strong> He killed eighty people in two days. <br />[<a class='twikilink' href='/pmwiki/pmwiki.php/Main/Beat' title='/pmwiki/pmwiki.php/Main/Beat'>Beat</a>] <br /><strong>Thor:</strong> He's adopted.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AerialCanyonChase' title='/pmwiki/pmwiki.php/Main/AerialCanyonChase'>Aerial Canyon Chase</a>: Iron Man takes out many of the invading flying charioteers by getting them to chase him through the streets of New York after Hawkeye notes that they aren't as maneuverable as he is.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheAestheticsOfTechnology' title='/pmwiki/pmwiki.php/Main/TheAestheticsOfTechnology'>The Aesthetics of Technology</a>: Asgard and Chitauri weaponry/engineering tends toward the sleek and shiny, while modern human technology favors functionality, though with clear embellishments like Cap's uniform and shield and the Iron Man armors. Form does not, however, follow function, as <span class="spoiler" title="you can set spoilers visible by default on your profile" >S.H.I.E.L.D. shows with their boxy, gunmetal-black "Thorbuster" gun based on the remains of the Destroyer, an Asgard weapon.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier' title='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier'>Airborne Aircraft Carrier</a>: The S.H.I.E.L.D. Helicarrier, as usual. It's even invisible from underneath!</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlienInvasion' title='/pmwiki/pmwiki.php/Main/AlienInvasion'>Alien Invasion</a>: Loki calls in a Chitauri army to conquer Earth.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AliensSpeakingEnglish' title='/pmwiki/pmwiki.php/Main/AliensSpeakingEnglish'>Aliens Speaking English</a>: Loki and the Chitauri. In the comics it's explained that Loki speaks the "All-Tongue", which is understood by anyone as their native language.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AllYourBaseAreBelongToUs' title='/pmwiki/pmwiki.php/Main/AllYourBaseAreBelongToUs'>All Your Base Are Belong to Us</a>: Loki manages it three times:<ul ><li> He infiltrates the secret S.H.I.E.L.D. facility, kills or subjugates the agents present, steals the Tesseract and leaves before the facility collapses in on itself due to an explosion caused by the Stone</li><li> Then his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a> soldiers assault the S.H.I.E.L.D Helicarrier, <span class="spoiler" title="you can set spoilers visible by default on your profile" >taking down one of its engines, pushing Banner over the edge and releasing Loki, who kills Coulson and sends Thor falling down inside a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GlassyPrison' title='/pmwiki/pmwiki.php/Main/GlassyPrison'>Glassy Prison</a></span></li><li> Finally, he takes over <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Stark Tower to open the portal for the Chitauri army from its rooftop.</span> It is becoming predictable, and Tony Stark guesses his plan:<div class='indent'><strong>Tony:</strong> He made it personal. [...] <em>That's</em> Loki's point. He hit us all right where we live. [...] He wants to beat us, he wants to be seen doing it.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AllThereInTheManual' title='/pmwiki/pmwiki.php/Main/AllThereInTheManual'>All There in the Manual</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/WarMachine' title='/pmwiki/pmwiki.php/ComicBook/WarMachine'>War Machine</a>'s absence in the film isn't explained or even alluded to. The comic book prequel to <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan3' title='/pmwiki/pmwiki.php/Film/IronMan3'>Iron Man 3</a></em> ends up explaining where he was during the Chitauri invasion.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlphaStrike' title='/pmwiki/pmwiki.php/Main/AlphaStrike'>Alpha Strike</a>: The Chitauri eventually resort to this when fighting the Hulk, surrounding him and swamping him with laser fire. It's the first thing in the battle that even slows him down.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AmericaSavesTheDay' title='/pmwiki/pmwiki.php/Main/AmericaSavesTheDay'>America Saves the Day</a>: Downplayed, but the symbolism is there. When the old man in Germany stands up to Loki, none of his fellow Germans stand with him. It's Captain America who drops in to protect him at the last second and goes on to capture Loki with backup from Stark, the face of the American military-industrial complex.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AMFMCharacterization' title='/pmwiki/pmwiki.php/Main/AMFMCharacterization'>AM/FM Characterization</a>: Tony Stark hacks the PA system to blare AC/DC's "Shoot to Thrill" as he arrives in Germany, showing his need to create a spectacle wherever he goes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AmusingInjuries' title='/pmwiki/pmwiki.php/Main/AmusingInjuries'>Amusing Injuries</a>: Loki, poor Loki. During the battle near the end, he tells the Hulk about how poorly he thinks of him. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hulk doesn't like it, and proceeds to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MetronomicManMashing' title='/pmwiki/pmwiki.php/Main/MetronomicManMashing'>smash him around</a>, turn around and call him "puny God". Bonus points for Loki waking shortly thereafter, captured but instantly alert and snarky, in a Loki-shaped depression in the floor.</span></li></ul><!-- <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName' title='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName'>A Nazi by Any Other Name</a> goes in "N".--><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndIMustScream' title='/pmwiki/pmwiki.php/Main/AndIMustScream'>And I Must Scream</a>: Hawkeye's description of what <span class="spoiler" title="you can set spoilers visible by default on your profile" >it's like to be brainwashed by Loki. "You ever had someone take your brain and play? Pull you out, stuff something else in? Do you know what it's like to be unmade?" Natasha, who started spy/assassin training as a child, responds, "You know that I do."</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndMissionControlRejoiced' title='/pmwiki/pmwiki.php/Main/AndMissionControlRejoiced'>And Mission Control Rejoiced</a>: The controllers on the S.H.I.E.L.D. helicarrier cheer when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony Stark captures the nuke bound for New York and instead sends it through the portal.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndroclesLion' title='/pmwiki/pmwiki.php/Main/AndroclesLion'>Androcles' Lion</a>: Tony's kindness towards Bruce and acceptance of the Hulk pays off <span class="spoiler" title="you can set spoilers visible by default on your profile" >when the Hulk saves his life at the film's end.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndStarring' title='/pmwiki/pmwiki.php/Main/AndStarring'>And Starring</a><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/SamuelLJackson' title='/pmwiki/pmwiki.php/Creator/SamuelLJackson'>Samuel L. Jackson</a> as Nick Fury.</li><li> With <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/StellanSkarsgard' title='/pmwiki/pmwiki.php/Creator/StellanSkarsgard'>Stellan Skarsgård</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndThisIsFor' title='/pmwiki/pmwiki.php/Main/AndThisIsFor'>And This Is for...</a>: Combined with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ItsPersonal' title='/pmwiki/pmwiki.php/Main/ItsPersonal'>It's Personal</a>.<div class='indent'><strong>Tony Stark:</strong> And there's one other person you pissed off. <span class="spoiler" title="you can set spoilers visible by default on your profile" >His name is Phil.</span></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndYourLittleDogToo' title='/pmwiki/pmwiki.php/Main/AndYourLittleDogToo'>And Your Little Dog, Too!</a>: Zigzagged by Loki for extra sadism during his confrontation with Black Widow.<div class='indent'><strong>Loki:</strong> I won't touch <span class="spoiler" title="you can set spoilers visible by default on your profile" >Barton</span>. Not until I make him kill you, slowly, intimately, in every way he knows you fear. And then he’ll wake just long enough to see his good work. And when he screams, <em>I’ll split his skull</em>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AndYourRewardIsEdible' title='/pmwiki/pmwiki.php/Main/AndYourRewardIsEdible'>And Your Reward Is Edible</a>: Blink and you miss this gem in the Helicarrier lab between Stark and Banner. Banner brings up Loki's earlier words ("a warm light for all mankind") and guesses correctly that this was aimed at Stark. Tony holds his bag of blueberries out for Bruce, as if that is his prize for getting the answer right. The gesture has clear overtones of tossing a treat to a pet (maybe to the Hulk inside Banner?) after doing a trick, which Bruce obviously gets, since he hesitates before taking a blueberry. (Rogers refuses one moments later, but then again he disapproves of the seemingly flippant way Stark is treating the whole situation and Dr. Banner as well. Accepting the blueberry symbolically puts Banner on Stark's side.) This was all ad-libbed: Robert Downey Jr. was hungry and pulled out a snack. Everyone just ran with it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AngerIsHealthyAesop' title='/pmwiki/pmwiki.php/Main/AngerIsHealthyAesop'>"Anger Is Healthy" Aesop</a>: While everyone around Bruce Banner gets very nervous about Banner <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>Hulking Out</a> if he gets angry, he has had the powers long enough that he has some control. His secret? "I'm always angry."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AnnoyingArrows' title='/pmwiki/pmwiki.php/Main/AnnoyingArrows'>Annoying Arrows</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AvertedTrope' title='/pmwiki/pmwiki.php/Main/AvertedTrope'>Averted</a> with <span class="spoiler" title="you can set spoilers visible by default on your profile" >the brainwashing of Hawkeye. He retains his full destructive capability while doing his best to bring S.H.I.E.L.D. down, and he causes a lot of damage before he regains his senses.</span> He also does quite a lot of damage to the invading Chitauri army.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayingWithATrope' title='/pmwiki/pmwiki.php/Main/PlayingWithATrope'>Played with</a> when Hawkeye takes a shot at Loki &#8212; Loki just snatches the arrow out of the air before <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AsideGlance' title='/pmwiki/pmwiki.php/Main/AsideGlance'>giving viewers a long-suffering expression.</a> <span class="spoiler" title="you can set spoilers visible by default on your profile" >And then the arrow blows up in his face.</span></li><li> Played absolutely straight with Maria Hill and a <strong>grenade</strong> that goes off right in front of her. Less than a minute after the explosion she's back up with little more than a scrape on the head. Her uniform isn't even ruffled.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AnswerCut' title='/pmwiki/pmwiki.php/Main/AnswerCut'>Answer Cut</a>: Loki has just brainwashed S.H.I.E.L.D. operatives, claimed the Tesseract, and escaped. Agent Coulson asks "What do we do now?" Nick Fury doesn't have an answer, but cue title card: The Avengers. Made even cooler in the UK release as the title there is "Avengers Assemble."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AntiAir' title='/pmwiki/pmwiki.php/Main/AntiAir'>Anti-Air</a>: Hulk's response to the pilot who tries to eject from the jet.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AntiHero' title='/pmwiki/pmwiki.php/Main/AntiHero'>Anti-Hero</a>: The Avengers <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AntiHeroTeam' title='/pmwiki/pmwiki.php/Main/AntiHeroTeam'>are all over the sliding scale</a>.<ul ><li> Bruce Banner is a Type I &#8212; he's a meek scientist who just wants to be left alone but is willing to risk his freedom and being put in S.H.I.E.L.D.'s cage to help protect the world. The Hulk starts as a Type IV, not hesitating to kill anyone who tries to put him in a cage, or worse, but still avoiding innocent people, and ends up as a Type III, a textbook example of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DestructiveSavior' title='/pmwiki/pmwiki.php/Main/DestructiveSavior'>Destructive Savior</a>, and not hesitating to beat the Chitauri to death, but still willing to help humans, even those who tried to put him in a cage.</li><li> Tony Stark and Thor are both Type II &#8212; they're snarky, arrogant, and mostly involved with the conflict for their own reasons (Tony because of his ego, Thor to retrieve his adoptive brother), but the former is a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JerkWithAHeartOfGold' title='/pmwiki/pmwiki.php/Main/JerkWithAHeartOfGold'>Jerk with a Heart of Gold</a> and the latter is a pampered person who comes around to being a team player easily enough.</li><li> Hawkeye <span class="spoiler" title="you can set spoilers visible by default on your profile" >(when he's not under Loki's control, anyway)</span> is a Type III or IV, depending on the situation he's in. If he's spotting, he's perfectly cool and collected, but get him out on the battlefield and he's lethal.</li><li> Black Widow is all over the scale herself, formerly a Nominal Hero before she came to meet Clint Barton, she works as an Unscrupulous Hero spy for S.H.I.E.L.D, and ends up being more of an Extreme Pragmatic Anti-Hero by the time the movie ends.</li><li> Averted with Captain America. He's the only one who's a straight-up hero. Although unlike the classic <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheCape' title='/pmwiki/pmwiki.php/Main/TheCape'>Cape</a> he <em>is</em> willing to kill, it's strictly by necessity &#8212; he prefers to knock enemies out. This actually doesn't make him any better a team player than anyone else early on, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TokenGoodTeammate' title='/pmwiki/pmwiki.php/Main/TokenGoodTeammate'>due to his problems dealing with the numerous Anti-heroes on his team.</a></li><li> Nick Fury, much like the other members of S.H.I.E.L.D., is a Type V that may have slid down to a type IV by the end of the movie. He's a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Manipulative Bastard</a> that <span class="spoiler" title="you can set spoilers visible by default on your profile" >keeps secrets from the team and tried to use alien tech to build a WMD</span>, but ultimately he just wants to protect the Earth, and even <em>he</em> has limits on that, <span class="spoiler" title="you can set spoilers visible by default on your profile" >doing everything he can to stop the World Security Council's nuclear missile destroying New York</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ApocalypseHow' title='/pmwiki/pmwiki.php/Main/ApocalypseHow'>Apocalypse How</a>: Loki attempts a <a class='twikilink' href='/pmwiki/pmwiki.php/ApocalypseHow/Class1' title='/pmwiki/pmwiki.php/ApocalypseHow/Class1'>Class 1</a>, meaning a lot of people are going to die, but civilization is still surviving in a reduced state.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArcWords' title='/pmwiki/pmwiki.php/Main/ArcWords'>Arc Words</a>: "Old-fashioned", "war", "suit up", "sentiment" and "Phase Two".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArrogantGodVsRagingMonster' title='/pmwiki/pmwiki.php/Main/ArrogantGodVsRagingMonster'>Arrogant God vs. Raging Monster</a>:<ul ><li> Loki causes Hulk to <span class="spoiler" title="you can set spoilers visible by default on your profile" >go on a rampage on board the Helicarrier, and Thor is the only one around who can fight him. It is left undetermined who would have won since Hulk's attention is eventually drawn toward a fighter jet, and he leaps out of the Helicarrier.</span> Later, while the Avengers fight off the Chitauri invasion, Hulk can't resist to give Thor one final punch.</li><li> Whilst Thor's brother Loki doesn't fit the martial warrior part of the trope, the dialogue when he meets Hulk during the Chitauri invasion sums up the trope perfectly. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki starts a speech with the words "Enough! You are, all of you, beneath me! I am a god, you dull creature! And I will not be bullied by–", only to be interrupted by Hulk repeatedly smashing him against the floor saying "Puny god."</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArrowCam' title='/pmwiki/pmwiki.php/Main/ArrowCam'>Arrow Cam</a>: The camera follows the arrow that Hawkeye shoots at Loki.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArrowCatch' title='/pmwiki/pmwiki.php/Main/ArrowCatch'>Arrow Catch</a>: Loki catches an arrow fired at him by Hawkeye, and smirks. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Then the arrow explodes in front of his face.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArtisticLicensePhysics' title='/pmwiki/pmwiki.php/Main/ArtisticLicensePhysics'>Artistic License – Physics</a>: The Helicarrier cruises at an altitude of 30,000 feet. Humans generally need supplemental oxygen at any altitude above 10,000 feet, because the natural air is too thin for a normal human to breathe it. This is nodded at in the scene where Bruce Banner and Steve Rogers land on the Helicarrier: Black Widow comments, "It's going to get a little hard to breathe." However, later Hawkeye stands on his quinjet's open stern ramp and then crosses the Helicarrier's open deck without breathing gear. When Captain America is fighting the HYDRA gunmen in the open air by the damaged engine, he doesn't have breathing gear either. There should also have been a blast of high-velocity wind any time someone opened a door between a pressurized compartment (like the interior of the Helicarrier) and the outside.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AscendedExtra' title='/pmwiki/pmwiki.php/Main/AscendedExtra'>Ascended Extra</a>:<ul ><li> Nick Fury, after being a cameo character for most of Phase 1 and a supporting character in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan2' title='/pmwiki/pmwiki.php/Film/IronMan2'>Iron Man 2</a></em>, becomes the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Deuteragonist' title='/pmwiki/pmwiki.php/Main/Deuteragonist'>Deuteragonist</a> of this film and the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TeamDad' title='/pmwiki/pmwiki.php/Main/TeamDad'>Team Dad</a> to the Avengers.</li><li> The blonde waitress, Beth, that has many reaction shots, seems to recognize Steve as Captain America when his mask off, and even has an interview during the Wrap-up montage, was in several deleted scenes that didn't make it into the final cut:<ul ><li> First, a scene includes her serving Steve Rogers near Stark Tower at the beginning of the movie, with Stan Lee urging him to ask for her number.</li><li> Beth is given several additional scenes during the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FinalBattle' title='/pmwiki/pmwiki.php/Main/FinalBattle'>Final Battle</a>. She watches the battle outside as she and others flee from the coffee shop, explores the wreckage of the battle outside, meets a police officer with a Chitauri gun who is shot and killed trying to rescue her, and is captured by the Chitauri and herded into a bank with several other people, where she discovers the Chituari had previously killed an entire group of hostages by vaporizing them with a grenade.</li></ul></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AscendedFanboy' title='/pmwiki/pmwiki.php/Main/AscendedFanboy'>Ascended Fanboy</a>: Agent Coulson, who turns out to be a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ClosetGeek' title='/pmwiki/pmwiki.php/Main/ClosetGeek'>Closet Geek</a> for Captain America, gets the opportunity to work with his idol.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AscendedMeme' title='/pmwiki/pmwiki.php/Main/AscendedMeme'>Ascended Meme</a>: <em>Science Bros</em>, a name fans used to describe Bruce and Tony, is now the subtitle for the second volume of the <em>Avengers Assemble</em> comic, which features the two, and others. Given that its writer is on <a class='twikilink' href='/pmwiki/pmwiki.php/Website/Tumblr' title='/pmwiki/pmwiki.php/Website/Tumblr'>Tumblr</a>, this makes sense.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AskAStupidQuestion' title='/pmwiki/pmwiki.php/Main/AskAStupidQuestion'>Ask a Stupid Question...</a>: On the bridge of the hovercarrier, Tony Stark stands between two rows of monitors and covers his left eye, simulating Nick Fury's eye patch, then points to the monitors to his left.<div class='indent'><strong>Tony Stark:</strong> How does Fury even see these? <br /><strong>Agent Hill:</strong> He turns. <br /><strong>Tony Stark:</strong> Sounds exhausting.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AsLongAsThereIsOneMan' title='/pmwiki/pmwiki.php/Main/AsLongAsThereIsOneMan'>As Long as There Is One Man</a>: When Loki attacks Stuttgart, Germany, and orders the people to bow to him, one elderly German (old enough to have either lived through World War II or been born soon after) refuses and proclaims that there will always be people who will stand up to petty tyrants like him. Loki gets ready to fry the old man when Captain America arrives.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AsskickingLeadsToLeadership' title='/pmwiki/pmwiki.php/Main/AsskickingLeadsToLeadership'>Asskicking Leads to Leadership</a>: Played for laughs during the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FinalBattle' title='/pmwiki/pmwiki.php/Main/FinalBattle'>Final Battle</a>. The NYPD won't listen to Cap's orders to evacuate the civilians and set up a perimeter until Cap takes out a couple of Chitauri in front of the officers, at which point the Sergeant there starts giving his men the exact same orders Cap gave a second ago.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AsskickingPose' title='/pmwiki/pmwiki.php/Main/AsskickingPose'>Ass-Kicking Pose</a>: The entire team as they stand prepared to fight against the enemy.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AstralProjection' title='/pmwiki/pmwiki.php/Main/AstralProjection'>Astral Projection</a>: Loki either uses the power of his magical scepter or his own illusion powers to project his consciousness across light-years of space to the distant lair of the Chitauri army. Despite physically being on a different planet, Loki is still scared enough of his alien master to flinch when he "approaches" him.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AteHisGun' title='/pmwiki/pmwiki.php/Main/AteHisGun'>Ate His Gun</a>: Bruce Banner mentions that he once tried to commit suicide this way, only for <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>"the other guy" to spit out the bullet</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheAtoner' title='/pmwiki/pmwiki.php/Main/TheAtoner'>The Atoner</a>:<ul ><li> Black Widow has "red in her ledger" (i.e. a debt to pay, but also <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheseHandsHaveKilled' title='/pmwiki/pmwiki.php/Main/TheseHandsHaveKilled'>These Hands Have Killed</a>) that she wants to wipe out.</li><li> Hawkeye also shows some shades of this. <span class="spoiler" title="you can set spoilers visible by default on your profile" >After being freed from Loki's brainwashing, the first thing he wants to know is how many of their fellow agents he's killed while under Loki's control.</span></li><li> Though not overly prevalent in this installment of the universe, Tony Stark's role as Iron Man and his participating in the battle at all can all be attributed to him trying to make up for all the years that he <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArmsDealer' title='/pmwiki/pmwiki.php/Main/ArmsDealer'>manufactured weapons</a> and that Obadiah Stane was selling them under the table to terrorist organizations.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AttackBackfire' title='/pmwiki/pmwiki.php/Main/AttackBackfire'>Attack Backfire</a>: Thor's lightning strike <span class="spoiler" title="you can set spoilers visible by default on your profile" >against Tony supercharges the Iron Man suit's power to 475%.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AttackReflector' title='/pmwiki/pmwiki.php/Main/AttackReflector'>Attack Reflector</a>: Captain America's shield, once again.<ul ><li> Cap redirects Loki's bolt when Loki tries to kill the old man who refused to bow.</li><li> Thor's overhead strike on Cap's shield causes a backlash that flattens Cap, Thor, Iron Man, and several hundred feet of surrounding forest.</li><li> Later, Cap and Iron Man use Cap's shield to reflect a repulsor beam blast into a squad of Chitauri behind Tony, &agrave; la <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/MarvelUltimateAlliance' title='/pmwiki/pmwiki.php/VideoGame/MarvelUltimateAlliance'>Marvel Ultimate Alliance</a> 2</em>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AttentionWhore' title='/pmwiki/pmwiki.php/Main/AttentionWhore'>Attention Whore</a>:<ul ><li> Tony Stark, good god. He's partly doing it to break the ice (and at one point, to implant a computer virus into S.H.I.E.L.D.'s network to find out what they're hiding from the Avengers), but he's also clearly reveling in his captive audience in order to show off and crack jokes nonstop.</li><li> Loki also seems to delight in doing this. Tony's not amused when he realises the similarities between them.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AudibleSharpness' title='/pmwiki/pmwiki.php/Main/AudibleSharpness'>Audible Sharpness</a>: Played with. Arrows and bladed scepters don't have audible sharpness. However, shields and hammers have audible <em>bluntness.</em></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AudienceSurrogate' title='/pmwiki/pmwiki.php/Main/AudienceSurrogate'>Audience Surrogate</a>: Captain America, being a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater' title='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater'>Fish out of Temporal Water</a>, regularly needs to be brought up to speed on the new world around him.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AuthorTract' title='/pmwiki/pmwiki.php/Main/AuthorTract'>Author Tract</a>: Averted with writer/director <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> having newly awake Steve Rogers (Captain America) giving his views (which were Whedon's own) on what was wrong with modern society, then cutting the scene out himself due to pacing.<div class='indent'><strong>Joss Whedon:</strong> One of the best scenes that I wrote was the beautiful and poignant scene between Steve and Peggy [Carter] that takes place in the present. And I was the one who was like, Guys, we need to lose this. It was killing the rhythm of the thing. And we did have a lot of Cap, because he really was the in for me. I really do feel a sense of loss about what's happening in our culture, loss of the idea of community, loss of health care and welfare and all sorts of things. I was spending a lot of time having him say it, and then I cut that.</div><ul ><li> Also when Joss Whedon (a noted atheist) gives Cap the line "There's only one God, ma'am, and I'm pretty sure he doesn't dress like that." Never in a million years something Joss Whedon would say, but absolutely something Cap would say.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AutobotsRockOut' title='/pmwiki/pmwiki.php/Main/AutobotsRockOut'>Autobots, Rock Out!</a>: Invoked. When Iron Man arrives in Stuttgart to back up Captain America, he first hacks the nearest sound system &#8212; the PA system of Black Widow's quinjet &#8212; to blast <a class='twikilink' href='/pmwiki/pmwiki.php/Music/ACDC' title='/pmwiki/pmwiki.php/Music/ACDC'>AC/DC</a>'s "Shoot to Thrill" during the fight. This also serves as a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CallBack' title='/pmwiki/pmwiki.php/Main/CallBack'>Call-Back</a> to <em>Iron Man 2</em>, where he enters the Stark Expo with the same song.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AvengersAssemble' title='/pmwiki/pmwiki.php/Main/AvengersAssemble'>Avengers Assemble</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TropeNamer' title='/pmwiki/pmwiki.php/Main/TropeNamer'>Naturally</a>. Though the line itself is only used in a begrudging sarcastic tone by Stark, as seen in the preview. It's used as the actual title of the movie in the UK and the Republic of Ireland.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AwesomeAnachronisticApparel' title='/pmwiki/pmwiki.php/Main/AwesomeAnachronisticApparel'>Awesome Anachronistic Apparel</a>: Steve still dresses and wears his hair like he's in the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheForties' title='/pmwiki/pmwiki.php/Main/TheForties'>1940s</a>. It becomes a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DiscussedTrope' title='/pmwiki/pmwiki.php/Main/DiscussedTrope'>Discussed Trope</a> when Steve worries that a jaded public might not receive his star-spangled, patriotic uniform as well as the <a class='twikilink' href='/pmwiki/pmwiki.php/UsefulNotes/WorldWarII' title='/pmwiki/pmwiki.php/UsefulNotes/WorldWarII'>World War II</a> generation, worrying that it might be seen as old-fashioned, to which Agent Coulson assures him that "Maybe we <em>need</em> some old-fashioned."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AwesomePersonnelCarrier' title='/pmwiki/pmwiki.php/Main/AwesomePersonnelCarrier'>Awesome Personnel Carrier</a>: The Chitauri leviathans serve as this, having no weapons of their own their role is to transport troops around and crash into things.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AwesomeYetImpractical' title='/pmwiki/pmwiki.php/Main/AwesomeYetImpractical'>Awesome, yet Impractical</a>: The S.H.I.E.L.D. helicarrier. Banner even lampshades it. It takes tons of Tony Stark's arc reactor technology to keep it afloat and is likely astronomically expensive. <span class="spoiler" title="you can set spoilers visible by default on your profile" >And if two of the turbines are taken out, you have a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColonyDrop' title='/pmwiki/pmwiki.php/Main/ColonyDrop'>Colony Drop</a> on your hands.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AxCrazy' title='/pmwiki/pmwiki.php/Main/AxCrazy'>Ax-Crazy</a>: Crossed with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CameBackWrong' title='/pmwiki/pmwiki.php/Main/CameBackWrong'>Came Back Wrong</a>. According to <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/TomHiddleston' title='/pmwiki/pmwiki.php/Creator/TomHiddleston'>Tom Hiddleston</a>, Loki's unprotected fall through the cosmos has led him to "see things". He's forsaken his family and is determined to destroy the Earth and hand the Tesseract over to those who would use its power to subjugate the entire universe just to spite his brother.</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder2');">&nbsp;&nbsp;&nbsp;&nbsp;B&nbsp;</div><div id="folder2" class="folder" isfolder="true" style="display:block;"><!-- <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BackedByThePentagon' title='/pmwiki/pmwiki.php/Main/BackedByThePentagon'>Backed by the Pentagon</a> is trivia.--><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BackToBackBadasses' title='/pmwiki/pmwiki.php/Main/BackToBackBadasses'>Back-to-Back Badasses</a>: Cap and Thor, Cap and Iron Man, Cap and Black Widow, Black Widow and Hawkeye, Thor and the Hulk... it's a popular tactic. The shot of all of them in a circle during the climax is a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MoneyShot' title='/pmwiki/pmwiki.php/Main/MoneyShot'>Money Shot</a> featured in the trailer.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassArmy' title='/pmwiki/pmwiki.php/Main/BadassArmy'>Badass Army</a>: Loki's secret master thought the Chitauri were one. Obviously not badass <em>enough.</em></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>Badass Boast</a>:<ul ><li> Tony makes several in a conversation with Loki.<div class='indent'><strong>Stark:</strong> You're missing the point &#8212; there's no throne, there is <em>no</em> version of this where you come out on top. <em>Maybe</em> your army comes, and <em>maybe</em> it's too much for us, but it's all on <em>you</em>... 'Cause if we can't protect the Earth, you can be <em>damn</em> well sure <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImpliedDeathThreat' title='/pmwiki/pmwiki.php/Main/ImpliedDeathThreat'>we'll avenge it</a>.</div></li><li> Loki himself gives one complete with an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>A God Am I</a> line. Unfortunately he just had to do it to <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Hulk. That <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShutUpHannibal' title='/pmwiki/pmwiki.php/Main/ShutUpHannibal'>didn't</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MetronomicManMashing' title='/pmwiki/pmwiki.php/Main/MetronomicManMashing'>end</a> <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk' title='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk'>well</a></span>.</li><li> At the end, Nick Fury suggests that he orchestrated much of what happened in the film as a big <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>Badass Boast</a> on behalf of the planet Earth, a way of declaring to all those <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien' title='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien'>Sufficiently Advanced Aliens</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlienInvasion' title='/pmwiki/pmwiki.php/Main/AlienInvasion'>would-be invaders</a> "come and have a go if you think you're hard enough!" The Chitauri themselves acknowledge this at the end. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Their master Thanos, however, takes it as a challenge</span>.<div class='indent'><strong>WSC member:</strong> Was that the point of all this? <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>A statement</a>? <br /><strong>Nick Fury:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PreAsskickingOneLiner' title='/pmwiki/pmwiki.php/Main/PreAsskickingOneLiner'>A promise.</a></div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBystander' title='/pmwiki/pmwiki.php/Main/BadassBystander'>Badass Bystander</a>: The old man who refuses to kneel to Loki. He knows what Loki is about, and he knows what is going to happen to him if he doesn't comply with the villain's wishes, because <a class='twikilink' href='/pmwiki/pmwiki.php/UsefulNotes/AdolfHitler' title='/pmwiki/pmwiki.php/UsefulNotes/AdolfHitler'>he's seen this sort of tyrant before</a>. Yet he <em>still</em> delivers a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KirkSummation' title='/pmwiki/pmwiki.php/Main/KirkSummation'>Kirk Summation</a> with his head held high.<div class='indent'><strong>Old German:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>Not to men like you.</a> <br /><strong>Loki:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>There are no men like me</a>. <br /><strong>Old German:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KirkSummation' title='/pmwiki/pmwiki.php/Main/KirkSummation'>There are</a> <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/KirkSummation' title='/pmwiki/pmwiki.php/Main/KirkSummation'>always</a></em> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KirkSummation' title='/pmwiki/pmwiki.php/Main/KirkSummation'>men like you</a>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassCrew' title='/pmwiki/pmwiki.php/Main/BadassCrew'>Badass Crew</a>: The idea behind the Avengers Initiative was to invoke this trope. It wasn't the crew Fury planned on, but it all worked out in the end.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassInANiceSuit' title='/pmwiki/pmwiki.php/Main/BadassInANiceSuit'>Badass in a Nice Suit</a><ul ><li> Loki, while not wearing Asgardian attire, looks dressed for the opera. He has to catch an act after all (and someone's eye).</li><li> Agent Coulson and most (male) S.H.I.E.L.D. agents also wear suits.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassLongcoat' title='/pmwiki/pmwiki.php/Main/BadassLongcoat'>Badass Longcoat</a>:<ul ><li> Nick Fury wears a fairly modern trench-coat.</li><li> Loki has a long coat as part of his Asgardian apparel <em>and</em> at the museum gala.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Badass Normal</a>: Nick Fury, Agent Coulson and Maria Hill contribute to the fight using S.H.I.E.L.D. weapons, tactics and leadership. Hawkeye and Black Widow fight side-by-side with the four "powered" characters.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BaitAndSwitchSuicide' title='/pmwiki/pmwiki.php/Main/BaitAndSwitchSuicide'>Bait-and-Switch Suicide</a>: After Selvig wakes up from Loki's brainwashing, Natasha finds him looking over the edge of Stark Tower's roof, like he's thinking about jumping. Natasha tries to talk him down, only for him to reveal that he's not looking at the ground; he's looking at Loki's scepter a few stories down, which is the key to closing the portal.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BallroomBlitz' title='/pmwiki/pmwiki.php/Main/BallroomBlitz'>Ballroom Blitz</a>: Loki disrupts a very formal party in Germany in order to use one of the guests' eyeballs to allow the corrupted Barton to break in and steal something.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BarehandedBladeBlock' title='/pmwiki/pmwiki.php/Main/BarehandedBladeBlock'>Barehanded Blade Block</a>: Captain America catches the blade of a Chitauri polearm/rifle-bayonet during the battle in Manhattan.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BashBrothers' title='/pmwiki/pmwiki.php/Main/BashBrothers'>Bash Brothers</a>: Several team ups, the most notable pairings being Iron Man and Captain America, Thor and the Hulk, and Black Widow and Hawkeye. Though Cap and Widow have their moments too.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BatmanCanBreatheInSpace' title='/pmwiki/pmwiki.php/Main/BatmanCanBreatheInSpace'>Batman Can Breathe in Space</a>:<ul ><li> The Chitauri don't seem to have any apparatus other than their (possibly ornamental) metal masks while riding their sleds in outer space. Of course, they may come from a dimension where the laws of physics are a bit different or their strange cyborg bodies may not need air.</li><li> Steve provides a lesser example. When they're outside the Helicarrier up in the air, everyone else wears breather masks. Steve doesn't need to. This could be his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSoldier' title='/pmwiki/pmwiki.php/Main/SuperSoldier'>Super Soldier</a> nature, but there's not really any reason a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSoldier' title='/pmwiki/pmwiki.php/Main/SuperSoldier'>Super Soldier</a> would be able to breathe thinner air (if anything, his enhanced, high-metabolism body should need <em>more</em> oxygen than other people. On the other hand, Rodger's body may be enhanced to operate like real world humans that live at high altitudes, like Sherpa. Research has shown that their mitochondria are more efficient than those of us who live at lower altitudes , requiring less oxygen to produce as much, or more ATP. They also have higher phosphocreatine levels, giving them an energy reserve when their ATP levels are depleted ).</li></ul></p><p></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BatmanGambit' title='/pmwiki/pmwiki.php/Main/BatmanGambit'>Batman Gambit</a>: Loki's plans. All of them rely on pressing the heroes' buttons to provoke reactions that he thinks will help him. <em>Largely</em> works in the second act. Doesn't work at <em>all</em> on the Hulk.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BeamSpam' title='/pmwiki/pmwiki.php/Main/BeamSpam'>Beam Spam</a>: Late in the final battle a group of Chitauri aircraft manage to corner the Hulk and start blasting the bejeezus out of him, <span class="spoiler" title="you can set spoilers visible by default on your profile" >though even that doesn't do any lasting damage</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BeatTheCurseOutOfHim' title='/pmwiki/pmwiki.php/Main/BeatTheCurseOutOfHim'>Beat the Curse Out of Him</a>: A solid blow to the head seems to reverse the mind control caused by Loki's staff, at least in the cases of <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye and Dr. Selvig.</span> Black Widow, not wanting to take the risk that the trope isn't in effect, knocks <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span> out cold just to be safe.<div class='indent'><strong>Black Widow:</strong> Cognitive recalibration. <em>[pause]</em> I hit you really hard on the head.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BeautifulDreamer' title='/pmwiki/pmwiki.php/Main/BeautifulDreamer'>Beautiful Dreamer</a>: Played for laughs rather than for romance, when Captain America hears the following from his biggest fanboy, Agent Coulson:<div class='indent'><strong>Coulson:</strong> I watched you while you were sleeping. <em>[<a class='twikilink' href='/pmwiki/pmwiki.php/Main/Beat' title='/pmwiki/pmwiki.php/Main/Beat'>Beat</a>]</em> I mean, I was present when you were unconscious from the ice.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BeautyIsNeverTarnished' title='/pmwiki/pmwiki.php/Main/BeautyIsNeverTarnished'>Beauty Is Never Tarnished</a>: Maria Hill gets small cuts on her cheek and forehead, though it notably stays there for the rest of the movie. Black Widow takes an accidental backhand from the <em>Hulk</em> and it doesn't even smudge her makeup, let alone pulverize her ribcage.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BehindTheBlack' title='/pmwiki/pmwiki.php/Main/BehindTheBlack'>Behind the Black</a>: Hulk's hilarious <span class="spoiler" title="you can set spoilers visible by default on your profile" >smack-down of Loki involves this: Loki is looking straight at the Hulk as he begins his "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>A God Am I</a>" speech.</span> There is enough distance between them that <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki would be able to see the Hulk's whole figure (so Hulk couldn't make any move without it being seen). But Loki is the only one in shot, and doesn't react until Hulk has already snatched his feet from under him mid-sentence so he can can whip him around like a ragdoll.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BenchBreaker' title='/pmwiki/pmwiki.php/Main/BenchBreaker'>Bench Breaker</a>: Black Widow does a flip <em>while tied to a chair</em>, shattering it on impact and freeing herself.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BerserkButton' title='/pmwiki/pmwiki.php/Main/BerserkButton'>Berserk Button</a>:<ul ><li> Thor &#8212; despite the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CharacterDevelopment' title='/pmwiki/pmwiki.php/Main/CharacterDevelopment'>Character Development</a> in his last film &#8212; still isn't fond of being told to put down his hammer.</li><li> The Hulk regards existence in general as one, but he responds particularly badly to Thor calling him "Banner" and to Loki beginning a monologue.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BFG' title='/pmwiki/pmwiki.php/Main/BFG'>BFG</a>: Coulson retrieves one based on the Destroyer's remains from the Helicarrier armory to face Loki.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BewareTheNiceOnes' title='/pmwiki/pmwiki.php/Main/BewareTheNiceOnes'>Beware the Nice Ones</a>:<ul ><li> Dr. Banner, obviously; "enormous green rage monster" inside the meek scientist.</li><li> Agent Phil Coulson also counts: barring Captain Rogers, Coulson is probably the kindest and most polite character in the cast, and yet he's one of the top agents of S.H.I.E.L.D. and one of Nick Fury's trustees, a position you do not get if you're not hard-core when it counts.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigApplesauce' title='/pmwiki/pmwiki.php/Main/BigApplesauce'>Big Applesauce</a>: The climactic fight sequence occurs in Manhattan. For once this is fully justified; it is explicitly stated that <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki is trying to show off and make a spectacle of his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilPlan' title='/pmwiki/pmwiki.php/Main/EvilPlan'>Evil Plan</a>, so it makes sense that he'd deliberately choose New York. Captain America tells the Avengers to try to contain the Chitauri in Midtown around Stark Tower (in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RealLife' title='/pmwiki/pmwiki.php/Main/RealLife'>Real Life</a> the site of the Met Life Building), and within three blocks of the <a class='urllink' href='http://en.wikipedia.org/wiki/Park_Avenue_Viaduct'>Park Avenue Viaduct<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> in front of Grand Central Terminal.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBad' title='/pmwiki/pmwiki.php/Main/BigBad'>Big Bad</a>: Loki is the main threat and the one who needs to be stopped, but <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos is the one directly behind the events of the film.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBadWannabe' title='/pmwiki/pmwiki.php/Main/BigBadWannabe'>Big Bad Wannabe</a>: Loki is this, too. Oh sure, he's got the Chitauri backing him up and he puts on a big show, but in the end he's nothing more than a self-absorbed pawn to <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span>. In the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilPlan' title='/pmwiki/pmwiki.php/Main/EvilPlan'>Evil Plan</a>, Loki will get Earth, but <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos will get the Infinity Stones and pretty much the whole universe.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBrotherInstinct' title='/pmwiki/pmwiki.php/Main/BigBrotherInstinct'>Big Brother Instinct</a>: Thor towards Loki. Even after all the scheming and attempted murder and genocide, he's still looking out for his little brother.<ul ><li> Subverted though in this exchange:<div class='indent'><strong>Bruce:</strong> I don’t think we should be focusing on Loki. That guy’s brain is a bag full of cats. You can smell crazy on him. <br /><strong>Thor:</strong> Have care how you speak! Loki is beyond reason, but is of Asgard and he is my brother. <br /><strong>Natasha:</strong> He killed eighty people in two days. <br /><strong>Thor:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VerbalBackspace' title='/pmwiki/pmwiki.php/Main/VerbalBackspace'>He’s adopted</a>.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigDamnHeroes' title='/pmwiki/pmwiki.php/Main/BigDamnHeroes'>Big Damn Heroes</a>: Marvel Comics and Joss Whedon both <em>love</em> using this trope.<ul ><li> An elderly German man defiantly stands against Loki in Stuttgart. As Loki is about to kill him, <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/CaptainAmerica' title='/pmwiki/pmwiki.php/ComicBook/CaptainAmerica'>Cap</a> bursts in, blocks the blast with his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfIndestructium' title='/pmwiki/pmwiki.php/Main/MadeOfIndestructium'>shield</a>, and fights.</li><li> Then, when Loki has Cap on the ropes, Iron Man arrives to provide backup.</li><li> Later, Thor saves Black Widow from Hulk on the Helicarrier.</li><li> Later still, the Avengers Assemble to stop the invasion from destroying New York.</li><li> Played for laughs when Bruce does this... by slowly chugging into Manhattan and up to the badly-outmatched heroes on an ancient, ridiculous-looking, tiny little motorcycle with the oh-so-inspiring comment "Well, this all looks... horrible."</li><li> When one of the leviathans is closing in on an office building and the people inside can only watch with horror, here comes... the Hulk, storming through cubicles to the rescue.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvokedTrope' title='/pmwiki/pmwiki.php/Main/InvokedTrope'>Set up</a> for Captain America when a squad of Chitauri have collected a number of civilians in the foyer of an office building, and are preparing an explosive device with a countdown that's just long enough for him to come and rescue everybody before it goes off.</li><li> Hulk leaping to catch <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man as he falls helplessly from the portal</span>.</li><li> And of course, there's Iron Man <span class="spoiler" title="you can set spoilers visible by default on your profile" >sacrificing himself by carrying a nuke into the Chitauri spaceship.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigEntrance' title='/pmwiki/pmwiki.php/Main/BigEntrance'>Big Entrance</a>:<ul ><li> Loki's first appearance: a portal to the other side of the universe opens up in a crackle of blue lightning, and suddenly Loki is standing there in front of several stunned S.H.I.E.L.D. agents. Whom he promptly starts attacking.</li><li> Tony makes his by hacking the Quinjet's stereo to blast AC/DC's "Shoot to Thrill", blasting Loki, and then making his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThreePointLanding' title='/pmwiki/pmwiki.php/Main/ThreePointLanding'>Three-Point Landing</a>. "Make a move, Reindeer Games."</li><li> Averted and played with when Banner arrives for the final battle riding an ancient motorcycle, with a bad muffler to boot.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BiggerStick' title='/pmwiki/pmwiki.php/Main/BiggerStick'>Bigger Stick</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >S.H.I.E.L.D.</span>'s true plans for the cube. <span class="spoiler" title="you can set spoilers visible by default on your profile" >The consequence of the dawning age of superheroes is to make better weapons.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigGood' title='/pmwiki/pmwiki.php/Main/BigGood'>Big Good</a>: Nick Fury, considering he (nominally) commands all of the heroes and everyone who outranks <em>him</em> is a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KnightTemplar' title='/pmwiki/pmwiki.php/Main/KnightTemplar'>Knight Templar</a> jerk. In actual battle, it's good ol' Cap, who's the most natural leader.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigGuyRodeo' title='/pmwiki/pmwiki.php/Main/BigGuyRodeo'>Big Guy Rodeo</a>: At one point, Thor hops on Hulk's back and starts choking him with his hammer.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigNo' title='/pmwiki/pmwiki.php/Main/BigNo'>Big "NO!"</a>:<ul ><li> Thor does one when Loki's illusion seems to escape the cage on the Helicarrier.</li><li> Thor does another when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki stabs Coulson in the back.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BilingualBonus' title='/pmwiki/pmwiki.php/Main/BilingualBonus'>Bilingual Bonus</a>:<ul ><li> At the gala in Stuttgart, there are banners saying "Eroberung und Opferung" ("conquest and sacrifice").</li><li> The address of the location is on the "K&ouml;nigsstra&szlig;e" ("king's road").</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BlackTieInfiltration' title='/pmwiki/pmwiki.php/Main/BlackTieInfiltration'>Black-Tie Infiltration</a>: Loki takes on the illusion of a tuxedo-wearing partygoer to infiltrate the museum gala and <span class="spoiler" title="you can set spoilers visible by default on your profile" >obtain the eye of a museum official to bypass the security system around a meteorite of rare metal</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BlatantLies' title='/pmwiki/pmwiki.php/Main/BlatantLies'>Blatant Lies</a>: When Tony Stark, still trying to get Coulson to leave him alone, tells him that official consulting hours are between eight and five every other Thursday. You can even hear a tiny pause before "Thursday" where he's making sure he doesn't actually use the <em>current</em> day of the week.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BloodFromTheMouth' title='/pmwiki/pmwiki.php/Main/BloodFromTheMouth'>Blood from the Mouth</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson has this after he's stabbed in the back by Loki. Fury tells everyone that he's dead afterwards.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BloodlessCarnage' title='/pmwiki/pmwiki.php/Main/BloodlessCarnage'>Bloodless Carnage</a>: In the American release, there is no blood in the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FinalBattle' title='/pmwiki/pmwiki.php/Main/FinalBattle'>Final Battle</a>. In the UK 3D release alien gore splatters out onto the audience.<ul ><li> The entire Chitauri invasion goes like this. While there are plenty of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SlowLaser' title='/pmwiki/pmwiki.php/Main/SlowLaser'>Slow Lasers</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StuffBlowingUp' title='/pmwiki/pmwiki.php/Main/StuffBlowingUp'>Stuff Blowing Up</a>, and general mayhem, not a single human casualty is depicted on screen, despite the fact that a news ticker displays the phrase "Hundreds Confirmed Dead", and a framed <em>Bulletin</em> front page in Ben Urich's office in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/Daredevil2015' title='/pmwiki/pmwiki.php/Series/Daredevil2015'>Daredevil (2015)</a></em> also says hundreds of people were killed.<ul ><li> Averted quite a bit in the deleted scenes, which show a lot more carnage in the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FinalBattle' title='/pmwiki/pmwiki.php/Main/FinalBattle'>Final Battle</a>. A police officer and a National Guard soldier are shown being killed, several civilians are lying dead in the streets, a civilian at Beth's coffee shop is shot by the Chitauri (though he may have survived, as he is shown moving afterwards) and Beth finds a watch and a pair of glasses when she is captured and taken hostage at the bank, suggesting the Chituari had already killed an entire group of hostages by vaporizing them with a grenade. It's implied that children may also have been amongst the group of vaporized civilians as well, as there are children in the next group they are about to execute before Captain America saves them.</li></ul></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BloodStainedLetter' title='/pmwiki/pmwiki.php/Main/BloodStainedLetter'>Blood-Stained Letter</a>: After <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> is killed, Nick Fury presents <span class="spoiler" title="you can set spoilers visible by default on your profile" >his beloved collection of Captain America collector's cards</span> to the team, still wet with his blood. After the team has <span class="spoiler" title="you can set spoilers visible by default on your profile" >gone to face Loki, Agent Hill says the cards were in Coulson's locker, at which point Fury admits he needed something to motivate them.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BluntYes' title='/pmwiki/pmwiki.php/Main/BluntYes'>Blunt "Yes"</a>: Loki responds this way when Thor asks him if he considers himself above the humans.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BondOneLiner' title='/pmwiki/pmwiki.php/Main/BondOneLiner'>Bond One-Liner</a>: The Hulk, of all people, gets one after <span class="spoiler" title="you can set spoilers visible by default on your profile" >thrashing Loki.</span><div class='indent'><strong>Hulk:</strong> Puny god.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BondVillainStupidity' title='/pmwiki/pmwiki.php/Main/BondVillainStupidity'>Bond Villain Stupidity</a>: A rare heroic example: Fury shows Loki the controls that will drop his holding cage out of the Helicarrier to (supposedly) certain doom; <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki uses the same controls to drop Thor overboard after he escapes and tricks Thor into the cell.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BoobsAndButtPose' title='/pmwiki/pmwiki.php/Main/BoobsAndButtPose'>Boobs-and-Butt Pose</a>: Black Widow does this in some posters, <em>Iron Man</em> does it in others.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BookEnds' title='/pmwiki/pmwiki.php/Main/BookEnds'>Book Ends</a>: The movie begins and ends with Loki leaving with the Tesseract, albeit under vastly different circumstances.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BoringButPractical' title='/pmwiki/pmwiki.php/Main/BoringButPractical'>Boring, but Practical</a><ul ><li> The S.H.I.E.L.D. agents all use conventional firearms. Even Nick Fury's RPG launcher fits here.</li><li> During one of his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InsufferableGenius' title='/pmwiki/pmwiki.php/Main/InsufferableGenius'>Insufferable Genius</a> monologues, Tony wonders aloud how Fury can see the monitors stationed to his left when he's missing an eye. Maria tells him as bluntly as possible <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeadpanSnarker' title='/pmwiki/pmwiki.php/Main/DeadpanSnarker'>"... he turns."</a> Tony finds this solution to be <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SarcasmMode' title='/pmwiki/pmwiki.php/Main/SarcasmMode'>woefully inefficient</a>.</li><li> When Fury wants to move the crippled Helicarrier south, the helmsman remarks that navigation systems are offline. Fury's response:<div class='indent'><strong>Nick Fury:</strong> Is the sun coming up? <br /><strong>Helmsman:</strong> ...Yes, sir. <br /><strong>Nick Fury:</strong> Then put it on the <em>left</em>!</div></li><li> When Tony <span class="spoiler" title="you can set spoilers visible by default on your profile" >uploads a computer virus to unlock all of S.H.I.E.L.D.'s files</span> to find out <span class="spoiler" title="you can set spoilers visible by default on your profile" >what they're really doing with the Cube, Cap decides it's taking too long. So he just breaks into the armory, steals a captured HYDRA gun, and dumps it on the table in front of the team.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BorrowedBiometricBypass' title='/pmwiki/pmwiki.php/Main/BorrowedBiometricBypass'>Borrowed Biometric Bypass</a>: Loki and his minions use a fancy piece of stolen S.H.I.E.L.D. tech that lets them scan someone's eye and turn it into a hologram good enough to fool a retina scanner. Loki probably didn't <em>have</em> to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EyeScream' title='/pmwiki/pmwiki.php/Main/EyeScream'>jam it right into the poor man's eye socket though</a>...</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BorrowedCatchphrase' title='/pmwiki/pmwiki.php/Main/BorrowedCatchphrase'>Borrowed Catchphrase</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Captain America borrows the Hulk's catchphrase: "Hulk? Smash."</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BottomlessMagazines' title='/pmwiki/pmwiki.php/Main/BottomlessMagazines'>Bottomless Magazines</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayingWithATrope' title='/pmwiki/pmwiki.php/Main/PlayingWithATrope'>Played with</a>.<ul ><li> Captain America and the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EliteMook' title='/pmwiki/pmwiki.php/Main/EliteMook'>Elite Mook</a> he fights at the Helicarrier never seem to run out of ammo in their rifles.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AvertedTrope' title='/pmwiki/pmwiki.php/Main/AvertedTrope'>Averted</a> when Hawkeye runs out of arrows when dealing with an alien horde. Toward the start of the battle, he can be seen retrieving some of the ones he's already fired and putting them back in his quiver.</li><li> Also averted by Black Widow, who is seen reloading one of her guns and scavenging alien weaponry.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Bowdlerize' title='/pmwiki/pmwiki.php/Main/Bowdlerize'>Bowdlerize</a>: This happened to <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson</span>'s death scene in the original American theatrical release and several European DVD releases. Oddly enough, despite being officially rated R by the MPAA, the uncut version is available on the American DVD release with the theatrical version's PG-13 rating. <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/Loki2021' title='/pmwiki/pmwiki.php/Series/Loki2021'>Loki (2021)</a></em> would use the uncensored clip during a flashback to the event in question.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye, Selvig</span>, and some S.H.I.E.L.D. agents are all mind-controlled by Loki.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrawlerLock' title='/pmwiki/pmwiki.php/Main/BrawlerLock'>Brawler Lock</a>: Iron Man throws two punches at Thor but he catches them and starts slowly crushing his gauntlets. Tony stops the lock by using his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PowerPalms' title='/pmwiki/pmwiki.php/Main/PowerPalms'>Power Palms</a> and headbutting the demigod. Unfortunately, Thor returns the favor.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BreakingTheFellowship' title='/pmwiki/pmwiki.php/Main/BreakingTheFellowship'>Breaking the Fellowship</a>: Part of Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilPlan' title='/pmwiki/pmwiki.php/Main/EvilPlan'>Evil Plan</a> early in the film, by causing <span class="spoiler" title="you can set spoilers visible by default on your profile" >Bruce Banner to turn into the Hulk and help break the Avengers group apart so they'd be out of his way while he summons the Chitauri to Earth. It nearly works.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BreakTheCutie' title='/pmwiki/pmwiki.php/Main/BreakTheCutie'>Break the Cutie</a>: Black Widow to a certain degree. She is chased by the Hulk in the Helicarrier and is nearly smashed by him, causing her considerable distress. <span class="spoiler" title="you can set spoilers visible by default on your profile" >She also confesses to Hawkeye that she's been "compromised" by Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HannibalLecture' title='/pmwiki/pmwiki.php/Main/HannibalLecture'>Hannibal Lecture</a> in spite of playing a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a> to trick him</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BreakThemByTalking' title='/pmwiki/pmwiki.php/Main/BreakThemByTalking'>Break Them by Talking</a>:<ul ><li> Loki loves doing this &#8212; with obvious relish &#8212; every chance he gets. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Which is presumably why he's muzzled at the end.</span></li><li> Tony is this to a lesser extent &#8212; compared to everyone else's, his verbal remarks were the cruelest and most debilitating. He particularly seemed to have it out for Cap in this installment.<div class='indent'><strong>Steve:</strong> <em>[to Tony]</em> You know, you may not be a threat, but you better stop pretending to be a hero. <br /><strong>Tony:</strong> A hero? Like you? You're a laboratory experiment, Rodgers. Everything special about you came out of a bottle.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrickJoke' title='/pmwiki/pmwiki.php/Main/BrickJoke'>Brick Joke</a>: Used repeatedly, mercilessly, and at every opportunity.<ul ><li> During their first scene, Tony tells Pepper to take "some of the credit" for Stark Tower, eventually settling on 12%. Her reaction prompts him to respond "I'm gonna pay for that later, aren't I?" When Coulson shows up with some S.H.I.E.L.D. intel for Tony to look at, Tony tries to get Pepper to send him away, saying "I thought we were having a moment." She responds "I was having 12% of a moment."</li><li> Steve Rogers tells Nick Fury that he isn't out exploring the wonders of the 21st century because "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/SeenItAll' title='/pmwiki/pmwiki.php/Main/SeenItAll'>I doubt anything could surprise me any more</a>." Fury replies "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/SideBet' title='/pmwiki/pmwiki.php/Main/SideBet'>Ten bucks says you're wrong.</a>" This just appears to be a figure of speech, until S.H.I.E.L.D.'s aircraft carrier takes off into the sky and turns invisible. Rogers appears on the bridge, and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Touche' title='/pmwiki/pmwiki.php/Main/Touche'>wordlessly passes Fury &#36;10</a>.</li><li> Agent Coulson's Captain America trading cards are mentioned to Steve and that he'll probably childishly ask him to sign them. The second time the two are together Coulson sheepishly asks if he will sign them. <span class="spoiler" title="you can set spoilers visible by default on your profile" >After Coulson's death, the cards appear again in a much darker context.</span></li><li> A rather heartwarming one occurs when Pepper asks Phil Coulson about his girlfriend, only to be informed that they broke up when she moved back to Portland. Later, when Tony arrives on the Helicarrier, he's shown offering to fly him out to see her on his private jet.</li><li> After Banner rattles off some <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>Techno Babble</a> (it's real science disguised as such), Tony says, "Finally! Someone who speaks English," to which Steve wonders bemusedly, "Is that what just happened?" Later, Tony attempts to explain to Steve what to do while they make some repairs, but does it <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>in such a way</a> that Steve has to tell him "Speak English!"</li><li> Tony says they should all eat at a <a class='urllink' href='http://en.wikipedia.org/wiki/Shawarma'>shawarma<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> joint he saw. <span class="spoiler" title="you can set spoilers visible by default on your profile" >In the second stinger added to the U.S. version, they do. Everyone, except Tony and Bruce, is in full costume, and the place is still messed up from the attack.</span> There's almost no way anyone would notice it on the first viewing, but Tony bounces past a shawarma joint when he crash-lands after his "Jonah maneuver" through one of the Leviathans. It's a blink-and-you-miss-it sort of thing, and is kind of amusing if you consider what it says about Tony.</li><li> Tony calls an employee of S.H.I.E.L.D. out on playing <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a></em> instead of working. It sounds like he's just <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HoldingTheFloor' title='/pmwiki/pmwiki.php/Main/HoldingTheFloor'>holding the floor as a distraction,</a> so he can plant his virus bug to break into S.H.I.E.L.D's mainframe. Cue the end of the scene where we see a S.H.I.E.L.D. grunt sheepishly switch windows and go back to playing <em>Galaga</em>.</li><li> <em>Ant. Boot.</em> First it's said by Loki to Fury and then by Fury to Loki.</li><li> Before Loki <span class="spoiler" title="you can set spoilers visible by default on your profile" >brainwashes Barton</span> his comment is "You have heart." Later in the movie when he <span class="spoiler" title="you can set spoilers visible by default on your profile" >tries to brainwash Tony Stark his attempt is blocked by the arc reactor.</span> Ironic when you consider that all the way back in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan1' title='/pmwiki/pmwiki.php/Film/IronMan1'>Iron Man</a></em> Pepper's birthday gift to Tony is <span class="spoiler" title="you can set spoilers visible by default on your profile" >his original arc reactor, as "Proof that Tony Stark has a heart."</span></li><li> Hawkeye commenting that he'd like to put an arrow in Loki's eye. <span class="spoiler" title="you can set spoilers visible by default on your profile" >It comes back twice: Once in Manhattan, he fires an arrow at Loki's eye, Loki catches it, and it explodes. The second return is at the end of the battle, when Loki crawls out of his Hulk Smash hole. The Avengers are all circled around him, and Hawkeye is front-and-center, with an arrow pointed at Loki's face (presumably aimed for the eye).</span></li><li> Tony offers Loki a drink. He declines at first, but later <a class='twikilink' href='/pmwiki/pmwiki.php/Main/INeedAFreakingDrink' title='/pmwiki/pmwiki.php/Main/INeedAFreakingDrink'>he ends up needing one</a>.</li><li> Several characters, most notably Natasha and Tony, express curiosity about Banner's "secret" for how he's managed to avoid getting angry and keep the Hulk from emerging for so long &#8212; Natasha speculates about yoga, while Tony's guesses include "Mellow jazz? Bongo drums? Big bag of weed?" Just before joining in the final battle, Bruce reveals it: <span class="spoiler" title="you can set spoilers visible by default on your profile" >"That's my secret. I'm always angry."</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BroadStrokes' title='/pmwiki/pmwiki.php/Main/BroadStrokes'>Broad Strokes</a>: The approach taken with Bruce Banner/Hulk. Iron Man, Thor, and Captain America have multiple characters and/or plot elements from their films play into this film, Banner/Hulk is the only one to show up from his film, and outside of brief glimpses of footage and a joke reference, his film is never really alluded to at all. In addition to being re-cast, the characterization of Banner and Hulk are quite different from in <em>The Incredible Hulk</em>. That film is the only Pre-<em>Avengers</em> film you could miss completely, as Banner/Hulk are effectively re-introduced in this film.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BuffySpeak' title='/pmwiki/pmwiki.php/Main/BuffySpeak'>Buffy Speak</a>: Inevitable, with the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TropeNamer' title='/pmwiki/pmwiki.php/Main/TropeNamer'>Trope Namer</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>on board</a>.<div class='indent'><strong>Tony Stark:</strong> ...enormous green rage-monster.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BuildingOfAdventure' title='/pmwiki/pmwiki.php/Main/BuildingOfAdventure'>Building of Adventure</a>: Stark Tower is a somewhat mundane example that's just focused around awesome Iron Man stuff. But a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreezeFrameBonus' title='/pmwiki/pmwiki.php/Main/FreezeFrameBonus'>Freeze-Frame Bonus</a> at the end reveals that he plans to give the building a substantial upgrade that includes a hangar for a Quinjet as well as giving the various members personalized floors of their own.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BulletproofVest' title='/pmwiki/pmwiki.php/Main/BulletproofVest'>Bulletproof Vest</a>:<ul ><li> After getting shot, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Fury</span> makes it a point to extract the bullet from the vest and show it to the camera as per trope tradition.</li><li> Cap also gets shot during the battle, but survives thanks to his armor.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BullyingADragon' title='/pmwiki/pmwiki.php/Main/BullyingADragon'>Bullying a Dragon</a>:<ul ><li> How Steve sees Tony shocking Bruce Banner mid-conversation with a miniature cattle-prod. Tony's intent is to show he trusts Bruce to control The Hulk, which Bruce recognizes.</li><li> Tony invokes this towards Loki, casually pointing out that he's met some of the most dangerous people on the planet and pissed off <em>"every single one of them"</em>.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Yes, Loki, you <em>are</em> a god,</span> but that <em>doesn't</em> mean <span class="spoiler" title="you can set spoilers visible by default on your profile" >you should try to push the Hulk around.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ButtMonkey' title='/pmwiki/pmwiki.php/Main/ButtMonkey'>Butt-Monkey</a>:<ul ><li> Despite being the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBad' title='/pmwiki/pmwiki.php/Main/BigBad'>Big Bad</a>, Loki has this status, especially towards the end of the film. Every Avenger gets his goat once<span class="notelabel" onclick="togglenote('note3bivt');"><sup>note&nbsp;</sup></span><span id="note3bivt" class="inlinefolder" isnote="true" onclick="togglenote('note3bivt');" style="cursor:pointer;font-size:smaller;display:none;">To wit: Cap managed to interrupt his gloating in Stutggart with a deflected beam attack; Natasha out-tricks him into revealing his plan to unleash the Hulk; Stark <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoSell' title='/pmwiki/pmwiki.php/Main/NoSell'>No Sells</a> his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControl' title='/pmwiki/pmwiki.php/Main/MindControl'>Mind Control</a> scepter thanks to his Arc Reactor (then shoots him with a Repulsor blast right before he can get his sceptre charged and on-target); Clint manages to hit him with an exploding arrow, which Loki thought was harmless when he caught it mid-air; and Hulk cuts him off from his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainousBreakdown' title='/pmwiki/pmwiki.php/Main/VillainousBreakdown'>Villainous Breakdown</a> with some good ol' <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MetronomicManMashing' title='/pmwiki/pmwiki.php/Main/MetronomicManMashing'>Metronomic Man Mashing</a>.</span>. Even <span class="spoiler" title="you can set spoilers visible by default on your profile" >Phil Coulson</span> gets in a good shot.</li><li> Poor Thor. He gets beat up by Iron Man, Cap (sort of), <em>and</em> the Hulk.</li><li> Tony Stark. A great deal of the humor in the various action sequences involve him first being genuinely badass, but then casually getting the shit kicked out of him (once by an inanimate propeller) because he a) is incredibly smart-alecky and boastful, and getting smacked around stops him from coming off as annoying, and b) wears a suit of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoweredArmor' title='/pmwiki/pmwiki.php/Main/PoweredArmor'>Powered Armor</a>, so getting the shit kicked out of him doesn't actually hurt anything but his pride.</li></ul></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder3');">&nbsp;&nbsp;&nbsp;&nbsp;C&nbsp;</div><div id="folder3" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CainAndAbel' title='/pmwiki/pmwiki.php/Main/CainAndAbel'>Cain and Abel</a>: Loki and Thor themselves as usual. Loki tries to <span class="spoiler" title="you can set spoilers visible by default on your profile" >outright <em>murder</em> his brother Thor when he was safely imprisoned (although it's very questionable whether he thought the trap would kill Thor)</span>. Thor later <span class="spoiler" title="you can set spoilers visible by default on your profile" >makes one last bid to talk Loki down during the climactic battle. Loki's response is to pull out a knife and stab him.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CallBack' title='/pmwiki/pmwiki.php/Main/CallBack'>Call-Back</a>: Stark scoffs at Fury's plans to use the Tesseract as a "nuclear deterrent". This mirrors Stark calling himself America's nuclear deterrent in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan2' title='/pmwiki/pmwiki.php/Film/IronMan2'>Iron Man 2</a></em>, before finding out he actually wasn't the only one who could duplicate Arc Reactor technology.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheCameo' title='/pmwiki/pmwiki.php/Main/TheCameo'>The Cameo</a>:<ul ><li> Gwyneth Paltrow as Pepper Potts from the <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan' title='/pmwiki/pmwiki.php/Film/IronMan'>Iron Man</a></em> films.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/StanLee' title='/pmwiki/pmwiki.php/Creator/StanLee'>Stan Lee</a>, creator of the Avengers, stating "Superheroes? In New York? Gimme a break!" in a news report at the end.</li><li> NY1 news anchor Pat Kiernan, MSNBC anchor Thomas Roberts, and then-White House press secretary Jay Carney all make brief appearances <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AsHimself' title='/pmwiki/pmwiki.php/Main/AsHimself'>As Themselves</a> during the montage of news reports at the end of the film. For Pat Kiernan, it would be the first of several MCU appearances.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CameraAbuse' title='/pmwiki/pmwiki.php/Main/CameraAbuse'>Camera Abuse</a>: The camera lens gets splattered with gore multiple times.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheCape' title='/pmwiki/pmwiki.php/Main/TheCape'>The Cape</a>: Captain America, who's definitely the most upstanding guy around. He's worried a bit that some may view this as old-fashioned in the cynical 21st century, but Coulson tells him that right now we may need his brand of "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodIsOldFashioned' title='/pmwiki/pmwiki.php/Main/GoodIsOldFashioned'>old-fashioned</a>."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheCaptain' title='/pmwiki/pmwiki.php/Main/TheCaptain'>The Captain</a>: Captain America (duh). During the final battle he quickly gets everyone playing to their strengths for maximum benefit: Hawkeye being the team spotter, himself and Black Widow evacuating people on the ground, Stark and Thor taking out enemies in the air, and Hulk... <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PhraseCatcher' title='/pmwiki/pmwiki.php/Main/PhraseCatcher'>smashing stuff</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CaptainObvious' title='/pmwiki/pmwiki.php/Main/CaptainObvious'>Captain Obvious</a>: When asked to inspect an electrical panel full of wires, fiber optic cables, circuit boards, and assorted other electronic gizmos, all Captain America can report is a distinctly sarcastic, "It seems to run on some form of electricity."<div class='indent'><strong>Tony Stark:</strong> Well... you're not wrong.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CapturedOnPurpose' title='/pmwiki/pmwiki.php/Main/CapturedOnPurpose'>Captured on Purpose</a>:<ul ><li> At the start of the film, Black Widow is implied to have allowed herself to be captured so she can hear the bad guy's plans.</li><li> Loki's capture and imprisonment on the helicarrier was part of his plan all along, to cripple S.H.I.E.L.D. and eliminate the only threat to his plans.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CarCushion' title='/pmwiki/pmwiki.php/Main/CarCushion'>Car Cushion</a>:<ul ><li> Cap gets this treatment. It helps that he only fell about one story on to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfIndestructium' title='/pmwiki/pmwiki.php/Main/MadeOfIndestructium'>his shield</a> and is empowered by <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSerum' title='/pmwiki/pmwiki.php/Main/SuperSerum'>the Super Soldier Serum</a>. He still takes at least a couple of minutes to get going again; it <em>really</em> hurt.</li><li> The Hulk crushes the hood end of a wrecked car when he slams into the ground after saving Stark. Being the Hulk, of course, he probably didn't even notice.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CarFu' title='/pmwiki/pmwiki.php/Main/CarFu'>Car Fu</a>: Thor takes out a few mooks with a car using a swing of his hammer.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CasualDangerDialogue' title='/pmwiki/pmwiki.php/Main/CasualDangerDialogue'>Casual Danger Dialogue</a>:<ul ><li> Coulson and Black Widow's very casual phone conversation while she was being held hostage and tied to a chair. She then showed she wasn't really in danger by knocking out the guys holding her hostage while <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SeenItAll' title='/pmwiki/pmwiki.php/Main/SeenItAll'>Coulson was still on the phone</a>, as if the sound of Natasha kicking the shit out of several bad guys is nothing more than hold music.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >A dying</span> Coulson shoots Loki with an experimental weapon:<div class='indent'><strong>Coulson:</strong> So <em>that's</em> what it does.</div></li><li> During the final battle in New York:<div class='indent'><strong>Tony:</strong> I'm bringing the party to you. <br /><em>[Tony appears, chased by a Leviathan]</em> <br /><strong>Natasha:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThisIsGonnaSuck' title='/pmwiki/pmwiki.php/Main/ThisIsGonnaSuck'>I... I don't see how that's a party.</a></div></li><li> Also, when she and Hawkeye are standing side-to-side once again against heavy opposition, Black Widow with her handgun and Hawkeye with his bow and arrow:<div class='indent'><em>[fighting cyborg alien invaders]</em> <br /><strong>Black Widow:</strong> It's like <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoodleIncident' title='/pmwiki/pmwiki.php/Main/NoodleIncident'>Budapest</a> all over again.  <br /><strong>Hawkeye:</strong> You and I remember Budapest <em>very</em> differently.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CatchAFallingStar' title='/pmwiki/pmwiki.php/Main/CatchAFallingStar'>Catch a Falling Star</a>: Towards the end of the movie, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man is falling from low earth orbit, unconscious and with no power in his suit. The Hulk leaps by, catches him, drags down a nearby building with his hand to slow both of them to an Iron Man-safe velocity, then cushions Tony with his own body for the final 20 feet or so to the pavement.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Catchphrase' title='/pmwiki/pmwiki.php/Main/Catchphrase'>Catchphrase</a>: Averted: nobody says "Avengers assemble!" Depending on which scene they tried to work it into, <a class='urllink' href='http://io9.com/5908245/why-the-avengers-dont-say-their-most-famous-catchphrase-in-the-avengers'>it was deemed too cheesy or redundant of a line<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>. However, there is the UK title, and cast members reportedly texted one another the phrase before gathering socially in their off-hours.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CerebusRetcon' title='/pmwiki/pmwiki.php/Main/CerebusRetcon'>Cerebus Retcon</a>: Just as Senator Stern in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan2' title='/pmwiki/pmwiki.php/Film/IronMan2'>Iron Man 2</a></em> was "revealed" to be <span class="spoiler" title="you can set spoilers visible by default on your profile" >a member of HYDRA</span> in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier'>Captain America: The Winter Soldier</a></em>, <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/AgentsOfSHIELD' title='/pmwiki/pmwiki.php/Series/AgentsOfSHIELD'>Agents of S.H.I.E.L.D.</a></em> brings back the World Security Councilman played by <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/PowersBoothe' title='/pmwiki/pmwiki.php/Creator/PowersBoothe'>Powers Boothe</a> and makes him <span class="spoiler" title="you can set spoilers visible by default on your profile" >one of HYDRA's <em>leaders</em></span>. It's not clear if his support of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NukeEm' title='/pmwiki/pmwiki.php/Main/NukeEm'>a nuclear strike on Manhattan</a> was intended to somehow serve an agenda or if he and the rest of the Council honestly thought <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainHasAPoint' title='/pmwiki/pmwiki.php/Main/VillainHasAPoint'>that this was the best call in a tough situation</a>; but his pressure on Fury to adopt the "Phase Two" Tesseract weaponry definitely takes on a darker subtext.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChairmanOfTheBrawl' title='/pmwiki/pmwiki.php/Main/ChairmanOfTheBrawl'>Chairman of the Brawl</a>: Black Widow beats up criminals with a chair and she doesn't even have to get up from it. Which was a useful ability, since she was tied to it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChairReveal' title='/pmwiki/pmwiki.php/Main/ChairReveal'>Chair Reveal</a>: Played with. During the mid-credits sequence that reveals <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span> as the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GreaterScopeVillain' title='/pmwiki/pmwiki.php/Main/GreaterScopeVillain'>Greater-Scope Villain</a>, rather than turning around in a spinning chair, he gets up and looks over his shoulder.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChangedMyMindKid' title='/pmwiki/pmwiki.php/Main/ChangedMyMindKid'>Changed My Mind, Kid</a>: Bruce Banner reluctantly lets himself get recruited for his scientific skills, and makes it clear that he's only there to help find the Tesseract and won't be sticking around once the fighting starts. After he leaves, Tony Stark is confident he'll decide to come back and help, but everybody else assumes he's gone for good. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NeutralNoLonger' title='/pmwiki/pmwiki.php/Main/NeutralNoLonger'>Tony turns out to be right.</a></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CharacterDevelopment' title='/pmwiki/pmwiki.php/Main/CharacterDevelopment'>Character Development</a>:<ul ><li> Loki's personality has changed a lot. In his prior film he was a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TragicVillain' title='/pmwiki/pmwiki.php/Main/TragicVillain'>Tragic Villain</a>: here he's unbalanced, and his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheChessmaster' title='/pmwiki/pmwiki.php/Main/TheChessmaster'>mastery of manipulation</a> continues to unravel. Something's clearly wrong, but the heroes don't look much further than the immediate threat (though Thor seems to be aware something is more wrong than usual with Loki). Tom Hiddleston described Loki in this film as having "seen things" while falling through the void, saying that getting tossed through a wormhole of his own making has really affected his psyche and his development as a villain.</li><li> Tony Stark starts out the snarky anti-hero of previous films, but when Cap calls him out on the selfish, lone wolf approach he's taken to superheroics, Tony realizes what it really means to be part of a team and to put his life on the line for someone else. It helps that <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson</span>, someone that Tony knew personally, does exactly this.</li><li> Bruce Banner continues his arc from the previous film: Tony offers him some words about being <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CursedWithAwesome' title='/pmwiki/pmwiki.php/Main/CursedWithAwesome'>Cursed with Awesome</a>. Banner takes another step toward accepting that the Hulk is a part of him, for good or ill.</li><li> Captain America goes from being confused about his place in the present and wondering if <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodIsOldFashioned' title='/pmwiki/pmwiki.php/Main/GoodIsOldFashioned'>Good Is Old-Fashioned</a> in the present, to realizing that his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NiceGuy' title='/pmwiki/pmwiki.php/Main/NiceGuy'>inherent goodness</a> and idealism are even <em>more</em> necessary in an age of cynicism and a team full of cynics.</li><li> Thor arrives on Earth confident that he'll (once again) be the only one able to save the day, and determined to redeem his brother. He comes to realize that his "tiny" teammates have much to contribute, and that it will be his burden to be his brother's jailor, not his savior.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CharacterizationMarchesOn' title='/pmwiki/pmwiki.php/Main/CharacterizationMarchesOn'>Characterization Marches On</a>: Agent Coulson, the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AscendedFanboy' title='/pmwiki/pmwiki.php/Main/AscendedFanboy'>Fanboy?</a> Hard to imagine that he threatened to taser Tony in <em>Iron Man 2</em> after he gave him lip.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChekhovsGag' title='/pmwiki/pmwiki.php/Main/ChekhovsGag'>Chekhov's Gag</a>: Black Widow quips it's only a matter of time before Coulson begs Steve Rogers to sign his trading cards. This quickly turns out to be the case. When we see the cards in question, they're still <span class="spoiler" title="you can set spoilers visible by default on your profile" >wet with Coulson's (fake) blood.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChekhovsGun' title='/pmwiki/pmwiki.php/Main/ChekhovsGun'>Chekhov's Gun</a>:<ul ><li> Much is made early on of the newly-launched Stark Tower, which runs on its own arc reactor, and how it could be interpreted as a giant monument to Tony's ego. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Later, Steve and Tony figure out that Loki needs access to a big power source to activate the Tesseract, and that Loki wants the invasion to be a monument to his own ego.</span></li><li> Cap berates Tony for his inability to be heroic, especially when it comes to making sacrifices. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Naturally, Tony makes a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicSacrifice' title='/pmwiki/pmwiki.php/Main/HeroicSacrifice'>Heroic Sacrifice</a> at the end. He suffocates, but survives.</span></li><li> Nick Fury's description of Loki's jail cell is a classic example: as soon as he mentions it's <span class="spoiler" title="you can set spoilers visible by default on your profile" >designed to be dropped out of the Helicarrier and will fall 30,000 feet</span>, you know that capability is getting put to use <em>somehow</em>.</li><li> Cap says that Loki's staff looks like HYDRA technology, which was powered by the Tesseract. <span class="spoiler" title="you can set spoilers visible by default on your profile" >S.H.I.E.L.D. too was designing HYDRA-inspired weapons powered by the Tesseract. And at the end, Loki's scepter is the only thing that can pierce the Tesseract's energy barrier</span>.</li><li> In the scene where The Other is threatening Loki, one of the Leviathans "swims" by in the background.</li><li> Averted with Thor's lightning providing Stark's armor with a 475% overcharge, as demonstrated accidentally during their forest skirmish. Although a potentially useful if self-destructive tactic (the armor didn't come out of it unscathed), this is never used during the final battle against the Chitauri. <span class="spoiler" title="you can set spoilers visible by default on your profile" >It does however, come back in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/AvengersEndgame' title='/pmwiki/pmwiki.php/Film/AvengersEndgame'>Avengers: Endgame</a></em>, where Tony has put in a system specifically designed to help perform this move more safely.</span></li><li> Averted with the shockwave produced by Thor's hammer interacting with the Captain's shield. Despite being a classic setup for the maneuver's reuse during the final battle, it does not appear again. Perhaps if the final battle hadn't been in an un-evacuated city... <span class="spoiler" title="you can set spoilers visible by default on your profile" >Although this particular gun finally goes off in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/AvengersAgeOfUltron' title='/pmwiki/pmwiki.php/Film/AvengersAgeOfUltron'>Avengers: Age of Ultron</a></em>, Thor and Cap having weaponized the technique.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChekhovsSkill' title='/pmwiki/pmwiki.php/Main/ChekhovsSkill'>Chekhov's Skill</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GuileHero' title='/pmwiki/pmwiki.php/Main/GuileHero'>Black Widow</a>'s <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a> used in the beginning is used on Loki later on.</li><li> Early on Tony is introduced while totally underwater, revealing that his suits are totally airtight and temporarily life-sustaining without an outside source of oxygen. This comes in handy when <span class="spoiler" title="you can set spoilers visible by default on your profile" >he needs to survive in the vacuum of space for a while during the climax.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheChessmaster' title='/pmwiki/pmwiki.php/Main/TheChessmaster'>The Chessmaster</a>: Played with.<ul ><li> Nick Fury is doing his best to be one, but unfortunately he is trying to manipulate two of the smartest people on Earth, a proud and reckless demigod and a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KnightInShiningArmor' title='/pmwiki/pmwiki.php/Main/KnightInShiningArmor'>Knight in Shining Armor</a>. The first two don't buy his bullshit, they spill the beans to the other two, who don't take it nicely. Fury has to give up, apologize and play, oh, just <em>a bit</em> straighter... but he's still <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSpymaster' title='/pmwiki/pmwiki.php/Main/TheSpymaster'>The Spymaster</a> and a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Manipulative Bastard</a>.</li><li> Loki begins the movie forced into a faustian bargain with a much higher weight-class of god than himself where his life depends on giving that god a power the latter explicitly intends to use to murder most of the sentient life in the universe, with little more than the verbal assurance that an eldritch horror from beyond space will leave him and his conquered planet (which he didn't really want in his previous appearance, rather he wanted Asgard). Basically, he's up a foul-smelling creek with no paddle and holding the Marvel equivalent of a Gigaton nuke. One series of "blunders" and increasingly-less-subtle hints to the rather dim heroes later, plus a bit of puppy-kicking to get them moving and "overlooking" a technician under his complete mental control building an easy backdoor into his wormhole, he's "foiled", the universe that he lives in too is safe from the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OmnicidalManiac' title='/pmwiki/pmwiki.php/Main/OmnicidalManiac'>Omnicidal Maniac</a>, and Loki is safely ensconced in one of the few places his former boss can't get to him and back in Asgard, from which he'd previously been banished. Skip to <em>Dark World</em> and he is in a comfy cell with all the books he can read and regular communication with his beloved mother.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CheshireCatGrin' title='/pmwiki/pmwiki.php/Main/CheshireCatGrin'>Cheshire Cat Grin</a>: The Hulk, in one of the most awesome (and hilarious) moments of the whole film.<div class='indent'><strong>Steve:</strong> <em>[finishes giving everyone else orders]</em> And Hulk? <br /><strong>Hulk:</strong> <em>[looks at Steve]</em> <br /><strong>Steve:</strong> ... smash. <br /><strong>Hulk:</strong> <em>[grins widely before happily smashing lots and lots and <strong>lots</strong> of aliens]</em></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChestBlaster' title='/pmwiki/pmwiki.php/Main/ChestBlaster'>Chest Blaster</a>: After getting supercharged by a lightning bolt from Thor, Iron Man uses this in conjunction with a double repulsor attack to blast Thor in retaliation.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChewingTheScenery' title='/pmwiki/pmwiki.php/Main/ChewingTheScenery'>Chewing the Scenery</a>: Loki gets his moments in the cell tearing into Black Widow and trying to do the same to Hulk.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChildrenAsPawns' title='/pmwiki/pmwiki.php/Main/ChildrenAsPawns'>Children as Pawns</a>: Downplayed. Black Widow pays a little girl to lure Bruce Banner to a remote area so that she could recruit him to trace the Tesseract for S.H.I.E.L.D. without worrying about him <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>Hulking Out</a> in the middle of a populous area. She ends up referencing her own background as a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChildSoldier' title='/pmwiki/pmwiki.php/Main/ChildSoldier'>Child Soldier</a>, as part of the Black Widow program.<div class='indent'> <strong>Banner:</strong> And your actress buddy, is she a spy too? Do they start that young?</div><div class='indent'> <strong>Natasha:</strong> I did.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Cloudcuckoolander' title='/pmwiki/pmwiki.php/Main/Cloudcuckoolander'>Cloudcuckoolander</a>: As per usual, Tony Stark:<ul ><li> The very first scene of him includes him giving Pepper a random 12% credit for Stark Tower and calling Agent Coulson a "security breach" when Phil uses the elevator to enter the tower.</li><li> Exaggerated when Tony first boards the Helicarrier; he goes from discussing thermonuclear astrophysics to mocking Thor to ordering around staff to complaining about computer monitors to accusing someone of playing Galaga to discussing thermonuclear astrophysics <em>again</em> to fanboying over Bruce Banner all in the space of about a minute and a half. It understandably leaves everyone else in the room confused.</li></ul></li></ul><!-- <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColbertBump' title='/pmwiki/pmwiki.php/Main/ColbertBump'>Colbert Bump</a> is trivia.--><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColdSniper' title='/pmwiki/pmwiki.php/Main/ColdSniper'>Cold Sniper</a>: Hawkeye, with his bow. <span class="spoiler" title="you can set spoilers visible by default on your profile" >The trope is particularly in effect during the first half of the film while he's under Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControlDevice' title='/pmwiki/pmwiki.php/Main/MindControlDevice'>Mind-Control Device</a></span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColonyDrop' title='/pmwiki/pmwiki.php/Main/ColonyDrop'>Colony Drop</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Part of Loki's plan involves having the Hulk wreck up the S.H.I.E.L.D. Helicarrier, thus distracting everyone from the brainwashed Agents sabotaging the engines until it drops like a stone out of the sky.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColourCodedForYourConvenience' title='/pmwiki/pmwiki.php/Main/ColourCodedForYourConvenience'>Colour-Coded for Your Convenience</a>: Every single S.H.I.E.L.D. Quinjet we see throughout the film is painted grey on top, except for the one that delivers <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Barton</a></span> and his mercenaries to the helicarrier. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Barton</span>, or Loki, or somebody, took the time to have this particular Quinjet painted... <em>black</em>. That should have tipped off the Hovercarrier air traffic controller, even if the whole "unscheduled arms and munitions" business didn't. Then during the assault, the loudspeaker announces that the intruders are wearing S.H.I.E.L.D. gear, which inverts this trope and makes them harder to take out.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CombatPragmatist' title='/pmwiki/pmwiki.php/Main/CombatPragmatist'>Combat Pragmatist</a>:<ul ><li> The Hulk has a style that consists of bashing, smashing, and using whatever is nearby. It is most obvious in his fight with Thor, who is a seasoned warrior with a much more refined style.</li><li> Black Widow, a highly-trained martial artist, is not above resorting to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GroinAttack' title='/pmwiki/pmwiki.php/Main/GroinAttack'>groin kicks</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManBitesMan' title='/pmwiki/pmwiki.php/Main/ManBitesMan'>biting</a>, although usually <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DoubleSubversion' title='/pmwiki/pmwiki.php/Main/DoubleSubversion'>only when a fight turns in her opponent's favor</a>.</li><li> Hawkeye is a talented archer, but the first weapon he uses in the film is his handgun. In his second combat sequence, he also carries a handgun and a knife as backup for his bow. He also resorts to hair-pulling in his fight with <span class="spoiler" title="you can set spoilers visible by default on your profile" >Natasha</span>.</li><li> When Hawkeye and Black Widow fight <span class="spoiler" title="you can set spoilers visible by default on your profile" >each other</span>, there's a noticeable amount of biting, scratching, and hair-pulling among the fancy martial arts moves.</li><li> As in his own film, Cap relies on his shield because of its powerful symbolic value but he'll still use a gun or any other weapon that's handy if the need arises, cuz ya know, there's a war on out there.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CombinationAttack' title='/pmwiki/pmwiki.php/Main/CombinationAttack'>Combination Attack</a>: Iron Man shoots his laser at Cap's shield which he uses to reflect the laser into the Chitauri.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ComicBookMoviesDontUseCodenames' title='/pmwiki/pmwiki.php/Main/ComicBookMoviesDontUseCodenames'>Comic-Book Movies Don't Use Codenames</a>: Per the course of their previous appearances, their superhero names are only mentioned a few times:<ul ><li> Banner goes out of his way to avoid saying "Hulk", instead referring to his alter-ego as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheScottishTrope' title='/pmwiki/pmwiki.php/Main/TheScottishTrope'>"the other guy"</a> &#8212; justified in his case by his deep-seated shame and guilt about "the other guy's" very existence. Other characters use the name, however, and he slips at least once.</li><li> Natasha directly calls Clint "Hawkeye" when she's riding a Chitauri hovercraft on piggyback because it's his radio callsign. Dr. Selvig also refers to him as "the Hawk" in the first scene. Otherwise, people refer to him as Clint or Barton.</li><li> Whilst being interrogated, Natasha Romanoff is referred to as "the famous Black Widow", but this is the only time her codename is used. Nick Fury typically refers to her as "Agent Romanoff". Clint refers to her as Natasha or Nat.</li><li> Tony is once again never referred to as "Iron Man" during the film, with closest being Thor calling him "Metal Man" and a reporter making the clear distinction of "Tony Stark's Iron Man" during one of the reports on the battle in Manhattan.</li><li> A mention is made of Captain America trading cards and Banner mutters the name once. A civilian bystander also refers to him as Captain America in an interview on the news during the epilogue. He's usually called just "Steve" or "Rogers". He is also called "Cap" and "Captain" too, which may be an aversion, or may be in reference to his army rank. It's not clear.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ComicallySerious' title='/pmwiki/pmwiki.php/Main/ComicallySerious'>Comically Serious</a>: Captain America to an extent, the way his more serious and determined approach towards his work clashes with the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeadpanSnarker' title='/pmwiki/pmwiki.php/Main/DeadpanSnarker'>Deadpan Snarker</a> Tony Stark and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BoisterousBruiser' title='/pmwiki/pmwiki.php/Main/BoisterousBruiser'>Boisterous Bruiser</a> Thor.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CompositeCharacter' title='/pmwiki/pmwiki.php/Main/CompositeCharacter'>Composite Character</a>: Of the object variety. The Tesseract is a composite of the Cosmic Cube and the <span class="spoiler" title="you can set spoilers visible by default on your profile" >Space Gem of the Infinity Stones</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConcealmentEqualsCover' title='/pmwiki/pmwiki.php/Main/ConcealmentEqualsCover'>Concealment Equals Cover</a>:<ul ><li> Amusingly, aside from Captain America's shield, the material best-suited to harmlessly absorbing Chitauri energy blasts is an office desk. Maybe they don't have wood on Chitaur.</li><li> Also as they destroy the Leviathan. When it explodes, Captain America's shield protects him and Natasha, but Hawkeye is left to scurry and duck behind a car.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConceptsAreCheap' title='/pmwiki/pmwiki.php/Main/ConceptsAreCheap'>Concepts Are Cheap</a>: Loki's words about <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill' title='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill'>The Evils of Free Will</a> hardly come up except a few times in the beginning, and hardly matter (except to briefly <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GodwinsLaw' title='/pmwiki/pmwiki.php/Main/GodwinsLaw'>compare him to Hitler</a>).</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConflictBall' title='/pmwiki/pmwiki.php/Main/ConflictBall'>Conflict Ball</a>: Loki gleefully gets captured just so he can toss one into the S.H.I.E.L.D. Helicarrier amongst the would-be Avengers. <span class="spoiler" title="you can set spoilers visible by default on your profile" >The crux of this is to draw out the Hulk from Banner.</span> The ball also seems to be a literal object, as Loki's staff is implied to be either causing the dissonance between the members, or at least amplifying what's already there.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConsequenceCombo' title='/pmwiki/pmwiki.php/Main/ConsequenceCombo'>Consequence Combo</a>: Loki is playing for <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeOverTheWorld' title='/pmwiki/pmwiki.php/Main/TakeOverTheWorld'>rulership of Earth</a>... but it's made very clear by the Chitauri that failure is not an option, and things will go very, very badly for him if they don't get what they want. When Thor tries to talk him into abandoning his scheme, he takes one look at the portal, looks genuinely terrified, and claims that it's too late to back out now even if he wanted to.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConsummateLiar' title='/pmwiki/pmwiki.php/Main/ConsummateLiar'>Consummate Liar</a>:<ul ><li> Black Widow is a spy. It's her job.</li><li> Nick Fury. Talked about later in the movie concerning <span class="spoiler" title="you can set spoilers visible by default on your profile" >where he found Coulson's Captain America trading cards</span>.<div class='indent'><strong>Tony Stark:</strong> He's a spy. He's <em>the</em> spy. His secrets have secrets.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConsummateProfessional' title='/pmwiki/pmwiki.php/Main/ConsummateProfessional'>Consummate Professional</a>: "Put on the suit." Cap can be in the middle of a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TestosteronePoisoning' title='/pmwiki/pmwiki.php/Main/TestosteronePoisoning'>Testosterone Poisoning</a> fueled argument with a rival hero that's quickly escalating its way towards an all-out super-brawl, but put the people around him in danger and he instantly switches to being all business and treating Tony as a teammate.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ContinuityNod' title='/pmwiki/pmwiki.php/Main/ContinuityNod'>Continuity Nod</a>: Has <a class='twikilink' href='/pmwiki/pmwiki.php/ContinuityNod/TheAvengers2012' title='/pmwiki/pmwiki.php/ContinuityNod/TheAvengers2012'>its own page</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConvenientlyEmptyBuilding' title='/pmwiki/pmwiki.php/Main/ConvenientlyEmptyBuilding'>Conveniently-Empty Building</a>: The climactic Battle of New York takes place in Midtown, one of the busiest parts of the city. On a few occasions we see Hulk rampage through occupied buildings, but the flying Leviathan creatures seem to crash through empty buildings, one brought down personally by Hulk and Thor.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CoolOldGuy' title='/pmwiki/pmwiki.php/Main/CoolOldGuy'>Cool Old Guy</a>: When Loki intimidates a crowd of people and forces them to kneel, an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBystander' title='/pmwiki/pmwiki.php/Main/BadassBystander'>elderly man</a> defies him.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CoolPlane' title='/pmwiki/pmwiki.php/Main/CoolPlane'>Cool Plane</a>: The Avengers' Quinjet is almost as fast as Iron Man and has a machine gun.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CoolShades' title='/pmwiki/pmwiki.php/Main/CoolShades'>Cool Shades</a>:<ul ><li> Phil Coulson sports a pair when greeting Fury at the start of the movie.</li><li> Hawkeye has these in the promo material but only wears them at the very end of the film itself.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CoolShip' title='/pmwiki/pmwiki.php/Main/CoolShip'>Cool Ship</a>:<ul ><li> The <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier' title='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier'>Helicarrier</a> for S.H.I.E.L.D.</li><li> The Leviathans are biological troop-transports for the Chitauri.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CoolVersusAwesome' title='/pmwiki/pmwiki.php/Main/CoolVersusAwesome'>Cool Versus Awesome</a>: Just about any of the fights in this movie.<ul ><li> The world's first superhero (a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSoldier' title='/pmwiki/pmwiki.php/Main/SuperSoldier'>Super Soldier</a>) vs. the Norse God of Mischief (who's also a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien' title='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien'>Sufficiently Advanced Alien</a> and an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilSorcerer' title='/pmwiki/pmwiki.php/Main/EvilSorcerer'>Evil Sorcerer</a>).</li><li> Genius in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoweredArmor' title='/pmwiki/pmwiki.php/Main/PoweredArmor'>Powered Armor</a> vs. the Norse god of thunder, with the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSoldier' title='/pmwiki/pmwiki.php/Main/SuperSoldier'>Super Soldier</a> trying to break it up. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnstoppableForceMeetsImmovableObject' title='/pmwiki/pmwiki.php/Main/UnstoppableForceMeetsImmovableObject'>Features Mj&ouml;lnir vs. Captain America's Shield</a>.</li><li> <a class='urllink' href='https://www.youtube.com/watch?v=3FrzYzJUmVg'>Norse God of Thunder<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> vs. an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BuffySpeak' title='/pmwiki/pmwiki.php/Main/BuffySpeak'>Enormous Green Rage Monster</a>.</li><li> World-class assassin vs. <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheAce' title='/pmwiki/pmwiki.php/Main/TheAce'>master</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArcherArchetype' title='/pmwiki/pmwiki.php/Main/ArcherArchetype'>archer</a>.</span></li><li> All of the above fighting the Norse god of mischief and his army of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NinjaPirateZombieRobot' title='/pmwiki/pmwiki.php/Main/NinjaPirateZombieRobot'>cybernetic alien monsters</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CosmopolitanCouncil' title='/pmwiki/pmwiki.php/Main/CosmopolitanCouncil'>Cosmopolitan Council</a>: The World Security Council consists of American, British, Chinese and Russian members.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CountryMatters' title='/pmwiki/pmwiki.php/Main/CountryMatters'>Country Matters</a>: Loki calls The Black Widow a "mewling quim" (which in modern English would be "whining cunt").</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CoversAlwaysLie' title='/pmwiki/pmwiki.php/Main/CoversAlwaysLie'>Covers Always Lie</a>: The poster shows Nick Fury in the ground battle in New York. Fury was on the Helicarrier during this time.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CrazyPrepared' title='/pmwiki/pmwiki.php/Main/CrazyPrepared'>Crazy-Prepared</a>:<ul ><li> Tony out-Batman's <em><a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/Batman' title='/pmwiki/pmwiki.php/Franchise/Batman'>Batman</a></em> for designing a suit that can <span class="spoiler" title="you can set spoilers visible by default on your profile" >deploy and attach itself to him <em>while he's falling out a building.</em></span> Justified, as Tony is a tinkerer, and figuring out a faster, more convenient way of suiting up is one of the first things he'd do while upgrading his suit(s).</li><li> Hawkeye has exploding arrowheads, hacking arrowheads, super-heating arrowheads, shrapnel arrowheads, grappling hook arrowheads, <span class="spoiler" title="you can set spoilers visible by default on your profile" >exploding arrowheads disguising to look like normal arrowheads so on the off chance the target has the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperReflexes' title='/pmwiki/pmwiki.php/Main/SuperReflexes'>Super Reflexes</a> to catch the arrow they won't recognize it as an exploding arrowhead...</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CreativeClosingCredits' title='/pmwiki/pmwiki.php/Main/CreativeClosingCredits'>Creative Closing Credits</a>: The credits show up next to the Avengers' costumes and weapons. Once the actors come, the heroes get <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VideoCredits' title='/pmwiki/pmwiki.php/Main/VideoCredits'>Video Credits</a> of sorts. (Robert Downey Jr.: Iron Man helmet; Chris Evans: Captain America's suit; Mark Ruffalo: Bruce Banner's glasses and shirt; Chris Hemsworth: Mjolnir; Scarlett Johansson: Black Widow's gauntlet; Jeremy Renner: Hawkeye's quiver; Samuel L. Jackson: a handgun)</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CreatorsCultureCarryover' title='/pmwiki/pmwiki.php/Main/CreatorsCultureCarryover'>Creator's Culture Carryover</a>: The German company being guarded by security officers complete with SMGs may be somewhat believable in an American setting, but in Germany, most private security firms would get into trouble issuing as much as <em>tasers</em> to their personnel.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CreepyShadowedUndereyes' title='/pmwiki/pmwiki.php/Main/CreepyShadowedUndereyes'>Creepy Shadowed Undereyes</a>: Loki has these, especially notable in his first scene, to empathise his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBadSlippage' title='/pmwiki/pmwiki.php/Main/BigBadSlippage'>Big Bad Slippage</a> between <em>Thor</em> and <em>The Avengers</em>. Completed with a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KubrickStare' title='/pmwiki/pmwiki.php/Main/KubrickStare'>Kubrick Stare</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CrucifiedHeroShot' title='/pmwiki/pmwiki.php/Main/CrucifiedHeroShot'>Crucified Hero Shot</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony gets one at the climax. After sacrificing himself to fly the nuke into space, he loses consciousness in the vacuum and slowly falls backwards, arms outstretched and head hanging limp.</span> And for a double-whammy of symbolism, <span class="spoiler" title="you can set spoilers visible by default on your profile" >he hauls the nuke up through the portal while <em>carrying it on his back</em>. He also sacrifices himself not while defeating the enemy, but while saving the WSC (who qualifies as a council of state officials) from the sin of murdering millions of civilians, skims over water to catch the nuke, carries it on his back and over one shoulder through the city while watched by thousands of bystanders and news-viewers, ascends into the heavens, <em>suffocates</em> and dies (temporarily) high above the city and all alone, and then returns to earth, where his limp body is caught and lowered to the ground and surrounded by his teammates before he then comes back to life and greets them. <em>And</em> the way the repulsor ports in his palms look while he's falling is pretty noticeable as well</span>. The only thing missing from the allegory was a bit of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PietaPlagiarism' title='/pmwiki/pmwiki.php/Main/PietaPlagiarism'>Pietà Plagiarism</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CulturalTranslation' title='/pmwiki/pmwiki.php/Main/CulturalTranslation'>Cultural Translation</a>:<ul ><li> The Castillian Spanish dub pulls a few with Tony's pop culture references. Instead of "<a class='twikilink' href='/pmwiki/pmwiki.php/Film/ReindeerGames' title='/pmwiki/pmwiki.php/Film/ReindeerGames'>Reindeer Games</a>", he calls Loki "<a class='twikilink' href='/pmwiki/pmwiki.php/WesternAnimation/Bambi' title='/pmwiki/pmwiki.php/WesternAnimation/Bambi'>Bambi</a>'s dad", and simply "rock star" instead of "<a class='twikilink' href='/pmwiki/pmwiki.php/Theatre/RockOfAges' title='/pmwiki/pmwiki.php/Theatre/RockOfAges'>Rock of Ages</a>". His reference to Bodhi when talking with Thor is also omitted.</li><li> Tony Stark at one point refers to the fact that Steve Rogers alias Captain America has been frozen for 70 years by calling him a "Capcicle", a pun on the superhero's name and either icicle or Popsicle (an American brand of ice pop that has become a generalized trademark). It seems that the creators of the German dub have chosen the latter interpretation, even though this brand is unknown in Germany. So, Tony calls Steve "Captain/K&auml;pt’n Iglo" in the dub instead, after the mascot of a brand of frozen food. This even serves as yet another one of those <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PopculturalOsmosisFailure' title='/pmwiki/pmwiki.php/Main/PopculturalOsmosisFailure'>pop-culture references which are going straight over Steve's head</a>, due to to K&auml;pt'n Iglo having been introduced as late as 1985, as opposed to Popsicles, which have been existing by that name since <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheRoaringTwenties' title='/pmwiki/pmwiki.php/Main/TheRoaringTwenties'>The Roaring '20s</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbStompBattle' title='/pmwiki/pmwiki.php/Main/CurbStompBattle'>Curb-Stomp Battle</a>:<ul ><li> You know the gigantic biomechanical Leviathan the trailer builds up as a grave threat? After roughly five minutes of being unstoppable, <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Hulk stops the first one with a single punch to the face, setting it up to be blasted by Iron Man.</span></li><li> At the climax, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki loses his cool and yells at the Hulk. This is exactly as bad of an idea as it sounds.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CursedWithAwesome' title='/pmwiki/pmwiki.php/Main/CursedWithAwesome'>Cursed with Awesome</a>: This is how Tony Stark has come to view the electromagnet and the miniature arc reactor plugged into his chest 24/7 and are the only things keeping him alive. He spends a good deal of the film trying to convince Bruce Banner that the Hulk is a similarly awesome curse. For Tony, the "awesome" part kicks in when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki tries to brainwash him, but he can't, because his heart is protected by the arc reactor.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurseOfTheAncients' title='/pmwiki/pmwiki.php/Main/CurseOfTheAncients'>Curse of The Ancients</a>: Loki's notorious "mewling quim" insult to Black Widow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CuttingTheKnot' title='/pmwiki/pmwiki.php/Main/CuttingTheKnot'>Cutting the Knot</a>:<ul ><li> While Tony is trying to hack into S.H.I.E.L.D.'s secret computer files, Steve decides it's taking too long and simply breaks into a locked room and physically finds what they're hiding.</li><li> During their argument, Steve accuses Tony of not being the sort of man to lie on a wire to let a comrade crawl over him. Tony remarks that he'd rather just cut the wire.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheCynic' title='/pmwiki/pmwiki.php/Main/TheCynic'>The Cynic</a>:<ul ><li> Tony Stark is still more than a little self-absorbed and doubtful of the competence and intelligence of anyone but himself, though throughout the film we see this change.</li><li> Bruce is hugely cynical throughout most of the movie, with notable lines like: "Well, this is all horrible," and "Oh no, this is much worse." In fact, you'd be hard pressed to find a positive word leaving that guy's mouth. <span class="spoiler" title="you can set spoilers visible by default on your profile" >He is, after all, always angry.</span></li></ul></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder4');">&nbsp;&nbsp;&nbsp;&nbsp;D&nbsp;</div><div id="folder4" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DamageControl' title='/pmwiki/pmwiki.php/Main/DamageControl'>Damage Control</a>: Iron Man and Captain America have to do repairs on the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier' title='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier'>Airborne Aircraft Carrier</a> at 30,000 feet after <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye attacks and blows up one of its engines</span>. Meanwhile Nick Fury and the bridge crew are trying to maneuver the ship to a safe place to put her down in case the repairs are unsuccessful.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DamnYouMuscleMemory' title='/pmwiki/pmwiki.php/Main/DamnYouMuscleMemory'>Damn You, Muscle Memory!</a>: Right after Nick Fury uses an RPG to take out the Quinjet carrying the nuke that the WSC ordered against New York, a second jet takes off from a different catapult. Without thinking about it, he whips out his sidearm before realizing the bullets would do as much damage as a spitball from that distance.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DarkestHour' title='/pmwiki/pmwiki.php/Main/DarkestHour'>Darkest Hour</a>:<ul ><li> Loki calls Fury on it.<div class='indent'><strong>Loki:</strong> How desperate are you, that you call upon such lost creatures to defend you?</div></li><li> Invoked for the team at large following the Helicarrier siege. Loki breaks it down again:<div class='indent'><strong>Loki:</strong> Your heroes are scattered, your floating fortress falls from the sky. Where is my disadvantage?</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DarkMessiah' title='/pmwiki/pmwiki.php/Main/DarkMessiah'>Dark Messiah</a>: Loki presents himself to the people of Earth as one but they'll stand for none of that crap.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ADayInTheLimelight' title='/pmwiki/pmwiki.php/Main/ADayInTheLimelight'>A Day in the Limelight</a>: For <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigGood' title='/pmwiki/pmwiki.php/Main/BigGood'>Nick Fury</a>, who rallies the Avengers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DaylightHorror' title='/pmwiki/pmwiki.php/Main/DaylightHorror'>Daylight Horror</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >The Chitauri invade New York in the middle of a bright and sunny afternoon, giving the audience a clear picture of their hideousness.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheDeadHaveNames' title='/pmwiki/pmwiki.php/Main/TheDeadHaveNames'>The Dead Have Names</a>: "<span class="spoiler" title="you can set spoilers visible by default on your profile" >His name was Phil</span>."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeadpanSnarker' title='/pmwiki/pmwiki.php/Main/DeadpanSnarker'>Deadpan Snarker</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorldOfSnark' title='/pmwiki/pmwiki.php/Main/WorldOfSnark'>All of the Avengers</a> (sans Thor and for the most part, Cap) as well as Loki and Fury have their moments:<ul ><li> When Fury comes to recruit Steve:<div class='indent'><strong>Nick Fury:</strong> Is there anything you can tell us about the Tesseract that we ought to know now? <br /><strong>Steve:</strong> You should have left it in the ocean.</div></li><li> The entire scene between Phil, Tony, and Pepper:<div class='indent'><strong>Phil:</strong> <em>[over the phone]</em> Mr. Stark, we need to talk. <br /><strong>Tony:</strong> <em>[picks up the phone]</em> Hello. You have reached the life model decoy of Tony Stark. Please leave a message. <br /><strong>Phil:</strong> <em>[exasperated]</em> This is urgent. <br /><strong>Tony:</strong> <em>[deadpan]</em> Then leave it urgently. <br /><em>[he closes the phone, just as the elevator opens to reveal Phil. Tony and Pepper turn to face him.]</em> <br /><strong>Tony:</strong> <em>[theatrically]</em> Security breach! <br /><strong>Phil:</strong> Mr. Stark &#8212; <br /><strong>Tony:</strong> <em>[to Pepper]</em> <em>[accusingly]</em> That's on you. <br /><em>[Pepper ignores him and goes to greet Phil]</em> <br /><strong>Pepper:</strong> <em>[warmly]</em> Phil! Come in! <br /><strong>Phil:</strong> I can't stay &#8212; <br /><strong>Tony:</strong> <em>[confused]</em> 'Phil'? His first name is Agent. <br /><em>[Pepper ignores him]</em> <br /><strong>Pepper:</strong> <em>[to Phil]</em> We're celebrating. <br /><strong>Tony:</strong> Which is why he can't stay. <br /><em>[Etc.]</em></div></li><li> After Thor snatches Loki from the quinjet and attempts to talk him into abandoning his plan:<div class='indent'><strong>Thor:</strong> You listen well, brother. I &#8212; <em>[gets bowled over by Iron Man, completely removing him from the picture]</em> <br /><strong>Loki:</strong> <em>[amused and unmoving, standing there as if Thor is still present]</em> I'm listening.</div></li><li> Tony's first encounter with Thor:<div class='indent'><strong>Thor:</strong> You have no idea what you are dealing with! <br /><strong>Tony:</strong> <em>[looks around]</em> Uh, Shakespeare in the park? <em>[he strikes a Shakespearean pose, adopts an Old English accent]</em> Doth mother know you weareth her drapes?</div><ul ><li> Also:<div class='indent'><strong>Thor:</strong> Do not touch me again! <br /><strong>Tony:</strong> Then don't take my stuff.</div></li></ul></li><li> The beginning of the Avengers' first major argument has a few good ones.<div class='indent'><strong>Tony:</strong> Wait, how is this now about me? <br /><strong>Steve:</strong> I'm sorry, isn't everything?</div><ul ><li> Then Tony gets him back:<div class='indent'><strong>Bruce:</strong> Wait, Captain America is on the threat list? <br /><strong>Tony:</strong> <em>[to Cap]</em> Wait, <em>you're</em> on that list? Are you above or below angry bees? <br /><strong>Steve:</strong> Stark, I swear, you make one more wisecrack...</div></li></ul></li><li> Loki tries to brainwash Stark with the scepter, only to be blocked by the arc reactor:<div class='indent'><strong>Loki:</strong> <em>[confused]</em> ...This usually works. <br /><strong>Tony:</strong> <em>[in an understanding tone]</em> Well, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight' title='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight'>performance issues.</a> It's not uncommon. One out of five &#8212; <br /><em>[Loki grabs him by the throat and throws him out the window]</em></div></li><li> After he learns that S.H.I.E.L.D. plans to invoke the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GodzillaThreshold' title='/pmwiki/pmwiki.php/Main/GodzillaThreshold'>Godzilla Threshold</a> trope on New York City:<div class='indent'><strong>Fury:</strong> <em>[through gritted teeth]</em> I recognize the Council has made a decision, but given that it's a stupid-ass decision, I've elected to ignore it.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeathGlare' title='/pmwiki/pmwiki.php/Main/DeathGlare'>Death Glare</a>: Thor gives one to Loki after the latter <span class="spoiler" title="you can set spoilers visible by default on your profile" >kills Coulson.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ADeathInTheLimelight' title='/pmwiki/pmwiki.php/Main/ADeathInTheLimelight'>A Death in the Limelight</a>: In as much as it's possible in an ensemble cast. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson gets a lot more character development here and in the tie-in comics, including that he has/had a romantic relationship with someone who may have been a cellist, and that he's a giant Captain America fanboy.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeathIsDramatic' title='/pmwiki/pmwiki.php/Main/DeathIsDramatic'>Death Is Dramatic</a>: Despite numerous casualties suffered by both attackers and S.H.I.E.L.D. agents on the Helicarrier the only one that any time is spent dwelling on is <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span>. Barton does ask how many died <span class="spoiler" title="you can set spoilers visible by default on your profile" >because of him</span> but he seems more angry that <span class="spoiler" title="you can set spoilers visible by default on your profile" >he was responsible rather than mourning their deaths.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DecoyDamsel' title='/pmwiki/pmwiki.php/Main/DecoyDamsel'>Decoy Damsel</a>: Black Widow's introduction scene. As <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> commented, "This is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SignatureStyle' title='/pmwiki/pmwiki.php/Main/SignatureStyle'>my entire career</a> in one scene: <em>Look, she's helpless! No, she's kicking their asses!</em>"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DefeatMeansFriendship' title='/pmwiki/pmwiki.php/Main/DefeatMeansFriendship'>Defeat Means Friendship</a>: After Thor spends a couple minutes beating the crap out of him before the two of them figure out they're on the same side, Tony brushes it off with a merry "No hard feelings, <a class='twikilink' href='/pmwiki/pmwiki.php/Film/PointBreak1991' title='/pmwiki/pmwiki.php/Film/PointBreak1991'>Point Break</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorthyOpponent' title='/pmwiki/pmwiki.php/Main/WorthyOpponent'>you've got a mean swing</a>" and cheerfully claps him on the arm.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DefenceMechanismSuperpower' title='/pmwiki/pmwiki.php/Main/DefenceMechanismSuperpower'>Defence Mechanism Superpower</a>: The Hulk takes this a step further, emerging not only when Banner is angry enough, but whenever his life is significantly threatened. As Banner learned the hard way, this includes <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DrivenToSuicide' title='/pmwiki/pmwiki.php/Main/DrivenToSuicide'>self-inflicted injury</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DefiantStoneThrow' title='/pmwiki/pmwiki.php/Main/DefiantStoneThrow'>Defiant Stone Throw</a>: The old German man, with <em>words</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DefiantToTheEnd' title='/pmwiki/pmwiki.php/Main/DefiantToTheEnd'>Defiant to the End</a>:<ul ><li> The old German man who refuses to kneel before Loki.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson</span>, who shows no fear when confronting Loki.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DelayedOhCrap' title='/pmwiki/pmwiki.php/Main/DelayedOhCrap'>Delayed "Oh, Crap!"</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForLaughs' title='/pmwiki/pmwiki.php/Main/PlayedForLaughs'>Played for Laughs</a> during an exchange between Steve and Tony after Coulson is killed, when they are discussing how Loki was planning to finish off the Avengers. Tony theorizes that Loki not only wanted to defeat them, he wanted to defeat them with the entire world watching....and immediately realizes that Loki was going to enact his plan at Stark Tower.<div class='indent'><strong>Tony:</strong> He made it personal. <br /><strong>Steve:</strong> That's not the point. <br /><strong>Tony:</strong> That <em>is</em> the point. That's Loki's point. He hit us all right where we live. Why? <br /><strong>Steve:</strong> To tear us apart. <br /><strong>Tony:</strong> Yeah, divide and conquer is great, but he knows he has to take us out to win, right? <em>That's</em> what he wants. He wants to beat us, he wants to be seen doing it – he wants an audience. <br /><strong>Steve:</strong> Right. I caught his act in Stuttgart. <br /><strong>Tony:</strong> Yeah, but that's just previews. This is opening night. And Loki, he's a full-tilt diva. He wants flowers, he wants parades, he wants a monument built to the sky with his name on....SONOFABITCH!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DemotedToExtra' title='/pmwiki/pmwiki.php/Main/DemotedToExtra'>Demoted to Extra</a>: A number of important supporting characters from the previous films receive much less screentime in this film:<ul ><li> Gwyneth Paltrow reprises her role from <em>Iron Man</em>, but in a minor capacity. Robert Downey Jr. asked for her to be included as a way of exploring the Potts/Stark relationship that was established at the end of <em>Iron Man 2</em>. Whedon agreed, because "you should always, given the opportunity, put a Gwyneth on-screen."</li><li> Dr. Selvig also returns from <em>Thor</em>, in a role that's more plot-important but doesn't necessarily get any more screentime.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Deprogram' title='/pmwiki/pmwiki.php/Main/Deprogram'>Deprogram</a>: Black Widow mentions that Hawkeye was in charge of deprogramming her. She later returns the favor by <span class="spoiler" title="you can set spoilers visible by default on your profile" >helping him break free of Loki's brainwashing.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DestinationDefenestration' title='/pmwiki/pmwiki.php/Main/DestinationDefenestration'>Destination Defenestration</a>:<ul ><li> Tony Stark gets tossed out of a window. Sans armor.</li><li> Cap later gets blasted out of a window at Grand Central Terminal. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LuckilyMyShieldWillProtectMe' title='/pmwiki/pmwiki.php/Main/LuckilyMyShieldWillProtectMe'>Luckily, his shield protects him</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DestroyingAPunchingBag' title='/pmwiki/pmwiki.php/Main/DestroyingAPunchingBag'>Destroying a Punching Bag</a>: One scene has Captain America practicing on a punching bag, all the while thinking about the life he had to leave behind because of his decades-long ice nap. At one point, he punches it across the room with a hole in it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Determinator' title='/pmwiki/pmwiki.php/Main/Determinator'>Determinator</a>: Much of the cast.<ul ><li> Cap especially seems this way, especially after the point where he gets flung out of a building by a bomb, is clearly worn down, and yet he gets up and keeps fighting.</li><li> Black Widow, especially where Hawkeye is concerned. On the Helicarrier, she takes a full-on hit from the Hulk and is obviously rattled and injured, to the point of a mini-BSOD. <span class="spoiler" title="you can set spoilers visible by default on your profile" >When she hears Hawkeye is in the complex? She gets right up and takes the fight to him.</span></li><li> Hulk, naturally. It's in his character, after all: he'll just keep fighting. Nothing you throw at him will stop him.</li><li> Thor when it comes to Loki and Earth. It's implied that he had his father <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedTechnology' title='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedTechnology'>use a lot of dark energy</a> to send him back to Earth, and when he gets there he seeks out Loki with almost single-minded drive.</li><li> Coulson <span class="spoiler" title="you can set spoilers visible by default on your profile" >takes a spear through the back</span> and <em>still</em> manages to give Loki a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a> and blast him through a wall <span class="spoiler" title="you can set spoilers visible by default on your profile" >as he's bleeding out.</span></li><li> Tony probably takes more punishment and damage than everyone else combined (the Mark VI armor is one good tap away from falling to pieces by the end of the second act) and still keeps going, making hasty repairs on the fly and pushing his servos to the limit when trying to restart the Helicarrier's engines.</li><li> Maria Hill in the pre-credits sequence, when she furiously chases down Loki, Clint, and Selvig in a Jeep through the rapidly-collapsing base, shaking off multiple crashes, gunfire, and falling debris. It takes an <em>entire tunnel</em> caving in on top of her and crushing her engine flat to finally stymie her.</li><li> The NYPD officers in the final battle. There's a wormhole to the other side of the galaxy gaping open above Manhattan, aliens with futuristic weapons and giant mechanical whales are pouring in and swarming the city, and yet New York's Finest are still out in the streets, keeping order, directing the evacuation, and trying to form a defense.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeusExMachina' title='/pmwiki/pmwiki.php/Main/DeusExMachina'>Deus ex Machina</a>: On the <img src="/images/article-hreficon-trivia.png" class="trivia1 rounded" title="This example contains a TRIVIA entry. It should be moved to the TRIVIA tab."><a class='twikilink' href='/pmwiki/pmwiki.php/Main/DVDCommentary' title='/pmwiki/pmwiki.php/Main/DVDCommentary'>DVD Commentary</a>, Joss Whedon calls <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk' title='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk'>The Incredible Hulk</a> a "Deus Ex Hulkina", showing up out of nowhere to help out the others at least twice in the movie. He justifies it by pointing out that if they showed every second of what the Hulk was doing, the movie would have gone far over budget.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeusExNukina' title='/pmwiki/pmwiki.php/Main/DeusExNukina'>Deus ex Nukina</a>: As the Avengers were not defeating the invasion, <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Council decided to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NukeEm' title='/pmwiki/pmwiki.php/Main/NukeEm'>Nuke 'em</a>. Then, once the nuclear missile was in the air, the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeusExNukina' title='/pmwiki/pmwiki.php/Main/DeusExNukina'>Deus ex Nukina</a> comes into play: Iron Man manages to grab it in flight, change its path, take it through the portal, and let fly straight to the alien mothership. When it was destroyed, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KeystoneArmy' title='/pmwiki/pmwiki.php/Main/KeystoneArmy'>all the invading army died immediately</a>. Happy ending, time for some Shawarma!</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DidYouJustPunchOutCthulhu' title='/pmwiki/pmwiki.php/Main/DidYouJustPunchOutCthulhu'>Did You Just Punch Out Cthulhu?</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hulk putting a smackdown on Loki</span>.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> gives a demonstration of why not to talk smack to a downed opponent.</li><li> Hulk <span class="spoiler" title="you can set spoilers visible by default on your profile" >rolling through an office to jump out the window and literally punch out a Leviathan</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DidYouJustScamCthulhu' title='/pmwiki/pmwiki.php/Main/DidYouJustScamCthulhu'>Did You Just Scam Cthulhu?</a>: The Black Widow, talking with Loki. A <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PunyEarthlings' title='/pmwiki/pmwiki.php/Main/PunyEarthlings'>mere mortal</a> that tricked the trickster.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DiesWideOpen' title='/pmwiki/pmwiki.php/Main/DiesWideOpen'>Dies Wide Open</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> keeps his eyes on <span class="spoiler" title="you can set spoilers visible by default on your profile" >Fury, as ordered,</span> even when the light goes out of them.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DisabilityImmunity' title='/pmwiki/pmwiki.php/Main/DisabilityImmunity'>Disability Immunity</a>: The arc reactor in Tony's chest that keeps his heart beating also <span class="spoiler" title="you can set spoilers visible by default on your profile" >makes Tony <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoSell' title='/pmwiki/pmwiki.php/Main/NoSell'>immune to Loki's brainwashing technique</a>.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DisneyDeath' title='/pmwiki/pmwiki.php/Main/DisneyDeath'>Disney Death</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man is apparently dead after coming out of the worm hole but turns out he was only unconscious</span>. Quite appropriate, since this was <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/Disney' title='/pmwiki/pmwiki.php/Creator/Disney'>Disney</a>'s first Marvel movie.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DisproportionateRetribution' title='/pmwiki/pmwiki.php/Main/DisproportionateRetribution'>Disproportionate Retribution</a>:<ul ><li> Loki's plot to take control of Earth is largely driven by <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheUnfavourite' title='/pmwiki/pmwiki.php/Main/TheUnfavourite'>jealousy</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheResenter' title='/pmwiki/pmwiki.php/Main/TheResenter'>resentment</a> towards his adoptive <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DysfunctionalFamily' title='/pmwiki/pmwiki.php/Main/DysfunctionalFamily'>brother Thor</a>, as well as rage at being deceived about <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilOrphan' title='/pmwiki/pmwiki.php/Main/EvilOrphan'>his true ancestry</a>. He wants to subjugate the entire population of Earth &#8212; a planet which Thor treasures and protects &#8212; thereby wiping out many of the people that Thor cares about. In addition, Loki feels that he was cheated out of his rightful place as the ruler of Asgard.<div class='indent'><strong>Thor:</strong> So you take the world I love as recompense for your imagined slights?</div></li><li> A somewhat smaller-scale example, but no less disproportionate, is when Thor first meets Cap. Cap tries to defuse the situation between him and Stark, and tells Thor to put down the hammer. Thor responds with utter rage and lethal force to this simple request &#8212; if not for the shield (which Thor knew nothing about), he would have turned perhaps the most heroic and incorruptible character in the MCU into paste.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DissonantSerenity' title='/pmwiki/pmwiki.php/Main/DissonantSerenity'>Dissonant Serenity</a>: Bruce Banner is pretty unshakable, facing down terrifying monsters with the full assurance that he's capable of getting way scarier than they are. And note the Hulk's expression during <span class="spoiler" title="you can set spoilers visible by default on your profile" >his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbStompBattle' title='/pmwiki/pmwiki.php/Main/CurbStompBattle'>Curb-Stomp Battle</a> against Loki. Whedon wanted his relatively calm face to communicate the idea that this wasn't a big deal for him.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DistinctionWithoutADifference' title='/pmwiki/pmwiki.php/Main/DistinctionWithoutADifference'>Distinction Without a Difference</a>:<ul ><li> Meta-example: Before the movie was released, Whedon and co. repeatedly denied that the Skrulls would be in the movie. The Chitauri are actually <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UltimateUniverse' title='/pmwiki/pmwiki.php/Main/UltimateUniverse'>Ultimate Universe</a> versions of the Skrulls (this distinction would become far more legitimate when <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Skrulls show up in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainMarvel2019' title='/pmwiki/pmwiki.php/Film/CaptainMarvel2019'>Captain Marvel (2019)</a></em>, establishing that in the MCU, the Skrulls and Chitauri are separate species</span>).</li><li> Tony certainly isn't stalling for time while talking to Loki (and waiting for the Mark Seven to be deployed). He's threatening him.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DivideAndConquer' title='/pmwiki/pmwiki.php/Main/DivideAndConquer'>Divide and Conquer</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >This is Loki's plan for dealing with the Avengers; he targets Bruce in particular. He succeeds for a while even after they realize what he's up to.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DividedWeFall' title='/pmwiki/pmwiki.php/Main/DividedWeFall'>Divided We Fall</a>: Happens quite brutally, with tragic consequences, during Act II. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Because the Avengers are fighting each other while arguing with Fury, Brainwashed!Hawkeye sneaks in and kills a bunch of people, like Coulson.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DoesThisRemindYouOfAnything' title='/pmwiki/pmwiki.php/Main/DoesThisRemindYouOfAnything'>Does This Remind You of Anything?</a>:<ul ><li> A more comedic moment: when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki fails to brainwash Tony with his staff, he looks taken aback and says this has never happened to him before. Tony makes an idle comment about <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight' title='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight'>performance issues</a>.</span></li><li> Massive damage to New York ensues after a surprise attack. The ending with post-strike reports just screams 9/11. Also, you will find few Americans who remember that day vividly and who empathized with the office workers who <em>weren't</em> reminded of it in the scene when the office workers look out the window to see, not a plane, but an equally impossible to imagine giant bug creature. (None who didn't feel a slight sense of satisfaction in seeing the <em>Hulk</em> racing through the cubicles to the rescue.)</li><li> At one point, a Leviathan exits from a building and you can see the building begin to fall behind it in a fashion similar to the World Trade Center towers.</li><li> When Iron Man lets go of <span class="spoiler" title="you can set spoilers visible by default on your profile" >the nuke</span>, it does a fair job of being the Space Shuttle separating from its external fuel tank. Though it's the shoulder jets from the Iron Man armor falling off, the imagery is there.</li><li> Loki's surprise entrance at the Joint Dark Energy Mission Facility via the Tesseract looks very similar to travel via <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/StargateVerse' title='/pmwiki/pmwiki.php/Franchise/StargateVerse'>Stargate</a>. Hawkeye even says that the prevailing theory is that the Tesseract is a doorway to the other end of space, and points out that doors can be opened from both sides.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheDogBitesBack' title='/pmwiki/pmwiki.php/Main/TheDogBitesBack'>The Dog Bites Back</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Even as Coulson is wounded by Loki, he still gets the chance to blast Loki with the weapon he was going to use against him.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DoNotTauntCthulhu' title='/pmwiki/pmwiki.php/Main/DoNotTauntCthulhu'>Do Not Taunt Cthulhu</a>: Loki's attempt to <span class="spoiler" title="you can set spoilers visible by default on your profile" ><em>intimidate</em> the Hulk ends <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbStompBattle' title='/pmwiki/pmwiki.php/Main/CurbStompBattle'>just as well as you can imagine</a>.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DoppelgangerSpin' title='/pmwiki/pmwiki.php/Main/DoppelgangerSpin'>Doppelgänger Spin</a>: Loki creates multiple illusions of himself to intimidate and encircle the crowd of people in Stuttgart, Germany.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DownerBeginning' title='/pmwiki/pmwiki.php/Main/DownerBeginning'>Downer Beginning</a>: The film opens with Loki killing over a dozen people, <span class="spoiler" title="you can set spoilers visible by default on your profile" >brainwashing one of S.H.I.E.L.D.'s top agents along with a renowned scientist</span>, and escaping with the Tesseract as an entire S.H.I.E.L.D. base is destroyed and Nick Fury escapes by the skin of his teeth. Cue title card.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DramaPreservingHandicap' title='/pmwiki/pmwiki.php/Main/DramaPreservingHandicap'>Drama-Preserving Handicap</a>:<ul ><li> Inverted for Iron Man. Whereas in his own movies he's been forced to go into the final showdown with some kind of handicap (the older, inefficient Arc Reactor in the first movie, having already used his biggest gun in the second), Tony Stark puts on a brand-spanking new, and much improved, armor just for the big climactic battle after putting his previous suit through the wringer.</li><li> Played straight with Captain America. Take a shot whenever he has to fight without his shield.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DramaticHighPerching' title='/pmwiki/pmwiki.php/Main/DramaticHighPerching'>Dramatic High Perching</a>: When Captain America throws his shield at Thor and Iron Man to get them to stop fighting and catch their attention, he does so from the top of a tree trunk.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheDreaded' title='/pmwiki/pmwiki.php/Main/TheDreaded'>The Dreaded</a>: Even his own team members are afraid of the Hulk. Natasha hasn't shown fear of anything else before. Tony flip-flops on this &#8212; intellectually he knows that the Hulk is an unstoppable <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OneManArmy' title='/pmwiki/pmwiki.php/Main/OneManArmy'>One-Man Army</a>, but he shows simple faith that Banner is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheKidWithTheLeash' title='/pmwiki/pmwiki.php/Main/TheKidWithTheLeash'>The Kid with the Leash</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DreamTeam' title='/pmwiki/pmwiki.php/Main/DreamTeam'>Dream Team</a>: Nick Fury pulled together a group of extraordinary people for to become a team that could do what no one else could.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DrivenToSuicide' title='/pmwiki/pmwiki.php/Main/DrivenToSuicide'>Driven to Suicide</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Banner reveals that he once tried to commit suicide, but the Hulk took control and spat the bullet out,</span> which happened in a comic AU miniseries, and was a deleted scene from <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheIncredibleHulk2008' title='/pmwiki/pmwiki.php/Film/TheIncredibleHulk2008'>The Incredible Hulk (2008)</a></em>.</li><li> Subverted with <span class="spoiler" title="you can set spoilers visible by default on your profile" >Selvig.</span> After he wakes up from <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki's brainwashing, Natasha finds him looking over the edge of Stark Tower's roof, like he's thinking about jumping. Natasha tries to talk him down, only for him to reveal that he's not looking at the ground; he's looking at Loki's scepter a few stories down, which is the key to closing the portal.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DroppingTheBombshell' title='/pmwiki/pmwiki.php/Main/DroppingTheBombshell'>Dropping the Bombshell</a>: Banner reveals he knew all along that S.H.I.E.L.D. had a contingency plan to kill him in case the Hulk got out of control &#8212; and then he tells them he <em>knows</em> the plan won't work because <span class="spoiler" title="you can set spoilers visible by default on your profile" >he's <em>already tried</em> to kill himself.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DropShip' title='/pmwiki/pmwiki.php/Main/DropShip'>Drop Ship</a>: The Chitauri ground troops were transported to Earth by Leviathans which combine this trope with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LivingShip' title='/pmwiki/pmwiki.php/Main/LivingShip'>Living Ship</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DropTheHammer' title='/pmwiki/pmwiki.php/Main/DropTheHammer'>Drop the Hammer</a>: This trope pops up whenever Thor is around, but this movie has a particularly interesting example since Thor drops his hammer on Cap's shield, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExactWords' title='/pmwiki/pmwiki.php/Main/ExactWords'>in response to Cap's request that he put down the weapon</a>.<div class='indent'><strong>Thor:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BerserkButton' title='/pmwiki/pmwiki.php/Main/BerserkButton'>You want me to put the hammer down</a>?!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DutchAngle' title='/pmwiki/pmwiki.php/Main/DutchAngle'>Dutch Angle</a>: Used several times throughout the film. <em>Very</em> heavily in Black Widow's establishing scene.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DyingMomentOfAwesome' title='/pmwiki/pmwiki.php/Main/DyingMomentOfAwesome'>Dying Moment of Awesome</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Phil Coulson gets stabbed. Despite this, he gives Loki a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a> and blasts him through a wall with a BFG, complete with a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BondOneLiner' title='/pmwiki/pmwiki.php/Main/BondOneLiner'>Bond One-Liner</a>. He tells Fury he's okay with going out this way, because it will give the Avengers &#8212; specifically Tony and Cap &#8212; the push they need to work together as a team.</span><div class='indent'><span class="spoiler" title="you can set spoilers visible by default on your profile" ><strong>Coulson:</strong> So that's what it does.</span></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DynamicEntry' title='/pmwiki/pmwiki.php/Main/DynamicEntry'>Dynamic Entry</a>: When Stark flies in to aid Cap, he swoops in and blasts Loki with both repulsors before he's close enough for Loki to see Stark clearly.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DysfunctionalFamily' title='/pmwiki/pmwiki.php/Main/DysfunctionalFamily'>Dysfunctional Family</a>: Thor and Loki have a rather rocky reunion. Hemsworth has noted that Thor's attitude in this movie is a mix between anger, disappointment, and protectiveness towards his little brother.<div class='indent'><strong>Thor:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThickerThanWater' title='/pmwiki/pmwiki.php/Main/ThickerThanWater'>He is of Asgard and he is my brother.</a> <br /><strong>Black Widow:</strong> He killed eighty people in two days. <br /><strong>Thor:</strong> <em>[<a class='twikilink' href='/pmwiki/pmwiki.php/Main/Beat' title='/pmwiki/pmwiki.php/Main/Beat'>Beat</a>]</em> ...<a class='twikilink' href='/pmwiki/pmwiki.php/Main/VerbalBackspace' title='/pmwiki/pmwiki.php/Main/VerbalBackspace'>He's adopted.</a></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DysfunctionJunction' title='/pmwiki/pmwiki.php/Main/DysfunctionJunction'>Dysfunction Junction</a>: Take your pick:<ul ><li> The ex-<a class='twikilink' href='/pmwiki/pmwiki.php/Main/LonelyRichKid' title='/pmwiki/pmwiki.php/Main/LonelyRichKid'>Lonely Rich Kid</a> orphan whose replacement-father figure tried to murder him and steal his company and became a supervillain?</li><li> The <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShellShockedVeteran' title='/pmwiki/pmwiki.php/Main/ShellShockedVeteran'>Shell-Shocked Veteran</a> who was preserved in ice since 1945 and woke up to find that the war he was made to fight was over and everyone he knew was dead?</li><li> The guy being chased around the world by his ex-girlfriend's father who is literally out for his blood due to his, uh, personality disorder? Banner deserves a special mention because he probably has PTSD, and almost definitely has dissociative identity disorder, which is generally believed to develop as a defense mechanism against childhood trauma.</li><li> The Russian assassin who was stolen from her parents and trained from childhood to be a cold-blooded killer?</li><li> The former orphan of an archer whose emotions get destroyed so thoroughly and will definitely blame himself worse than <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/SpiderMan' title='/pmwiki/pmwiki.php/ComicBook/SpiderMan'>Spider-Man</a> if the invasion succeeds?</li><li> Or to top all of them put together, the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RoyallyScrewedUp' title='/pmwiki/pmwiki.php/Main/RoyallyScrewedUp'>crown prince of a godlike alien dimension</a> whose little brother is a throne-grabbing, world-conquering, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DaddyIssues' title='/pmwiki/pmwiki.php/Main/DaddyIssues'>Daddy Issues</a>-plagued, fratricidal, patricidal, genocidal maniac from a completely different species than him and has a case of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SiblingRivalry' title='/pmwiki/pmwiki.php/Main/SiblingRivalry'>Sibling Rivalry</a> so intense a squabble over daddy's approval between the two of them leveled a town?</li><li> The correct answer is, of course, all of the above! Furthermore, all the egos visible from space having to exist together in a single room. These issues have a very strong effect on the characters' volatile, overly-developed, wildly divergent, intra- and inter-personal conflict-ridden Type-A personalities and actions, too. In the words of WSC, they are "isolated and unstable". In the words of Loki, they are "lost creatures". In the words of Bruce Banner:<div class='indent'><strong>Banner:</strong> What are we, a team? No, no, we're a chemical mixture that makes chaos. We're a time bomb.</div></li></ul></li></ul></div><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Film/TheAvengers2012">Film/The Avengers (2012)</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/TheAvengers/TropesEToL">Tropes E to L</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/scraper/resources/theavengers_tropesEtoL.html
+++ b/tropestogo/service/scraper/resources/theavengers_tropesEtoL.html
@@ -1,0 +1,1821 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "TheAvengers", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Tropes E to L / The Avengers - TV Tropes</title>
+            <meta name="description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesEToL" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Tropes E to L / The Avengers - TV Tropes" />
+            <meta name="twitter:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Tropes E to L / The Avengers - TV Tropes" />
+			<meta property="og:type" content="website" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesEToL" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: Spoilers from the earlier films are unmarked.  Early-Installment Weirdness: Thanos' appearance &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "3249201cca6b7eeca1de118d08d4474b20e5ab7e",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/BeneathNotice" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Creator/LetticeGalbraith" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/TheAvengers/TropesEToL?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=TheAvengers/TropesEToL">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=TheAvengers.TropesEToL">
+                <i class="fa fa-history"></i> History</a></li><li class="link-discussion"><a href="/pmwiki/remarks.php?trope=TheAvengers.TropesEToL">
+                  <i class="fa fa-comment"></i> Discussion</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/TheAvengers/TropesEToL?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="TheAvengers"/>
+<input type="hidden" id="title-hidden" value="TropesEToL"/>
+<input type="hidden" id="article_id" value="406147" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesEToL</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>The Avengers / </strong>
+        
+        Tropes E to L
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "TheAvengers",
+                "item": "https://tvtropes.org/pmwiki/index_report.php?groupname=TheAvengers"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Tropes E to L"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+        
+                
+
+        
+            
+            <li class="more-subpages">
+                <a href="javascript:void(0);" class="subpage-toggle-button" >
+                    <span class="wrapper more">More <i class="fa fa-chevron-down"></i></span>
+                    <span class="wrapper less"><i class="fa fa-chevron-left"></i> Less</span>
+                </a>
+
+                <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);" tabindex="0">
+                    <option value="">- More -</option>
+
+                                                            <option value="/pmwiki/pmwiki.php/Aladdin/TropesEToL">Aladdin</option>
+                                                                                <option value="/pmwiki/pmwiki.php/BreakingBad/TropesEToL">BreakingBad</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Castle/TropesEToL">Castle</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FostersHomeForImaginaryFriends/TropesEToL">FostersHomeFor&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/HearthstoneHeroesOfWarcraft/TropesEToL">HearthstoneHer&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/JudgeDredd/TropesEToL">JudgeDredd</option>
+                                                                                <option value="/pmwiki/pmwiki.php/RickAndMorty/TropesEToL">RickAndMorty</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StarTrekDeepSpaceNine/TropesEToL">StarTrekDeepSp&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Supernatural/TropesEToL">Supernatural</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheAvengers/TropesEToL">TheAvengers</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheWire/TropesEToL">TheWire</option>
+                                                                                <option value="/pmwiki/pmwiki.php/WeAreNotAlone/TropesEToL">WeAreNotAlone</option>
+                                        
+                </select>
+
+            </li>
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/TropesEToL?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/TropesEToL?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/TropesEToL?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/TropesEToL?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/TropesEToL?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/TropesEToL?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/TropesEToL?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/TropesEToL?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/TropesEToL?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/TropesEToL?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/TropesEToL?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/TropesEToL?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/TropesEToL?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/TropesEToL?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/TropesEToL?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/TropesEToL?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/TropesEToL?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/TropesEToL?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesAToD' title='/pmwiki/pmwiki.php/TheAvengers/TropesAToD'>Tropes A to D</a> | <strong>Tropes E to L</strong> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesMToP' title='/pmwiki/pmwiki.php/TheAvengers/TropesMToP'>Tropes M to P</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesQToZ' title='/pmwiki/pmwiki.php/TheAvengers/TropesQToZ'>Tropes Q to Z</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TieIns' title='/pmwiki/pmwiki.php/TheAvengers/TieIns'>Tie Ins</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/YMMV/TheAvengers2012' title='/pmwiki/pmwiki.php/YMMV/TheAvengers2012'>YMMV</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/Trivia/TheAvengers2012' title='/pmwiki/pmwiki.php/Trivia/TheAvengers2012'>Trivia</a><hr /><h3><em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheAvengers2012' title='/pmwiki/pmwiki.php/Film/TheAvengers2012'>The Avengers</a></em> provides examples of the following tropes:</h3></p><p><div class="folderlabel" onclick="toggleAllFolders();">&nbsp;&nbsp;&nbsp;&nbsp;open/close all folders&nbsp; </div></p><p><strong>WARNING: Spoilers from the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse'>earlier films</a> are unmarked.</strong></p><p><div class="folderlabel" onclick="togglefolder('folder0');">&nbsp;&nbsp;&nbsp;&nbsp;E&nbsp;</div><div id="folder0" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EarlyInstallmentWeirdness' title='/pmwiki/pmwiki.php/Main/EarlyInstallmentWeirdness'>Early-Installment Weirdness</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos'</span> appearance here isn't really easy to reconcile with the motivations we're given in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/AvengersInfinityWar' title='/pmwiki/pmwiki.php/Film/AvengersInfinityWar'>Avengers: Infinity War</a>.</em> Even if we accept that he was speaking metaphorically about <span class="spoiler" title="you can set spoilers visible by default on your profile" >"courting Death"</span> it still implies that he's motivated by a chance for thrills, far removed from the purpose-driven character we see later.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EasilyThwartedAlienInvasion' title='/pmwiki/pmwiki.php/Main/EasilyThwartedAlienInvasion'>Easily Thwarted Alien Invasion</a>: The Chitauri turn out to be a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KeystoneArmy' title='/pmwiki/pmwiki.php/Main/KeystoneArmy'>Keystone Army</a>, and other than their Leviathan transports are inferior to Loki's generic human soldiers. Lampshaded in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>The Stinger</a>: They were expecting negligible resistance from a race of pushovers going by what Loki told them.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EatMe' title='/pmwiki/pmwiki.php/Main/EatMe'>Eat Me</a>: Tony's approach to a giant alien Leviathan with impenetrable armor. It's even lampshaded by Tony, who asks Jarvis immediately beforehand if he's ever heard of the story of Jonah from <a class='twikilink' href='/pmwiki/pmwiki.php/Literature/TheBible' title='/pmwiki/pmwiki.php/Literature/TheBible'>The Bible</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EatTheBomb' title='/pmwiki/pmwiki.php/Main/EatTheBomb'>Eat the Bomb</a>: Bruce Banner sarcastically asks if Fury wants him to do this with the Tesseract.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EleventhHourRanger' title='/pmwiki/pmwiki.php/Main/EleventhHourRanger'>11th-Hour Ranger</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span> spends most of the film <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a> and isn't freed until before the end battle with Loki and the Chitauri.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EndOfEpisodeSilliness' title='/pmwiki/pmwiki.php/Main/EndOfEpisodeSilliness'>End-of-Episode Silliness</a>: In the famous post-credits scene, the titular characters are eating in silence in a shawarma restaurant.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EnergyAbsorption' title='/pmwiki/pmwiki.php/Main/EnergyAbsorption'>Energy Absorption</a>: Iron Man's suit absorbs Thor's lightning bolt.<div class='indent'><strong>Jarvis:</strong> Power to four-hundred percent capacity. <br /><strong>Tony Stark:</strong> How about that? <em>[fires a supercharged repulsion blast back at Thor]</em></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EpicFail' title='/pmwiki/pmwiki.php/Main/EpicFail'>Epic Fail</a>: Loki attempts to <span class="spoiler" title="you can set spoilers visible by default on your profile" >subdue Hulk in Stark Tower by yelling at him. It gets him slammed into the ground repeatedly mid-speech</span>. Granted, Loki <em>is</em> having a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainousBreakdown' title='/pmwiki/pmwiki.php/Main/VillainousBreakdown'>Villainous Breakdown</a>, but it still isn't one of his better ideas.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EpicMovie' title='/pmwiki/pmwiki.php/Main/EpicMovie'>Epic Movie</a>: It has a huge, climactic battle and has so many characters larger than life that the movie effectively had five preceding movies!</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EpicTrackingShot' title='/pmwiki/pmwiki.php/Main/EpicTrackingShot'>Epic Tracking Shot</a>: <a class='urllink' href='https://www.youtube.com/watch?v=Y69kGmPeHw0'>During the final battle in New York<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>. The single shot pans between Black Widow, Iron Man, Captain America, Hawkeye, Hulk and Thor all fighting through the Chitauri hordes across the city, both on their own and in pairs.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EqualOpportunityEvil' title='/pmwiki/pmwiki.php/Main/EqualOpportunityEvil'>Equal-Opportunity Evil</a>:<ul ><li> Loki's henchmen seem fairly diverse, at least racially. Where they're from is never specified though; Hawkeye just refers to them as enemies of S.H.I.E.L.D.</li><li> Given events in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier'>Captain America: The Winter Soldier</a></em>, some of them may have been <span class="spoiler" title="you can set spoilers visible by default on your profile" >HYDRA agents</span> who later claimed <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControlDevice' title='/pmwiki/pmwiki.php/Main/MindControlDevice'>Loki's brainwashing</a> as an excuse. (It's also possible not, because <span class="spoiler" title="you can set spoilers visible by default on your profile" >HYDRA</span> probably doesn't want anyone but themselves taking over the world.)</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EstablishingCharacterMoment' title='/pmwiki/pmwiki.php/Main/EstablishingCharacterMoment'>Establishing Character Moment</a>:<ul ><li> Maria Hill shows up in the beginning of the movie, butts heads with Nick Fury over the evacuation of a S.H.I.E.L.D. facility, and gets into a car chase with an escaping Loki that ends up with her driving backwards at full speed trading gunfire with another vehicle, all before the title credits.</li><li> In his first five minutes, Loki slaughters half-a-dozen S.H.I.E.L.D. personnel, puts the mind control whammy on some main characters, and steals the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MacGuffin' title='/pmwiki/pmwiki.php/Main/MacGuffin'>MacGuffin</a>.</li><li> Black Widow's first appearance in the film has her utilizing the rather unique interrogation techniques on some rogue Russians, and then kicking ass and taking names when Coulson contacts her about Hawkeye being compromised by Loki.</li><li> It's subtle, but Bruce Banner's humanity is the first thing established about him. When a little girl comes begging for his help healing her sick father, Banner's compassion overrides his better judgment; in fact, this is the bait Black Widow uses to draw him into their initial meeting. This moment is an extremely effective contrast with the jibes later in the movie about Banner being a "beast" or "monster".</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EstablishingTeamShot' title='/pmwiki/pmwiki.php/Main/EstablishingTeamShot'>Establishing Team Shot</a>:<ul ><li> The rotating team shot of Hawkeye, Thor, the Black Widow, Captain America, Iron Man and Hulk.</li><li> Another one after the climatic battle, when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki turns around and sees the entire team glaring at him.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EurekaMoment' title='/pmwiki/pmwiki.php/Main/EurekaMoment'>"Eureka!" Moment</a>: When Stark is discussing Loki's actions, he mentions that Loki wants his name on his own personal monument, <span class="spoiler" title="you can set spoilers visible by default on your profile" >then realizes <em>he</em> built such a place, with its own unlimited power source.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EverybodysDeadDave' title='/pmwiki/pmwiki.php/Main/EverybodysDeadDave'>Everybody's Dead, Dave</a>: A deleted scene shows Steve Rogers looking at folders about his former allies Howard Stark, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Jim Morita, and James Montgomery Falsworth are listed as dead. Peggy Carter is listed as retired, and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChekhovMIA' title='/pmwiki/pmwiki.php/Main/ChekhovMIA'>Bucky is declared M.I.A.</a></span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EverybodyOwnsAFord' title='/pmwiki/pmwiki.php/Main/EverybodyOwnsAFord'>Everybody Owns a Ford</a>: The movie features numerous Acuras.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EverythingIsOnline' title='/pmwiki/pmwiki.php/Main/EverythingIsOnline'>Everything Is Online</a>: S.H.I.E.L.D. searches for Loki by accessing every security camera on the planet... <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustifiedTrope' title='/pmwiki/pmwiki.php/Main/JustifiedTrope'>if it's wireless-connected</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilBrit' title='/pmwiki/pmwiki.php/Main/EvilBrit'>Evil Brit</a>: Played straight with <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/TomHiddleston' title='/pmwiki/pmwiki.php/Creator/TomHiddleston'>Tom Hiddleston</a>'s Loki, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WellIntentionedExtremist' title='/pmwiki/pmwiki.php/Main/WellIntentionedExtremist'>subverted</a> with the British member of the World Security Council, and averted with Jarvis. Also averted with Thor. Although <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/ChrisHemsworth' title='/pmwiki/pmwiki.php/Creator/ChrisHemsworth'>Chris Hemsworth</a> is Australian, Thor speaks with an RP accent (of varying quality).</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilGloating' title='/pmwiki/pmwiki.php/Main/EvilGloating'>Evil Gloating</a>: Loki <em>loves</em> to gloat, though he has a tendency to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShutUpHannibal' title='/pmwiki/pmwiki.php/Main/ShutUpHannibal'>underestimate his audience</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilIsHammy' title='/pmwiki/pmwiki.php/Main/EvilIsHammy'>Evil Is Hammy</a>: While Loki is still subdued compared to Thor or Odin, he still gets his moments of this when he wants to make a speech or some grand gesture. Otherwise, his style is to savor the scenery, more than outright chew it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilPlan' title='/pmwiki/pmwiki.php/Main/EvilPlan'>Evil Plan</a>: Loki wants to rule the earth. For this reason he works with the Chitauri and steals the Tesseract to create a portal for them. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Or so he claims. He didn't tell Thanos how tough humans are, and that portal only let a few hundred aliens through at a time. New York City alone has more police than that army had soldiers. At the end of the movie, Loki is back home with his family, Thanos has lost the Tesseract and the Staff of Control, and Earth has hardened itself against a second invasion.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilWillFail' title='/pmwiki/pmwiki.php/Main/EvilWillFail'>Evil Will Fail</a>:<ul ><li> "You're going to lose. It's in your nature. You lack conviction."</li><li> As well as Tony's comment that "There's no <em>throne</em>."</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill' title='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill'>The Evils of Free Will</a>: Loki twice gives a speech about this, first when he appears at S.H.I.E.L.D headquarters and later in Germany.<div class='indent'><strong>Loki:</strong> Is not this simpler? Is this not your natural state? It's the unspoken truth of humanity, that you crave subjugation. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HobbesWasRight' title='/pmwiki/pmwiki.php/Main/HobbesWasRight'>The bright lure of freedom diminishes your life's joy in a mad scramble for power, for identity</a>. You were made to be ruled. In the end, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KneelBeforeZod' title='/pmwiki/pmwiki.php/Main/KneelBeforeZod'>you will always kneel</a>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExactWords' title='/pmwiki/pmwiki.php/Main/ExactWords'>Exact Words</a>:<ul ><li> In Stuttgart, Loki threatens the old gentleman defying him and says, "Look to your elder, people." Just as he fires an energy bolt, Cap intervenes and reflects it back on him. Cap is probably older than most (or all) of the people there.</li><li> Captain America tells Thor to "put the hammer down." Thor puts the hammer down... on Captain America.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a> Hawkeye</span>'s cover story when approaching the Helicarrier.<div class='indent'><strong>Control tower:</strong> We have you on record but not on schedule; what is your haul? <br /><strong><span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span>:</strong> Arms and ammunition.</div></li><li> Tony Stark tells JARVIS to blow off Agent Coulson's call because he's "not in". He is standing on the balcony right outside.<div class='indent'><strong>Stark:</strong> I'm not in. I'm <em>actually</em> out!</div></li><li> And a few seconds later...<div class='indent'><strong>Stark:</strong> I did do the heavy lifting. Literally, I lifted the heavy things.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExplainExplainOhCrap' title='/pmwiki/pmwiki.php/Main/ExplainExplainOhCrap'>Explain, Explain... Oh, Crap!</a>: Tony Stark, upon working out Loki's plan:<div class='indent'><strong>Tony:</strong> ...And Loki, he's a full-tilt diva! He wants flowers, he wants parades, he wants a monument built to the skies with his name plastered on&#8212; <br /><em>[realizes he's describing Stark Tower and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NotSoDifferentRemark' title='/pmwiki/pmwiki.php/Main/NotSoDifferentRemark'>in turn, himself</a>]</em> <br /><strong>Tony:</strong> Sonofabitch.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExpertConsultant' title='/pmwiki/pmwiki.php/Main/ExpertConsultant'>Expert Consultant</a>: Mentioned in passing to explain why <a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>Jane Foster</a> isn't present<span class="notelabel" onclick="togglenote('note04ojd');"><sup>note&nbsp;</sup></span><span id="note04ojd" class="inlinefolder" isnote="true" onclick="togglenote('note04ojd');" style="cursor:pointer;font-size:smaller;display:none;"><a class='twikilink' href='/pmwiki/pmwiki.php/Creator/NataliePortman' title='/pmwiki/pmwiki.php/Creator/NataliePortman'>Natalie Portman</a> was pregnant at the time and thus couldn't appear in <em>The Avengers</em></span>; S.H.I.E.L.D. set her up as a consultant for a distant, remote observatory to keep her out of harm's way.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExplosionsInSpace' title='/pmwiki/pmwiki.php/Main/ExplosionsInSpace'>Explosions in Space</a>: Done correctly at the end of the film. <span class="spoiler" title="you can set spoilers visible by default on your profile" >The nuke Tony steers into the Chitauri mothership detonates as an expanding sphere, with no mushroom cloud or <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlanarShockwave' title='/pmwiki/pmwiki.php/Main/PlanarShockwave'>Planar Shockwave</a></span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExpositoryHairstyleChange' title='/pmwiki/pmwiki.php/Main/ExpositoryHairstyleChange'>Expository Hairstyle Change</a>: Loki starts off with tidy hair that doesn't reach his shoulders during <em>Thor</em>. When he returns as a would-be world conqueror, his hair is quite a bit longer and noticeably un-cared for. This serves as an indicator that he's considerably less stable than before, now more of a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBad' title='/pmwiki/pmwiki.php/Main/BigBad'>straight-up villain</a> rather than a sympathetic <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AntiVillain' title='/pmwiki/pmwiki.php/Main/AntiVillain'>Anti-Villain</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EyeColourChange' title='/pmwiki/pmwiki.php/Main/EyeColourChange'>Eye Colour Change</a>: Loki's staff changes people's eyes blue when he mind-controls them. On the DVD commentary, director <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> explains that this was actually something they added in post-production to make the difference between brainwashed characters and people acting under their own will clear, and so that there was a clear visual sign in <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span> when he finally broke out of it, which makes his teammates taking him back more understandable.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EyeScream' title='/pmwiki/pmwiki.php/Main/EyeScream'>Eye Scream</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span>, <span class="spoiler" title="you can set spoilers visible by default on your profile" >while <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a></span>, has a decidedly blunt approach to bypassing retinal scanners, and Loki is happy to oblige him. It's presumed that the remote eyeball thing that Loki jams into the German scientist's head is at least painful, if not resulting in the loss of the man's eye.</li><li> Hawkeye shows a desire to "put an arrow through Loki's eye socket".</li></ul></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder1');">&nbsp;&nbsp;&nbsp;&nbsp;F&nbsp;</div><div id="folder1" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FaceRevealingTurn' title='/pmwiki/pmwiki.php/Main/FaceRevealingTurn'>Face-Revealing Turn</a>: The post-credits stinger, as the mysterious figure Loki has been working for slowly turns to reveal a grinning <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FailedAttemptAtDrama' title='/pmwiki/pmwiki.php/Main/FailedAttemptAtDrama'>Failed Attempt at Drama</a>:<ul ><li> Thor throwing his weight around with Loki, ordering him to "Listen well, brother..." He doesn't get too far in his speech before Iron Man rockets into him and tackles him off the cliff.</li><li> Loki's dramatic failure to brainwash Tony thanks to the latter's <span class="spoiler" title="you can set spoilers visible by default on your profile" >miniature arc reactor</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FakeNationality' title='/pmwiki/pmwiki.php/Main/FakeNationality'>Fake Nationality</a>: <span style="display:none">invoked</span> Black Widow, being a master manipulator and spy, can pass herself off pretty convincingly as an American. Whether this is done deliberately by the film makers or it's a case of Scarlett Johansson <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NotEvenBotheringWithTheAccent' title='/pmwiki/pmwiki.php/Main/NotEvenBotheringWithTheAccent'>Not Even Bothering with the Accent</a> (the character is traditionally portrayed in most iterations with a Russian accent and using Gratuitous Russian) isn't elaborated upon.<div class='indent'><strong>Natasha Romanoff:</strong> Regimes fall every day. I tend not to weep over that, I'm Russian &#8212; or I <em>was</em>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FamilyUnfriendlyDeath' title='/pmwiki/pmwiki.php/Main/FamilyUnfriendlyDeath'>Family-Unfriendly Death</a>:<ul ><li> It goes by very quickly, but when the Hulk is fighting several Chitauri on a rooftop before being swarmed by their gliders, he palms one guy's head and crushes his skull like a grape.</li><li> Also when Cap fights the Chitauri after giving orders to the NYPD he grabs one of their arm cannons, cuts the arm off and then dumps it out of the gun. Later, when he jumps into defent Clint and Nat he slices open another Chitauri's chest with his shield, though that too occurs quickly and is easily missed.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Fanboy' title='/pmwiki/pmwiki.php/Main/Fanboy'>Fanboy</a>: Agent Coulson is a pretty big fanboy of Captain America. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThatCameOutWrong' title='/pmwiki/pmwiki.php/Main/ThatCameOutWrong'>He also watched Rogers while he was sleeping.</a> We... we mean... he was... he was present, while <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumanPopsicle' title='/pmwiki/pmwiki.php/Main/HumanPopsicle'>Rogers was unconscious, from the ice</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Fanservice' title='/pmwiki/pmwiki.php/Main/Fanservice'>Fanservice</a>: Pretty much every character at some point either, if they're a lady, show off their behind in tight spandex, or if they're a dude, their chest in tight muscle shirts, or wears a suit that exposes their bare and toned arms.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FantasticRacism' title='/pmwiki/pmwiki.php/Main/FantasticRacism'>Fantastic Racism</a>: Loki views humans as an inferior race meant for slavery. He sums up this opinion pretty succinctly when he and Thor are talking on the mountain:<div class='indent'><strong>Thor:</strong> You think yourself above them? <br /><strong>Loki:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CaptainObvious' title='/pmwiki/pmwiki.php/Main/CaptainObvious'>Well,</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BluntYes' title='/pmwiki/pmwiki.php/Main/BluntYes'>yes</a>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FantasyKitchenSink' title='/pmwiki/pmwiki.php/Main/FantasyKitchenSink'>Fantasy Kitchen Sink</a>: As one reviewer noted, in theory taking a hero from epic fantasy and putting him together with two heroes with utterly different science-fiction origins, a 1930s/40s style pulp action hero, two escapees from a Jason Bourne film and a Bond-styled superspy organization, all fighting another epic fantasy character leading an alien invasion really shouldn't have worked so gloriously well.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FatalFamilyPhoto' title='/pmwiki/pmwiki.php/Main/FatalFamilyPhoto'>Fatal Family Photo</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's trading cards</span>. Tony also makes mention of <span class="spoiler" title="you can set spoilers visible by default on your profile" >a cellist girlfriend whom Coulson</span> had been seeing in his spare time.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FateWorseThanDeath' title='/pmwiki/pmwiki.php/Main/FateWorseThanDeath'>Fate Worse than Death</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos has something special planned for Loki, should he fail to fork over the Tesseract. Since Loki fails to take over Earth, he better <em>hope</em> that his Asgardian brethren protect him indefinitely by locking him up. God only knows what his benefactor will do to him for the rest of eternity if he finds Loki.</span><div class='indent'><strong>The Other:</strong> You think you know pain? <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GreaterScopeVillain' title='/pmwiki/pmwiki.php/Main/GreaterScopeVillain'>He</a> will make you long for something sweet as pain.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FauxActionGirl' title='/pmwiki/pmwiki.php/Main/FauxActionGirl'>Faux Action Girl</a>: Subverted by Black Widow, who appears to have been beaten and cowed by the Russian mobsters. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LampshadeHanging' title='/pmwiki/pmwiki.php/Main/LampshadeHanging'>They even mock her supposed tough reputation</a>. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>However, this is all a play to get them to reveal information</a>. Once she is tasked with a much more important mission she quickly breaks free and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbStompBattle' title='/pmwiki/pmwiki.php/Main/CurbStompBattle'>dispatches them</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Fauxshadow' title='/pmwiki/pmwiki.php/Main/Fauxshadow'>Fauxshadow</a>: Come on, you know you thought the <span class="spoiler" title="you can set spoilers visible by default on your profile" >Mj&ouml;lnir/Cap's Shield shockwave trick</span> and <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thor's lightning charging up Iron Man's armor</span> was going to come in handy during the climax... but it doesn't.<ul ><li> They make good use of it in the Endgame sequel though.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FearOfThunder' title='/pmwiki/pmwiki.php/Main/FearOfThunder'>Fear of Thunder</a>: Justified, when Loki becomes uneasy when a storm starts, prompting this exchange:<div class='indent'><strong>Captain America:</strong> What's the matter? Scared of a little lightning? <br /><strong>Loki:</strong> I'm not overly fond of what follows.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FemaleGaze' title='/pmwiki/pmwiki.php/Main/FemaleGaze'>Female Gaze</a>: The male heroes' chiseled physiques are often on display. Even their civilian clothing often includes tight muscle shirts. However, only a newly de-Hulked Bruce Banner is seen shirtless.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FightingFromTheInside' title='/pmwiki/pmwiki.php/Main/FightingFromTheInside'>Fighting from the Inside</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Selvig manages to install a fail-safe in Loki's portal that would allow it to be shut down</span>, even while he is deep under Loki's control.</li><li> Heavily implied with <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span>. He shoots Fury in his armored vest, which Fury notes in a deleted scene, and later when Loki asks him what the Tesseract showed him, he responds "My next target," while looking at Loki. And more than that, he misses hitting Maria Hill with a handgun early on, and later when <span class="spoiler" title="you can set spoilers visible by default on your profile" >fighting Natasha (his closest friend) on the Helicarrier</span>, he fails to hit her with his arrows (though the first time, she side-stepped it at close-range before he fired). <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImprobableAimingSkills' title='/pmwiki/pmwiki.php/Main/ImprobableAimingSkills'>And that's what he's best at</a>.</li><li> The Hulk helps out his fellow Avengers during the climactic battle, in contrast to attacking them earlier in the film. Either Banner's feelings toward the rest of the Avengers have changed, causing the Hulk to behave differently toward them, or Banner is actively guiding the Hulk's actions from the inside. Banner himself <em>always</em> attempts control over the Hulk, as quite plainly demonstrated by his first involuntary Hulk-out: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ResistTheBeast' title='/pmwiki/pmwiki.php/Main/ResistTheBeast'>he gives Natasha an utterly anguished look as the transformation takes hold</a>, and actively hurls himself <em>away</em> from her as the change takes place.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FireForgedFriends' title='/pmwiki/pmwiki.php/Main/FireForgedFriends'>Fire-Forged Friends</a>: An element of the story is that the members don't get along at first but eventually become friends and learn to work together.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater' title='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater'>Fish out of Temporal Water</a>: Captain America, falling exactly in line with his comic counterpart. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForDrama' title='/pmwiki/pmwiki.php/Main/PlayedForDrama'>Played for Drama</a> or <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForLaughs' title='/pmwiki/pmwiki.php/Main/PlayedForLaughs'>Played for Laughs</a> depending on the situation.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FiveManBand' title='/pmwiki/pmwiki.php/Main/FiveManBand'>Five-Man Band</a>: For the bulk of the movie there are only five avengers because Hawkeye is brainwashed. They fit the archetype well until the final battle.<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLeader' title='/pmwiki/pmwiki.php/Main/TheLeader'>The Leader</a> &#8212; Captain America. Type II in practice and Type IV in theory. It takes him a while, but eventually he realizes his good heart and tactical knowledge are what is needed to bring the team together.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLancer' title='/pmwiki/pmwiki.php/Main/TheLancer'>The Lancer</a> &#8212; Iron Man. The total opposite of Captain America and the most resistant to being a team player. However, his loose cannon recklessness saves the day several times and conversely it is eventually he who benefits the most from having people watching his back.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheBigGuy' title='/pmwiki/pmwiki.php/Main/TheBigGuy'>The Big Guy</a> &#8212; Thor is a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BoisterousBruiser' title='/pmwiki/pmwiki.php/Main/BoisterousBruiser'>boisterous</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ProudWarriorRaceGuy' title='/pmwiki/pmwiki.php/Main/ProudWarriorRaceGuy'>Proud Warrior Race Guy</a>. Between his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperStrength' title='/pmwiki/pmwiki.php/Main/SuperStrength'>Super Strength</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DropTheHammer' title='/pmwiki/pmwiki.php/Main/DropTheHammer'>hammer</a>, and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShockAndAwe' title='/pmwiki/pmwiki.php/Main/ShockAndAwe'>Shock and Awe</a> powers he's the strongest of the team. Bruce as the Hulk also qualifies. <!--Tony is a normal human without his suit and Bruce better fits Smart Guy.--></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSmartGuy' title='/pmwiki/pmwiki.php/Main/TheSmartGuy'>The Smart Guy</a> &#8212; Bruce Banner was reassured he was recruited for his scientific expertise and that his purpose was to track the Tesseract. Aside from the climax this is his purpose. Stark, also being a super-scientist, is a secondary example but fits Lancer better. The two of them bond over <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>Techno Babble</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StealthExpert' title='/pmwiki/pmwiki.php/Main/StealthExpert'>Stealth Expert</a> &#8212; Black Widow, by virtue of being <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSmurfettePrinciple' title='/pmwiki/pmwiki.php/Main/TheSmurfettePrinciple'>the girl of the group</a>, her ability to get to places where people don't want her to be, and her use of emotions to manipulate villains. She's almost a heroic version of the <a class='twikilink disambiglink' href='/pmwiki/pmwiki.php/Main/DarkChick' title='/pmwiki/pmwiki.php/Main/DarkChick'>Dark Chick</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SixthRanger' title='/pmwiki/pmwiki.php/Main/SixthRanger'>Sixth Ranger</a> &#8212; After being knocked out of his brainwashing, Clint Barton becomes this just in time for the final battle.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FiveRoundsRapid' title='/pmwiki/pmwiki.php/Main/FiveRoundsRapid'>Five Rounds Rapid</a>: The NYPD is seen firing at the Chitauri with just their handguns. Black Widow also uses handguns and is shown to be rather effective with them, although she trades up for a looted Chitauri weapon.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FlawExploitation' title='/pmwiki/pmwiki.php/Main/FlawExploitation'>Flaw Exploitation</a>:<ul ><li> Black Widow manipulates Loki's love for <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a> to get important information from him. The Chitauri use his thirst for revenge and "worthiness" to have him fetch the Tesseract.</li><li> This is Loki's favorite tactic, but it is used against him in the climax. Tony realizes that he and Loki aren't so different, and this helps him figure out that Loki would sacrifice pragmatism for showmanship, which would end up biting Loki hard.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FlyingFirepower' title='/pmwiki/pmwiki.php/Main/FlyingFirepower'>Flying Firepower</a>: Essential in how the final battle plays out.<ul ><li> When Thor arrives on the scene, the first thing he does is rain lightning down on the soldiers threatening the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Badass Normals</a>. Cap then charges Thor (one of only two members of the team that could fly high enough) with using his lightning as artillery to bottleneck the Tesseract portal.</li><li> But even moreso, this is Iron Man's <em>specialty</em>. His armor is extremely fast yet highly maneuverable, which is a huge advantage against the Chitauri. Furthermore, because of his speed and firepower, Cap places him in charge of containing the enemy to a few blocks. To see just how well Tony can pull this off, check out his feats in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheOner' title='/pmwiki/pmwiki.php/Main/TheOner'>The Oner</a>. He provides cover for Black Widow, Cap and Hawkeye in the span of a few seconds.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Foil' title='/pmwiki/pmwiki.php/Main/Foil'>Foil</a>: The heart of the humor and drama of this movie lies in the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BirdsOfAFeather' title='/pmwiki/pmwiki.php/Main/BirdsOfAFeather'>similarities</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OppositesAttract' title='/pmwiki/pmwiki.php/Main/OppositesAttract'>contrasts</a> of the lead characters.<ul ><li> It's taken to ridiculous extremes with Tony to the point where it's not just that he stands in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Pun' title='/pmwiki/pmwiki.php/Main/Pun'>stark</a> contrast with every other main character, but even with <em><strong>himself</strong></em>, (Tony at the beginning vs. Tony at the end).</li><li> Bruce Banner vs. Tony Stark: Both are genius-level scientists, and harbor mutual respect for each other. While both have a dark side, they are completely different personality-wise. Bruce is, by necessity, mild-mannered and cautious to control his id, while Tony's flamboyance and irreverence are the tip of his self-destructive decadence.</li><li> Tony Stark vs. Steve Rogers: Apart from being tied by family history, both are motivated by a sense of American patriotism and a desire to end wars and bring peace to the world. But Tony and Steve are completely different in terms of temperament and modus operandi, and Steve has uneasy memories of having worked with Tony's father. According to <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/RobertDowneyJr' title='/pmwiki/pmwiki.php/Creator/RobertDowneyJr'>Robert Downey Jr.</a>, Tony has heard so much about Steve from his dad that he's like a big brother he can never live up to. Also noted is that Steve and Tony are the two main benefactors of Howard's legacy: Steve couldn't have received the Super Soldier Formula without Howard (he wouldn't have even met Dr. Erskine if he hadn't watched Howard's performance), while Tony inherited everything from his father. <br /><br />In an odd contrast, going back to their origin movies, how they received their powers and what they had before them are on the opposite ends of the spectrum: Steve had no physical resources, but had the moral and personality traits necessary for super-heroism, and was handed the Super Soldier Formula on a platter. Tony, who was given a lot of outside resources but nothing internally, didn't just have to build his armor, but he also had to create the whole superhero mindset from his previous status as a "genius billionaire playboy philanthropist". On top of that, Steve received his powers because he wanted to go from his life to the front lines, while Tony built his so he could escape for his life from the front lines! Heck, even the scientific workshops where their powers began; Steve's was nicely furnished, clean, run by a government agency, while Tony's was <em><strong>in a cave with a box of scraps</strong></em>. Then there's the chase post-lab shootings, Steve's running to catch an enemy and with Tony, the enemy is chasing him! <br /><br />It reaches the point where it just somehow suffers from Steve not bringing up a few stories about Howard, or at the very least a photo of the Captain and Howard together (but if Pepper Potts almost didn't appear in the movie, then there's no way that was making it in).</li><li> Thor vs. Steve Rogers: Both are old-fashioned in ideals and aesthetics, initially felt ill at ease on modern Earth, and are driven by a sense of duty before their homeland. Still, both find it difficult to comprehend each other &#8212; they are two very different kinds of old-fashioned, after all. They also share a lack of understanding of modern idioms. Thor and Steve's origins are also from opposite directions. Thor was born into power and privilege, a spoilt, proud, but well-meaning child, abusing his strength as a bully. Steve was a sickly, skinny little orphan from Brooklyn, weak and poor, but possessing an unshakable sense of justice, standing up against those he felt needed standing up to despite his weakness. Thor was stripped of his gifts and learned humility. Steve gained strength as a reward for his virtuous nature.</li><li> Steve Rogers vs. Bruce Banner: It's only touched on briefly, but Steve Rogers is the Super Soldier experiment gone right, while Bruce Banner is the experiment gone wrong (or "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/CursedWithAwesome' title='/pmwiki/pmwiki.php/Main/CursedWithAwesome'>wrong</a>").</li><li> Natasha Romanoff vs. <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Hawkeye' title='/pmwiki/pmwiki.php/ComicBook/Hawkeye'>Clint Barton</a>: Secret agents with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DarkAndTroubledPast' title='/pmwiki/pmwiki.php/Main/DarkAndTroubledPast'>Dark and Troubled Pasts</a>, a sense of chilly professionalism, and a deep, long-standing friendship originating when <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Hawkeye' title='/pmwiki/pmwiki.php/ComicBook/Hawkeye'>Clint</a> made a choice that perhaps Natasha wouldn't have.</li><li> In addition, Loki has traits that resonate or clash with the leads: Asgardian origins (Thor), intelligence, mercurial temperament, and love for theatrics (Iron Man), manipulation of emotions (Bruce Banner), disregard for freedom and human life (Captain America), a lack of empathy (Black Widow), and a disregard for free will (Hawkeye).</li><li> All four of the main powered heroes have different ways by which they acquired and use their powers. Iron Man had no power, but built them on his own in a time of crisis. Thor was born with power, then stripped of them and learned humility to use them responsibly. Bruce Banner was given power he never wanted, and it is a struggle for him to control it. And Captain America was born with weakness, but granted power by a benefactor. Iron Man has some resentment towards this in particular because he's the only one whose abilities, aside from his intellect and charm, could be realistically negated. (You can't untrain Widow or Hawkeye, nor is there anyone to strip Thor of his powers, cure Banner of the Hulk, or negate the Super Soldier Serum in Rogers.)<div class='indent'><strong>Tony:</strong> You're a lab experiment, Rogers. Everything special about you came out of a bottle.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FoodEnd' title='/pmwiki/pmwiki.php/Main/FoodEnd'>Food End</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >At least in the U.S. release. There's Shawarma!</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ForbiddenChekhovsGun' title='/pmwiki/pmwiki.php/Main/ForbiddenChekhovsGun'>Forbidden Chekhov's Gun</a>: The whole team (minus Tony) spends a lot of time trying to keep Bruce Banner calm. Then the alien invasion arrives.<div class='indent'><em>[alien leviathan starts heading towards the group]</em> <br /><strong>Captain America:</strong> Dr. Banner! Now might be a good time to get angry. <br /><strong>Banner:</strong> That's my secret Captain. I'm always angry. <br /><em>[Banner Hulks Out and punches the leviathan]</em></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Foreshadowing' title='/pmwiki/pmwiki.php/Main/Foreshadowing'>Foreshadowing</a>:<ul ><li> Not long before <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReveal' title='/pmwiki/pmwiki.php/Main/TheReveal'>The Reveal</a>, Coulson makes an offhand comment to Thor that he "changed everything".</li><li> Very subtly done in the scene where Natasha and Banner meet for the first time, when she has a child lure Banner to a isolated house in order to ask him to return to S.H.I.E.L.D. Pay close attention to the background when Banner is speaking. There are many green objects and green streaks of paint, all in sharp focus. When Natasha is shown, there are also green objects and green paint, but further in the background and out-of-focus. As the scene progresses, the green objects behind Banner get more obvious. This progression coincides with Natasha slowly realizing that the Hulk is very close and she starts treading very lightly.</li><li> Cap telling Tony that he's not the kind to <span class="spoiler" title="you can set spoilers visible by default on your profile" >sacrifice himself for a greater cause</span>.</li><li> A very subtle one in the beginning: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Barton shoots Fury on the chest, even though he would have normally been able to hit him on the head. It shows that Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControl' title='/pmwiki/pmwiki.php/Main/MindControl'>Mind Control</a> is not 100% perfect. Later it turns out that the brainwashed Selvig was able to install a backdoor to turn off the Tesseract and the portal</span>.</li><li> Loki's new staff that was given to him by the Chitauri's leader. It's mind control powers hints that it is <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Mind Gem from the Infinity Gauntlet and that the leader is Thanos</span>.</li><li> Very early in the battle with the Chitauri, one of the air speeders chasing Iron Man smashes into a building because it couldn't turn fast enough. Barton later points out their poor maneuverability to Tony, who immediately puts the knowledge to deliberate use.</li><li> One for <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan3' title='/pmwiki/pmwiki.php/Film/IronMan3'>Iron Man 3</a></em> with <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony testing out a new device that'll allow him to call his suit to him in case of long distance emergency. He expands upon it in the third film.</span></li><li> Watch carefully when Nick Fury brings out <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's blood-stained trading cards and says he got them from Coulson's jacket.</span> Agent Hill gives Fury a "What the hell?" expression. Later she calls Fury out on this saying that <span class="spoiler" title="you can set spoilers visible by default on your profile" >the trading cards were actually in his locker.</span></li><li> Another subtle one for <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier'>Captain America: The Winter Soldier</a></em>: Before Banner suggests other methods, S.H.I.E.L.D. attempts to find Loki by tapping into pretty much every camera or digital device on the planet. <span class="spoiler" title="you can set spoilers visible by default on your profile" >This is also how HYDRA will pinpoint targets for its scheme to eliminate any and all potential challengers before they even suspect danger.</span></li><li> When Selvig asks Barton "where did you find all these people?" Barton's response is simply, "S.H.I.E.L.D. has many enemies." As <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier'>Captain America: The Winter Soldier</a></em> will reveal, <span class="spoiler" title="you can set spoilers visible by default on your profile" >it's likely these are just S.H.I.E.L.D. staffers who know how to subvert and destroy their own organization</span>.</li><li> Also, the S.H.I.E.L.D. Helicarrier has a cargo hold full of HYDRA weapons and crates stamped with the HYDRA logo. One can wonder how many HYDRA <em>items</em> were present on board during the operation.</li><li> When Tony arrives on the bridge and starts dumping exposition, he pauses to shout "That man is playing <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a></em>!" The primary objective of <em>Galaga</em> is to shoot aliens descending from the top of the screen, <span class="spoiler" title="you can set spoilers visible by default on your profile" >which is exactly how the final battle plays out.</span></li><li> A very subtle one. In Natasha's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EstablishingCharacterMoment' title='/pmwiki/pmwiki.php/Main/EstablishingCharacterMoment'>Establishing Character Moment</a>, she's apparently at someone's mercy, feeling threatened and vulnerable, only for her to reveal that this was exactly the position she wanted to be in to con information from the one who thinks he's in control. This is exactly the method she uses <span class="spoiler" title="you can set spoilers visible by default on your profile" >on Loki to find out what he wanted on the Helicarrier</span>.</li><li> In her first meeting with Bruce, Natasha is established to be rather afraid of the Hulk, shown when Bruce faking an angry outburst badly rattles her into immediately drawing her gun and needing him to speak calmly and non-threateningly to her to get her to regain her composure. Later in the film, <span class="spoiler" title="you can set spoilers visible by default on your profile" >she's quick to assume that Loki's plan is centered around unleashing the Hulk and leaves the interrogation with no inkling of his true plan, having Barton and a squad of mercenaries track his scepter to find and attack the helicarrier.</span></li><li> Among the list of past atrocities that Loki throws in Natasha's face is "Dreykov's daughter". This becomes significant in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/BlackWidow2021' title='/pmwiki/pmwiki.php/Film/BlackWidow2021'>Black Widow (2021)</a></em>.</li><li> During various interviews from people after the Battle of New York, one person, Senator Boynton of the United States Government argues that there should be an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperRegistrationAct' title='/pmwiki/pmwiki.php/Main/SuperRegistrationAct'>Super Registration Act</a> for any damages the Avengers and the Chitauri caused during their fight. <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaCivilWar' title='/pmwiki/pmwiki.php/Film/CaptainAmericaCivilWar'>Captain America: Civil War</a></em> would grant his wish with the Sokovia Accords after the team's battle with Ultron.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ForTheEvulz' title='/pmwiki/pmwiki.php/Main/ForTheEvulz'>For the Evulz</a>: Loki probably didn't need to shove the eye scanner into that guy's eye quite so hard... <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilFeelsGood' title='/pmwiki/pmwiki.php/Main/EvilFeelsGood'>or gleefully</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreedomFromChoice' title='/pmwiki/pmwiki.php/Main/FreedomFromChoice'>Freedom from Choice</a>: Loki claims that this is what humans need.<div class='indent'><strong>Loki:</strong> I come with glad tidings, of a world made free. <br /><strong>Fury:</strong> Free from what? <br /><strong>Loki:</strong> Freedom.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreezeFrameBonus' title='/pmwiki/pmwiki.php/Main/FreezeFrameBonus'>Freeze-Frame Bonus</a>:<ul ><li> When Iron Man crash lands after pulling his "Jonah" stunt, the building behind him is actually the shawarma joint he later mentions wanting to try out.</li><li> The blueprints Tony's studying in the very last scene are of Stark Tower, with floors labeled for each Avenger to live in.</li><li> After Bruce blurts out that he once tried to kill himself, the expression that flits across Tony's face is utterly terrified and heartbroken.</li><li> If you look closely, Stark tower is not only where the current Metlife Building stands, the tower itself appears to be growing out of the Metlife building's lower half.</li><li> When the S.H.I.E.L.D. sensors interrupt Banner's speech ("Sorry kids, you don't get to see my party trick") it shows that the energy source is in NYC. (Banner gets a quick <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OhCrap' title='/pmwiki/pmwiki.php/Main/OhCrap'>Oh, Crap!</a> moment.)</li><li> As soon as Hawkeye tells Stark that the Chitauri "can't bank worth a damn" and to "find a tight corner," JARVIS is already plotting his course to slalom through the buildings.</li><li> As Agent Hill is trying to shut down the rogue bird using her console, one can see that the WSC override code has locked her out of the system. Fury takes matters into his own hands.</li><li> The equipment monitoring Loki includes a heat signature detector, which shows Loki having a very low body temperature due to his being a Frost Giant.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FunnyBackgroundEvent' title='/pmwiki/pmwiki.php/Main/FunnyBackgroundEvent'>Funny Background Event</a>:<ul ><li> As the team is busy striking a badass pose, watch Tony crack a trademark smirk when Loki <a class='twikilink' href='/pmwiki/pmwiki.php/Main/INeedaFreakingDrink' title='/pmwiki/pmwiki.php/Main/INeedaFreakingDrink'>finally accepts his offer for a drink</a>.</li><li> The Shawarma Palace, in the second stinger, was given an "A" rating by the NY restaurant board, the certificate on the back wall when the <em>A</em>vengers are eating there.</li><li> During Bruce Banner's transformation into the Hulk <span class="spoiler" title="you can set spoilers visible by default on your profile" >aboard the Helicarrier</span>, a floor panel says "WARNING CONTENTS UNDER PRESSURE" with arrows pointing to Banner.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreudianExcuseIsNoExcuse' title='/pmwiki/pmwiki.php/Main/FreudianExcuseIsNoExcuse'>Freudian Excuse Is No Excuse</a>: When Loki is talking about living in his brother's shadow, Thor points out that sorting out family issues and seeking recompense for imagined slights is a slim excuse for conquering a planet.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FunWithAcronyms' title='/pmwiki/pmwiki.php/Main/FunWithAcronyms'>Fun with Acronyms</a>: S.H.I.E.L.D. <em>really</em> loves 'em:<div class='indent'>Joint Projects with NASA: <br /><strong>Advanced Dark Energy Physics Telescope (ADEPT)</strong> <br /><strong>Dark Energy Space Telescope (DESTINY)</strong> (OK, that one is stretching it) <br /><strong>Supernova Acceleration Probe Lensing (SNAP-L)</strong> <br /><strong>Potential Energy Group/Alternate Sources/United States (Project PEGASUS)</strong> (The research facility where the movie begins.)</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FunWithAlphabetSoup' title='/pmwiki/pmwiki.php/Main/FunWithAlphabetSoup'>Fun with Alphabet Soup</a>: The <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GagDub' title='/pmwiki/pmwiki.php/Main/GagDub'>Gag Dub</a> by <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/Coldmirror' title='/pmwiki/pmwiki.php/Creator/Coldmirror'>Coldmirror</a> has <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MakesAsMuchSenseInContext' title='/pmwiki/pmwiki.php/Main/MakesAsMuchSenseInContext'>this conversation:</a><div class='indent'><strong>Phil Coulson:</strong> Was ist eigentlich in Buchstabensuppe drin?<span class="notelabel" onclick="togglenote('note1idpx');"><sup>note&nbsp;</sup></span><span id="note1idpx" class="inlinefolder" isnote="true" onclick="togglenote('note1idpx');" style="cursor:pointer;font-size:smaller;display:none;"> What's actually in alphabet soup?</span></div><div class='indent'><strong>Steve Rogers:</strong> Ein Haufen bl&ouml;der Buchstaben.<span class="notelabel" onclick="togglenote('note296yq');"><sup>note&nbsp;</sup></span><span id="note296yq" class="inlinefolder" isnote="true" onclick="togglenote('note296yq');" style="cursor:pointer;font-size:smaller;display:none;"> A bunch of stupid letters.</span></div></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder2');">&nbsp;&nbsp;&nbsp;&nbsp;G&nbsp;</div><div id="folder2" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GenerationXerox' title='/pmwiki/pmwiki.php/Main/GenerationXerox'>Generation Xerox</a>: Captain America's initial dislike and butting heads with Tony Stark mirrors the relationship he had with his father, Howard. Although not as unrealistic as it's usually done, since Tony displays a lot of his father's quirks and attitude.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GeniusBruiser' title='/pmwiki/pmwiki.php/Main/GeniusBruiser'>Genius Bruiser</a>:<ul ><li> Captain America, both a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSoldier' title='/pmwiki/pmwiki.php/Main/SuperSoldier'>Super Soldier</a> and a brilliant strategist (or at least, a very competent field soldier), as the final scene shows.</li><li> Also Loki, who might not have the strength of Thor, but is still a badass Asgardian.</li><li> Tony and Bruce as well, being both scientific geniuses and capable in combat as well.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GenreBlind' title='/pmwiki/pmwiki.php/Main/GenreBlind'>Genre Blind</a>: Thor, yet again, is lured into a vulnerable spot by falling for Loki's trick of creating false images of himself.<div class='indent'><strong>Loki:</strong> Are you ever <em>not</em> going to fall for that?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GetAHoldOfYourselfMan' title='/pmwiki/pmwiki.php/Main/GetAHoldOfYourselfMan'>Get a Hold of Yourself, Man!</a>:<ul ><li> Steve does a subtle one to Tony when the latter, not having Cap's combat experience or training, is having a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicBSOD' title='/pmwiki/pmwiki.php/Main/HeroicBSOD'>Heroic BSoD</a> over <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's death</span>.</li><li> Thor gets one when he first confronts Hulk on the Helicarrier. He tries to get through to Banner. "Banner, try and think. We are not your enemy." Unfortunately, Hulk isn't in a mood to listen.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheGhost' title='/pmwiki/pmwiki.php/Main/TheGhost'>The Ghost</a>: Jane Foster is mentioned as working at a private observatory in Troms&oslash; and doesn't make a proper appearance in the movie at all.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GiantFlyer' title='/pmwiki/pmwiki.php/Main/GiantFlyer'>Giant Flyer</a>: The Leviathans, gigantic flying serpent-like creatures that carry hundreds of Chitauri soldiers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GlassesPull' title='/pmwiki/pmwiki.php/Main/GlassesPull'>Glasses Pull</a>: Done by Coulson in the first scene of the film. Especially notable because those are sunglasses and it is <em>during the night</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GlassyPrison' title='/pmwiki/pmwiki.php/Main/GlassyPrison'>Glassy Prison</a>: The S.H.I.E.L.D. Helicarrier contains one as a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TailorMadePrison' title='/pmwiki/pmwiki.php/Main/TailorMadePrison'>Tailor-Made Prison</a> for the Hulk but they are using it to hold Loki that can be dropped 30,000-odd feet out of the bottom of the ship at the push of a button. <span class="spoiler" title="you can set spoilers visible by default on your profile" >He escapes (surprise, surprise) and traps Thor in it, who escapes by smashing his hammer through the glass.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>A God Am I</a>:<ul ><li> Loki has developed a full-blown god complex &#8212; which is rather appropriate, given that, in the Marvel Cinematic Universe, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien' title='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien'>Asgardians</a> were mistaken for and <a class='twikilink' href='/pmwiki/pmwiki.php/Myth/NorseMythology' title='/pmwiki/pmwiki.php/Myth/NorseMythology'>worshiped as gods</a>.<div class='indent'><strong>Black Widow:</strong> They're basically gods. <br /><strong>Captain America:</strong> There's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RealMenLoveJesus' title='/pmwiki/pmwiki.php/Main/RealMenLoveJesus'>only one God</a>, ma'am, and I'm pretty sure He doesn't dress like that.</div></li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki later tries to give his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>A God Am I</a> speech to the Hulk. Let's just say he won't be doing that again anytime soon</span>.</li><li> Thor also starts slipping into this when everyone in the lab argument scene was succumbing to the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HatePlague' title='/pmwiki/pmwiki.php/Main/HatePlague'>discord field</a> that Loki's staff was giving off.<div class='indent'><strong>Thor:</strong> You people are so petty. And <em>tiny</em>.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GodwinsLaw' title='/pmwiki/pmwiki.php/Main/GodwinsLaw'>Godwin's Law</a>:<ul ><li> Invoked, appropriately enough, by Captain America, who compares Loki to the man he dealt with "the last time I was in Germany." He may technically have been referring to Red Skull rather than Hitler but they were both Nazi and he could be referring to both of them.</li><li> Same by the elderly German in the same scene who refuses to kneel.<div class='indent'><span class="spoiler" title="you can set spoilers visible by default on your profile" ><strong>Elderly man:</strong> There are <em>always</em> men like you.</span></div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GodzillaThreshold' title='/pmwiki/pmwiki.php/Main/GodzillaThreshold'>Godzilla Threshold</a>:<ul ><li> Fury states that the events of <em>Thor</em> proving humanity wasn't alone in the universe prompted S.H.I.E.L.D. to initiate Phase Two in the event that a hostile alien threat attacked Earth and crossed the threshold. Later, <span class="spoiler" title="you can set spoilers visible by default on your profile" >the WSC decides to go ahead and nuke Manhattan, in the event that the Avengers can't force the Chitauri back</span>. Also discussed by Loki and Nick Fury.<div class='indent'><strong>Loki:</strong> How desperate are you? That you call on such lost creatures to defend you? <br /><strong>Fury:</strong> How desperate am I? You threaten my world with war, you steal a force you can't hope to control, you talk about peace, and you kill 'cause it's fun. You have made me very desperate. You might not be glad that you did.</div></li><li> Also, in a more literal sense, Captain America telling Bruce Banner that now might be a good time to get angry.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoKartingWithBowser' title='/pmwiki/pmwiki.php/Main/GoKartingWithBowser'>Go-Karting with Bowser</a>: Tony pours himself a drink as he talks to Loki and even offers him one. May be a slight subversion, as he seems to be using this as a cover to discreetly put on bracelets that match his Iron Man suit. We subsequently see that these allow the suit to 'lock-on' to him after Loki throws him out of the tower.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodGunsBadGuns' title='/pmwiki/pmwiki.php/Main/GoodGunsBadGuns'>Good Guns, Bad Guns</a>:<ul ><li> S.H.I.E.L.D. agents are mostly armed with Glock pistols and M4A1 carbines. Bad guys use a mix and match collection of weapons that wouldn't look out of place in your average <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/ModernWarfare' title='/pmwiki/pmwiki.php/VideoGame/ModernWarfare'>MW2</a></em> match or, in the case of the aliens, high-tech blasters.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReveal' title='/pmwiki/pmwiki.php/Main/TheReveal'>The Reveal</a> of Phase 2 being <span class="spoiler" title="you can set spoilers visible by default on your profile" >the reverse engineering and development of weapons based on <a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier'>HYDRA technology</a></span> serves to sow quite a bit of discord amongst the heroes, partly due to them being left in the dark about this plan. Captain America and Thor in particular are very upset by this, for different reasons.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheGoodGuysAlwaysWin' title='/pmwiki/pmwiki.php/Main/TheGoodGuysAlwaysWin'>The Good Guys Always Win</a>: The Avengers band together and save New York City and the world with zero casualties to the team itself.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodIsNotDumb' title='/pmwiki/pmwiki.php/Main/GoodIsNotDumb'>Good Is Not Dumb</a>: Captain America, who despite his belief in doing the right thing and following orders, knows as much as anyone there's something insidious about S.H.I.E.L.D.'s "phase two" program.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodIsNotNice' title='/pmwiki/pmwiki.php/Main/GoodIsNotNice'>Good is Not Nice</a>: Almost everybody, as is often the case in the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelUniverse'>Marvel Universe</a>.<ul ><li> Tony Stark is of course a conceited and arrogant jackass who has problems with authority, but still a man who wants to make up for his past failures.</li><li> Thor still has shades of being a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BoisterousBruiser' title='/pmwiki/pmwiki.php/Main/BoisterousBruiser'>Boisterous Bruiser</a> that smashes first and asks questions later, but he follows his heart and demonstrates <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UndyingLoyalty' title='/pmwiki/pmwiki.php/Main/UndyingLoyalty'>Undying Loyalty</a> to his family, allies, and the Earth itself.</li><li> The Hulk is a rampaging id monster which smashes friend and foe alike during his temper tantrums, but just because he doesn't like you doesn't mean he won't protect you. Simultaneously, just because he fights alongside you for the same cause doesn't mean he's above sucker punching you later.</li><li> Hawkeye and Black Widow are assassins and former criminals who won't hesitate to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IDidWhatIHadToDo' title='/pmwiki/pmwiki.php/Main/IDidWhatIHadToDo'>do what needs to be done</a>. That doesn't stop the two of them from being loyal to each other and to their comrades.</li><li> And Nick Fury, who will employ every dirty trick he can think of to get the job done. Of course, the job is preserving worldwide freedom.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodIsNotSoft' title='/pmwiki/pmwiki.php/Main/GoodIsNotSoft'>Good Is Not Soft</a>: Steve Rogers is a nice, lovable guy and the only straight-up hero... but he'll throw you out of the Helicarrier to your death even if you're a brainwashed mook, or rip the arms off of invading Chitauri if it means protecting the innocent.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodIsOldFashioned' title='/pmwiki/pmwiki.php/Main/GoodIsOldFashioned'>Good Is Old-Fashioned</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Invoked' title='/pmwiki/pmwiki.php/Main/Invoked'>Invoked</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Discussed' title='/pmwiki/pmwiki.php/Main/Discussed'>discussed</a> several times, mostly regarding Captain America. The conclusion is that old-fashioned heroism is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustifiedTrope' title='/pmwiki/pmwiki.php/Main/JustifiedTrope'>is exactly what people need</a> during Earth's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DarkestHour' title='/pmwiki/pmwiki.php/Main/DarkestHour'>Darkest Hour</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoodOldWays' title='/pmwiki/pmwiki.php/Main/GoodOldWays'>Good Old Ways</a>: Being old-fashioned is Thor's and Captain America's trademark, although it's significantly <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Downplayed' title='/pmwiki/pmwiki.php/Main/Downplayed'>downplayed</a> compared to many of their previous portrayals.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GoshDangItToHeck' title='/pmwiki/pmwiki.php/Main/GoshDangItToHeck'>Gosh Dang It to Heck!</a>: Captain America, after <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man puts the nuke into the portal and falls back to Earth before the portal closes.</span><div class='indent'><strong>Steve:</strong> Son of a gun.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GracefulLoser' title='/pmwiki/pmwiki.php/Main/GracefulLoser'>Graceful Loser</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki would like that drink now, thank you.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GrandStaircaseEntrance' title='/pmwiki/pmwiki.php/Main/GrandStaircaseEntrance'>Grand Staircase Entrance</a>: Loki shows up at a museum gala in Stuttgart, Germany, strolling down a huge marble suitcase in an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassInANiceSuit' title='/pmwiki/pmwiki.php/Main/BadassInANiceSuit'>impeccable suit</a> to the soothing strains of a string quartet. Then, in time to the quartet, he whacks a guy with his staff and stabs another in the eye.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GratuitousRussian' title='/pmwiki/pmwiki.php/Main/GratuitousRussian'>Gratuitous Russian</a>: Black Widow speaks decent Russian (although not like a native she's supposed to be), while working undercover and being interrogated by a Russian general (who also has an accent, as he's played by a Polish actor). At the end of that scene, she exclaims "Bozhe moi!" ("My God!") after finding out that Coulson wants her to bring in Bruce Banner (the only person that terrifies her). Apparently, <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/ScarlettJohansson' title='/pmwiki/pmwiki.php/Creator/ScarlettJohansson'>Scarlett Johansson</a> had a voice coach train her to say Russian words.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GreaterScopeVillain' title='/pmwiki/pmwiki.php/Main/GreaterScopeVillain'>Greater-Scope Villain</a>: In <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>The Stinger</a> #1, the greatest villain of this story is revealed to be <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos, but he's otherwise uninvolved with the plot.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GreenAesop' title='/pmwiki/pmwiki.php/Main/GreenAesop'>Green Aesop</a>: This is central to the plot. The Tesseract is a clean power-source, Stark Tower runs on self-sustaining energy, and so on. Although, one of the key fights of the film ends up leveling half a forest. It also causes severe complications at the climax &#8212; self-sustaining energy is hard to just switch off.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GrenadeHotPotato' title='/pmwiki/pmwiki.php/Main/GrenadeHotPotato'>Grenade Hot Potato</a>: A group of alien Chitauri soldiers during the invasion of Manhattan have cornered a large number of civilians in a bank. From the second floor, one of them prepares to throw a powerful energy grenade below to kill dozens of people. They get interrupted by Captain America, however, who knocks the grenade out of the Chitauri's hand and starts brawling with them. As the counter on the bomb audibly winds down, one of the Chitauri frantically picks up the grenade and starts turning around to throw it at Cap &#8212; who jumps into the air and holds his shield between them. The Chitauri tries to throw the bomb after him &#8212; as much to hurt Cap as to just get the grenade away from himself &#8212; but he can't even manage to get it out of his hand before it blows up, enveloping the entire second floor of the bank in the explosion and blasting Cap out a window and onto a car below.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GrievousHarmWithABody' title='/pmwiki/pmwiki.php/Main/GrievousHarmWithABody'>Grievous Harm with a Body</a>: Early in the battle, Hulk snatches one of the Chitauri that are climbing a building and tosses it at its companions, knocking them off the wall.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GuileHero' title='/pmwiki/pmwiki.php/Main/GuileHero'>Guile Hero</a>: Black Widow's favorite interrogation technique is to make the bad guys feel powerful with her acting skills and then listen to what they let slip in their victorious rants.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GunsAkimbo' title='/pmwiki/pmwiki.php/Main/GunsAkimbo'>Guns Akimbo</a>: The Black Widow uses two glock pistols at the same time fighting the Chitauri.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GuysSmashGirlsShoot' title='/pmwiki/pmwiki.php/Main/GuysSmashGirlsShoot'>Guys Smash, Girls Shoot</a>: A rare gender inversion in the team of Hawkeye and Black Widow: while both are entirely capable in the other field (she's a crack shot and he can certainly deal damage hand-to-hand), Natasha is the superior martial artist while Clint is the finer marksman. The trope is still somewhat played straight in that while Natasha is certainly technically more skilled in hand-to-hand combat, Clint is still able to get the upper hand thanks to his superior brute strength, forcing Natasha to resort to more <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManBitesMan' title='/pmwiki/pmwiki.php/Main/ManBitesMan'>creative tactics</a> in order to defeat him (there's also the fact that she's trying to subdue him, not kill him, so she isn't going all-out).</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder3');">&nbsp;&nbsp;&nbsp;&nbsp;H&nbsp;</div><div id="folder3" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HairFlip' title='/pmwiki/pmwiki.php/Main/HairFlip'>Hair Flip</a>: Two of them in rapid succession during the climactic battle, first by Black Widow after letting herself drop on top of the Stark Tower and then by Loki after landing on the platform of the tower following Hawkeye's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrickArrow' title='/pmwiki/pmwiki.php/Main/TrickArrow'>Trick Arrow</a> exploding in his face.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HandSignals' title='/pmwiki/pmwiki.php/Main/HandSignals'>Hand Signals</a>: A Chitauri squadron leader uses the "hold fire" sign then a slashing motion to allow his troops to combine their barrage on The Hulk. Unfortunately for him, that just makes The Hulk angrier.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HannibalLecture' title='/pmwiki/pmwiki.php/Main/HannibalLecture'>Hannibal Lecture</a>:<ul ><li> Loki's <em>other</em> favorite tactic; he <em>loves</em> the chance to tear apart Black Widow from inside his cell.</li><li> This is also Black Widow's preferred method of interrogation: get captured, act vulnerable and nail her "captor" with information they felt comfortable enough to share with their "victim". <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>See directly above</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HardHead' title='/pmwiki/pmwiki.php/Main/HardHead'>Hard Head</a>:<ul ><li> Thor. At one point, he headbutts a fully-suited Iron Man, and the latter ends up in far more pain (this is assuming Thor felt any pain at all, which he may not have). If you look closely, you can even see that Iron Man's <em>helmet is dented.</em> Then, when Captain America breaks up the fight, he throws his shield to get their attention. It bounces off of Thor's bare forehead, and the way he reacts (or, really, <em>doesn't</em> react) makes it look like Cap's shield is made of Styrofoam. Sort of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustifiedTrope' title='/pmwiki/pmwiki.php/Main/JustifiedTrope'>justified</a> as Asgardians are much more durable than humans.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayingWithATrope' title='/pmwiki/pmwiki.php/Main/PlayingWithATrope'>Played straight</a> with Hawkeye. Despite being punched in the face and bashed against a metal railing hard enough to knock him out <em>and</em> <span class="spoiler" title="you can set spoilers visible by default on your profile" >break off Loki's mind-control</span>, when he wakes up later, he seems to only suffer from some headache/fatigue that clears out quickly. Mere hours later, he's back in full shape, fighting the Chitauri invasion as if nothing happened. In reality, he would have required hospitalisation (or at the very least serious medical attention) and a full recovery would have taken days, if not weeks.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HatePlague' title='/pmwiki/pmwiki.php/Main/HatePlague'>Hate Plague</a>: Not that the Avengers <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MoreThanMindControl' title='/pmwiki/pmwiki.php/Main/MoreThanMindControl'>weren't getting on each other's nerves before</a>, but just being in the room as Loki's mind-controlling scepter supernaturally raises the tensions to near-violence. When Banner starts getting angry, he picks up the scepter without realizing it. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Revision' title='/pmwiki/pmwiki.php/Main/Revision'>Revised</a> by Kevin Feige: Loki's scepter is made from <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Mind Stone, one of the Infinity Stones.</span> Furthermore, <a class='urllink' href='https://www.marvel.com/characters/loki/on-screen'>according<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> to Marvel's site, Loki himself was also affected by the scepter: it fueled his hatred of Thor and humans of Earth.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeadbuttingHeroes' title='/pmwiki/pmwiki.php/Main/HeadbuttingHeroes'>Headbutting Heroes</a>:<ul ><li> Thor and Tony's first encounter, when they fight over custody of Loki. Literally.</li><li> Stark and Rogers, which makes perfect sense considering their vastly different personalities. At one point, Rogers is <em>begging</em> Tony to put on his suit so they can fight one another.</li><li> All of them get into a verbal sparring match onboard the helicarrier.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeDidntMakeIt' title='/pmwiki/pmwiki.php/Main/HeDidntMakeIt'>He Didn't Make It</a>: Nick Fury says that "[the medics] called it" in reference to <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's death.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeelFaceTurn' title='/pmwiki/pmwiki.php/Main/HeelFaceTurn'>Heel–Face Turn</a>: Subverted. In the fight between Thor and Loki, Loki seems to start doing this, but eventually <span class="spoiler" title="you can set spoilers visible by default on your profile" >decides that "it's too late", stabs Thor and flees.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeHadAName' title='/pmwiki/pmwiki.php/Main/HeHadAName'>He Had a Name</a>: And it's <span class="spoiler" title="you can set spoilers visible by default on your profile" >Phil</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HelmetsAreHardlyHeroic' title='/pmwiki/pmwiki.php/Main/HelmetsAreHardlyHeroic'>Helmets Are Hardly Heroic</a>: A S.H.I.E.L.D. fighter pilot lifts the visor from his eyes for no apparent reason besides letting the audience get a better look at his fear when his attempt to subdue the Hulk fails.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HelpImStuck' title='/pmwiki/pmwiki.php/Main/HelpImStuck'>Help, I'm Stuck!</a>: When Bruce Banner along with Natasha Romanoff get thrown into another room due to an explosion, Romanoff’s leg is tightly stuck under metal poles. As she tries to free herself, Bruce starts turning into the Hulk. With a big yank, Black Widow was able free her leg.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroesGoneFishing' title='/pmwiki/pmwiki.php/Main/HeroesGoneFishing'>Heroes Gone Fishing</a>: In the second <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>Stinger</a> at the end <span class="spoiler" title="you can set spoilers visible by default on your profile" >the exhausted Avengers actually go to the shawarma joint that Tony mentioned and sit around a table eating in silence.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicBSOD' title='/pmwiki/pmwiki.php/Main/HeroicBSOD'>Heroic BSoD</a>: Romanov is reduced to hugging her knees and shivering after a near-death experience against The Hulk. She snaps out of it when a call to take down <span class="spoiler" title="you can set spoilers visible by default on your profile" >Flying Monkey Barton</span> is put out, though.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicNeutral' title='/pmwiki/pmwiki.php/Main/HeroicNeutral'>Heroic Neutral</a>: Banner doesn't want to get involved in the fighting, mostly to keep Hulk at bay, <span class="spoiler" title="you can set spoilers visible by default on your profile" >but he changes after some character development</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicSacrifice' title='/pmwiki/pmwiki.php/Main/HeroicSacrifice'>Heroic Sacrifice</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Discussed' title='/pmwiki/pmwiki.php/Main/Discussed'>Discussed</a> when Captain America thinks the other Avengers (particularly Iron Man, who's a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeAThirdOption' title='/pmwiki/pmwiki.php/Main/TakeAThirdOption'>Take a Third Option</a> kinda guy) aren't heroes at all because they're not willing to make the "sacrifice play", as he calls it. It's a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CallBack' title='/pmwiki/pmwiki.php/Main/CallBack'>Call-Back</a> to <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheFirstAvenger' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheFirstAvenger'>Captain America: The First Avenger</a></em> and how Cap wound up in the future in the first place.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's decision to face Loki alone. Even with the big anti-Destroyer gun, he seemed to think his death would inspire the Avengers to work together in order to avenge him</span>.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony eventually does attempt this, and while he <em>does</em> survive his heroic act of driving a nuke into space, he did it accepting that he may die</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicSafeMode' title='/pmwiki/pmwiki.php/Main/HeroicSafeMode'>Heroic Safe Mode</a>: Natasha assumes Bruce Banner is concentrating on doing good works, avoiding things like soldiers and guns, so he can minimize his stress at all times.<div class='indent'><strong>Bruce:</strong> <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/SubvertedTrope' title='/pmwiki/pmwiki.php/Main/SubvertedTrope'>Avoiding stress isn't the secret</a>.</em></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroInsurance' title='/pmwiki/pmwiki.php/Main/HeroInsurance'>Hero Insurance</a>: After everything's said and done, one of the many news reports tries to blame the Avengers for the damage to the city. Fury conveniently fails to ask where the Avengers were going after their mission is complete, precisely to avoid such questions.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroOfAnotherStory' title='/pmwiki/pmwiki.php/Main/HeroOfAnotherStory'>Hero of Another Story</a>: Every member has had his own movie or at least a minor role (or cameo) in a previous film.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroStoleMyBike' title='/pmwiki/pmwiki.php/Main/HeroStoleMyBike'>Hero Stole My Bike</a>: The Avengers snag a S.H.I.E.L.D. quinjet to take to the final battle. An agent mentions they are unauthorized, but Captain America quickly shuts him up.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HesitantSacrifice' title='/pmwiki/pmwiki.php/Main/HesitantSacrifice'>Hesitant Sacrifice</a>: Subverted. When <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony Stark</span> sacrifices himself to save New York, he does so completely calmly and professionally, without a fuss, hesitation, or even any kind of acknowledgement or last words other than trying (unsuccessfully) to call his girlfriend to say goodbye. However, the expression of sheer, naked terror on his face as he flies himself into space through the portal, where he knows he will die, effectively serves this trope's purpose anyway. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony survives just barely</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HiddenHeartOfGold' title='/pmwiki/pmwiki.php/Main/HiddenHeartOfGold'>Hidden Heart of Gold</a>: Tony Stark is pretty adamant that none of title characters other than Bruce ever find out he actually gives a damn. A prime example: when he's alone with Coulson, Tony's seen assuring him that all Coulson has to do is say the word and pick a weekend, and Tony will personally fly Coulson to Portland to make up with his cellist ex-girlfriend and "keep love alive!" Much later in the film, after <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> is killed, Steve cautiously asks Tony if he had a wife, to which Tony replies <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OrSoIHeard' title='/pmwiki/pmwiki.php/Main/OrSoIHeard'>"There was a cellist -- I think"</a> and then proceeds to snort derisively and fumblingly <span class="spoiler" title="you can set spoilers visible by default on your profile" >call Coulson an idiot for trying to take on Loki</span> while turning away so Steve can't see the tears in his eyes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HighCollarOfDoom' title='/pmwiki/pmwiki.php/Main/HighCollarOfDoom'>High Collar of Doom</a>: Loki sports one which, while relatively subdued, is larger than in <em>Thor</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HobbesWasRight' title='/pmwiki/pmwiki.php/Main/HobbesWasRight'>Hobbes Was Right</a>: Loki holds this belief about humanity:<div class='indent'><strong>Loki:</strong> <em>[to Thor]</em> The humans slaughter each other in droves while you idly fret. I mean to <em>rule</em> them and why should I not?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HoistByHisOwnPetard' title='/pmwiki/pmwiki.php/Main/HoistByHisOwnPetard'>Hoist by His Own Petard</a>:<ul ><li> Thor tries to fry Iron Man with a bolt of lightning. Though it causes some damage, it also charges the armor to quadruple capacity, which Tony uses immediately to blast Thor with a supercharged repulsor discharge.</li><li> In the movie <em>Thor</em>, Loki took control of the Destroyer and sent it to Earth to get rid of Thor. It also did a number on Agent Coulson's men. It was trashed and its remains were picked up by S.H.I.E.L.D. Fast forward to the present, and Loki is blasted through a bulkhead by an Earth-made BFG built from Destroyer technology, wielded by Agent Coulson. It doesn't kill or seriously harm Loki, but it probably hurt his pride at least a little.</li><li> Loki decides to <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/AllYourBaseAreBelongToUs' title='/pmwiki/pmwiki.php/Main/AllYourBaseAreBelongToUs'>hijack Stark Tower, and its arc reactor</a> to power the portal. However, this gives Tony an opportunity to switch out the Mark VI suit, which had been severely damaged in battle, and get into the Mark VII suit. If the battle had been held <em>anywhere</em> else, Tony would not have had that opportunity, and would have been significantly less effective in battle.</span></li><li> Black Widow uses a fallen Chitauri weapon to use against them at one point, and is actually very proficient at it.</li><li> Loki's scepter <span class="spoiler" title="you can set spoilers visible by default on your profile" >serves as a tool for shutting down the portal to the other dimension</span>.</li><li> It was S.H.I.E.L.D. screwing around with the Tesseract that sets the whole plot in motion. But, in a bit of brilliance from <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a>, it is <em>also</em> the portal being generated by the Tesseract itself that allows Iron Man to deposit a nuke right into Chitauri HQ, effectively stopping their invasion cold (and possibly wiping out their army altogether).</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HoistHeroOverHead' title='/pmwiki/pmwiki.php/Main/HoistHeroOverHead'>Hoist Hero over Head</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvertedTrope' title='/pmwiki/pmwiki.php/Main/InvertedTrope'>Inverted</a>; Thor (a hero) does this to Loki (a villain) during their fight in New York.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HoldingTheFloor' title='/pmwiki/pmwiki.php/Main/HoldingTheFloor'>Holding the Floor</a>:<ul ><li> Fury attempts it against Loki during the opening sequence, as the remaining energy from the Tesseract threatens to make the underground facility collapse.</li><li> Later, Tony Stark's borderline <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Cloudcuckoolander' title='/pmwiki/pmwiki.php/Main/Cloudcuckoolander'>Cloudcuckoolander</a> monologue when he first arrives on the Helicarrier <span class="spoiler" title="you can set spoilers visible by default on your profile" >successfully distracts the group while he slips his hacking device onto a nearby computer</span>.</li><li> Also, Tony's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>Badass Boast</a> to Loki in Stark Tower is undoubtedly at least in part to stall for time while Jarvis preppes his Mark VII Suit. Loki notices that Stark is stalling but mistakenly assumes that he is just trying to prolong the arrival of the Chitauri army.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HollywoodTactics' title='/pmwiki/pmwiki.php/Main/HollywoodTactics'>Hollywood Tactics</a>:<ul ><li> For what is explicitly an army bent on conquest, the Chitauri make very little effort to do anything except fly around and blow stuff up. They don't seek out enemy emplacements or forces, they don't attempt to capture any beach-heads, and some of them take hostages for no apparent reason. They act more like super-powered rioters than an army that intends to capture and hold territory.</li><li> Loki choosing to site the main battle in New York City is also an example of this. Cities are much harder to capture or hold than open territory, and New York, with its many skyscrapers, limited sight lines and maze of underground tunnels, is harder than most (though that's justified by his pathological need to be seen to win by as many people as possible).</li><li> Averted by Captain America &#8212; he orders Iron Man to set a perimeter, Hawkeye to act as spotter, Thor to close the gate to prevent more enemy coming through, and while his command to Hulk isn't the greatest, it's probably the best tactical use one can make of an enormous green rage monster.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HomeFieldAdvantage' title='/pmwiki/pmwiki.php/Main/HomeFieldAdvantage'>Home Field Advantage</a>: The film's finale takes place in New York City. Captain America, being a native New Yorker, (even if <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater' title='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater'>70 years</a> out of his native <em>time</em>), is able to quickly formulate battle plans and issue orders as the battle develops.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HonorBeforeReason' title='/pmwiki/pmwiki.php/Main/HonorBeforeReason'>Honor Before Reason</a>: Captain America, while retaining his core sense of honor, averts this. Despite his initial insistence to Tony and Bruce that they should trust in their orders, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Cap does take their skepticism seriously, and does some off-book investigating of his own. He ends up <em>beating Tony to the punch</em> in calling out Fury</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HoodHopping' title='/pmwiki/pmwiki.php/Main/HoodHopping'>Hood Hopping</a>: Cap hops along a few car roofs while avoiding explosions.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HorrifyingHero' title='/pmwiki/pmwiki.php/Main/HorrifyingHero'>Horrifying Hero</a>: The Hulk may ultimately fight against the villains, but he is very much a monster that strikes terror into the bravest of men. Even the normally <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStoic' title='/pmwiki/pmwiki.php/Main/TheStoic'>expressionless</a> Black Widow trembles in fear whenever the Hulk threatens to come out and when he first emerges, Bruce Banner is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TransformationHorror' title='/pmwiki/pmwiki.php/Main/TransformationHorror'>writhing in pain as it sounds like his bones are breaking while a monster takes over his body</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HowDareYouDieOnMe' title='/pmwiki/pmwiki.php/Main/HowDareYouDieOnMe'>How Dare You Die on Me!</a>:<ul ><li> Tony takes <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Phil Coulson</span>'s Heroic Sacrifice <em>really</em> badly, calling him an idiot for facing Loki alone and hopelessly outmatched.</li><li> Also when the Hulk roars Tony back to consciousness.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>Hulking Out</a>: It is the Hulk, after all.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumanPopsicle' title='/pmwiki/pmwiki.php/Main/HumanPopsicle'>Human Popsicle</a>: Unlike <em>Captain America: The First Avenger</em>, we do get to see Steve's frozen fate, which is briefly shown in a series of flashbacks that he has while working out.<div class='indent'><strong>Tony Stark:</strong> Yeah, you may have missed out a few things, doing time as a Cap-sicle.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumansAreInsects' title='/pmwiki/pmwiki.php/Main/HumansAreInsects'>Humans Are Insects</a>: Discussed:<div class='indent'><strong>Nick Fury:</strong> We have no quarrel with your people. <br /><strong>Loki:</strong> An ant has no quarrel with a boot.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumansAreWarriors' title='/pmwiki/pmwiki.php/Main/HumansAreWarriors'>Humans Are Warriors</a>:<ul ><li> Tony invokes this when talking with Loki, that even if he <em>wins</em>, humanity won't simply lie down and submit.<div class='indent'><strong>Tony:</strong> You're missing the point &#8212; there's no throne, there is <em>no</em> version of this where you come out on top. <em>Maybe</em> your army comes, and <em>maybe</em> it's too much for us, but it's all on <em>you</em>... <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>'Cause if we can't protect the Earth, you can be</a> <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>damn well sure</a></em> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>we'll avenge it.</a></div></li><li> After the Avengers repel the Chitauri invasion, the Other informs his master that humans are not a species to be messed with.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumiliationConga' title='/pmwiki/pmwiki.php/Main/HumiliationConga'>Humiliation Conga</a>: Over the course of the movie every single Avenger and Agent Coulson manage to land at least one good hit on <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki</span>, with the amount of them increasing by the finale.<ul ><li> Captain America <span class="spoiler" title="you can set spoilers visible by default on your profile" >takes Loki in one on one combat. Though he manages to throw in a few quips and put up a decent fight, he's on the losing end before Iron Man shows up.</span></li><li> Nick Fury <span class="spoiler" title="you can set spoilers visible by default on your profile" >turns Loki's previous retort about how "an ant has no quarrel with a boot" on its head by locking him in an enormous cage and declaring himself the "boot".</span></li><li> Black Widow <span class="spoiler" title="you can set spoilers visible by default on your profile" >lets Loki go into full <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HannibalLecture' title='/pmwiki/pmwiki.php/Main/HannibalLecture'>Hannibal Lecture</a> mode and allows him to think he's reduced her to tears... before revealing she was just waiting for him to give his real plan away. "Thank you for your cooperation."</span></li><li> Coulson <span class="spoiler" title="you can set spoilers visible by default on your profile" >is fatally stabbed by Loki, but bravely tells him that Loki is doomed to fail. As the latter tries to retort, Coulson shoots him through the wall.</span></li><li> Iron Man <span class="spoiler" title="you can set spoilers visible by default on your profile" >likewise has a lecture battle with Loki, then is immune to his attacks. Both succeed, as Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Plan' title='/pmwiki/pmwiki.php/Main/Plan'>plan</a> follows through and Tony is only stalling, but Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainousBreakdown' title='/pmwiki/pmwiki.php/Main/VillainousBreakdown'>Villainous Breakdown</a> begins.</span><ul ><li> It can be argued that <span class="spoiler" title="you can set spoilers visible by default on your profile" ><em>JARVIS</em> also got a shot at Loki here, if the Mark VII's deployment-pod sideswiping him on its way out the window wasn't just a coincidence. Given how precisely the AI pilots other suits in <em>Iron Man 3</em>, it was probably deliberate.</span></li></ul></li><li> Thor <span class="spoiler" title="you can set spoilers visible by default on your profile" >is outsmarted by Loki earlier but when the two fight in the climax, he maintains the upper hand, forcing Loki to flee</span>.</li><li> Hawkeye <span class="spoiler" title="you can set spoilers visible by default on your profile" >fires an arrow at Loki's glider, which the latter <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArrowCatch' title='/pmwiki/pmwiki.php/Main/ArrowCatch'>catches in midair</a> before it explodes and sends him flying.</span></li><li> The Hulk <span class="spoiler" title="you can set spoilers visible by default on your profile" >grabs Loki mid-<a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilGloating' title='/pmwiki/pmwiki.php/Main/EvilGloating'>monologue</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbStompBattle' title='/pmwiki/pmwiki.php/Main/CurbStompBattle'>beats him into the ground</a>. Many times, in rapid succession, with one brief pause before continuing.</span></li><li> When confronted with the entire team together, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki doesn't even bother resisting.</span><div class='indent'><em>"<a class='urllink' href='https://www.youtube.com/watch?v=SnaMwQ1Xsis'>Has everyone here had a chance to talk to, and beat up<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki</span>?"</em></div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HurtingHero' title='/pmwiki/pmwiki.php/Main/HurtingHero'>Hurting Hero</a>:<ul ><li> Captain America, as seen in his first onscreen appearance. He's seventy years out of his own time, everything he's ever known is gone, and nothing in the world makes sense to him anymore. Also, super-serum or not, the war took its toll on him. A deleted scene shows how out of time he is as he tries to wander around modern New York City. Whedon cut it because a) it made Cap's character too complicated (by throwing him out of time <em>and</em> giving him PTSD), and b) because the line of punching bags in the gym is more than enough to show <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShellShockedVeteran' title='/pmwiki/pmwiki.php/Main/ShellShockedVeteran'>exactly what he's going through anyway</a>.</li><li> Also Bruce Banner. Though he tries to hide it through sarcasm. The "secret" to how he controls his transformation pretty much spells out much this trope applies.</li><li> Hawkeye, especially <span class="spoiler" title="you can set spoilers visible by default on your profile" >after being freed from his brainwashing</span>. If he's lucky, he's going to be having nightmares for a while.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HydePlaysJekyll' title='/pmwiki/pmwiki.php/Main/HydePlaysJekyll'>Hyde Plays Jekyll</a>: Bruce Banner briefly pretends to be on the edge of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnstoppableRage' title='/pmwiki/pmwiki.php/Main/UnstoppableRage'>Unstoppable Rage</a> to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Troll' title='/pmwiki/pmwiki.php/Main/Troll'>mess with</a> Black Widow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HypocriticalHumor' title='/pmwiki/pmwiki.php/Main/HypocriticalHumor'>Hypocritical Humor</a>:<ul ><li> "You people are so petty... <em>and tiny</em>." And:<div class='indent'><strong>Thor:</strong> Have care how you speak! Loki is beyond reason, but <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThickerThanWater' title='/pmwiki/pmwiki.php/Main/ThickerThanWater'>he is of Asgard, and he's my brother</a>. <br /><strong>Natasha Romanoff:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AxCrazy' title='/pmwiki/pmwiki.php/Main/AxCrazy'>He killed eighty people in two days.</a> <br /><strong>Thor:</strong> <em>[<a class='twikilink' href='/pmwiki/pmwiki.php/Main/Beat' title='/pmwiki/pmwiki.php/Main/Beat'>hesitantly</a>]</em> ...He's adopted.</div></li><li> In a meta-example, an interviewed New Yorker (played by Stan Lee) scoffs at the idea of superheroes existing in New York.</li></ul></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder4');">&nbsp;&nbsp;&nbsp;&nbsp;I&nbsp;</div><div id="folder4" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IAmNotLeftHanded' title='/pmwiki/pmwiki.php/Main/IAmNotLeftHanded'>I Am Not Left-Handed</a>:<ul ><li> Bruce Banner's secret to keeping his Hulk Mode on standby is to <span class="spoiler" title="you can set spoilers visible by default on your profile" >stay just angry enough... <em>all the time</em></span>.</li><li> Once again, Thor initially holds back when fighting Loki, not wanting to hurt his little brother. And once again, Loki pushes Thor too far and is promptly stomped. Director Joss Whedon even described this point as Thor "finally having enough of Loki's shit."</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ICannotSelfTerminate' title='/pmwiki/pmwiki.php/Main/ICannotSelfTerminate'>I Cannot Self-Terminate</a>: Bruce Banner, literally. He mentions that he tried to commit suicide by <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AteHisGun' title='/pmwiki/pmwiki.php/Main/AteHisGun'>orally shooting himself</a> once, but he went Hulk and spat the bullet out.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ISurrenderSuckers' title='/pmwiki/pmwiki.php/Main/ISurrenderSuckers'>I Surrender, Suckers</a>: Loki does this when the Avengers capture him for the first time, only for him to subtly manipulate all of them and cause conflict among the heroes (and essentially make them all fight each other.)</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IcyBlueEyes' title='/pmwiki/pmwiki.php/Main/IcyBlueEyes'>Icy Blue Eyes</a>:<ul ><li> A visible effect of Loki's brainwashing. Everyone under its influence is suitably cold and ruthless, except for Selvig who is more "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/ForScience' title='/pmwiki/pmwiki.php/Main/ForScience'>For Science!</a>".</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos has them as well</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IfItSwimsItFlies' title='/pmwiki/pmwiki.php/Main/IfItSwimsItFlies'>If It Swims, It Flies</a>: The Helicarrier can serve as both an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier' title='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier'>Airborne Aircraft Carrier</a> and a regular aircraft carrier, the former presumably meant for covert operations since it comes with an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvisibilityCloak' title='/pmwiki/pmwiki.php/Main/InvisibilityCloak'>Invisibility Cloak</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IfJesusThenAliens' title='/pmwiki/pmwiki.php/Main/IfJesusThenAliens'>If Jesus, Then Aliens</a>: Captain America. While he refuses to believe Thor and Loki are gods ("There's only one God, ma'am, and I'm pretty sure He doesn't dress like that."), he accepts that they're magic-using aliens without question. Of course, he has seen the very-unscientific powers of the Tesseract first-hand, so it's not that much of a stretch for him. Steve is technically correct, as well, given that in the movie universe, the Asgardians are supposed to be <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien' title='/pmwiki/pmwiki.php/Main/SufficientlyAdvancedAlien'>Sufficiently Advanced Aliens</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IgnoredEpiphany' title='/pmwiki/pmwiki.php/Main/IgnoredEpiphany'>Ignored Epiphany</a>: When the Chitauri are attacking New York, Thor tries for a last time to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LastSecondChance' title='/pmwiki/pmwiki.php/Main/LastSecondChance'>approach his brother</a>, trying to make him aware of the destruction and the hypocrisy of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill' title='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill'>his plan</a>. For a short moment, Loki seems genuinely shocked, telling Thor that "it's too late to stop it". But just when Thor responds that <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HopeSpot' title='/pmwiki/pmwiki.php/Main/HopeSpot'>they can do it together</a>, Loki <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RedemptionRejection' title='/pmwiki/pmwiki.php/Main/RedemptionRejection'>stabs him and flees</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IHaveNoSon' title='/pmwiki/pmwiki.php/Main/IHaveNoSon'>I Have No Son!</a>: Subverted and Double Subverted by Thor with regards to his adoptive brother Loki. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HilarityEnsues' title='/pmwiki/pmwiki.php/Main/HilarityEnsues'>Hilarity Ensues</a>.<div class='indent'><strong>Bruce Banner:</strong> I don't think we should be focusing on Loki. That guy's brain is a bag full of cats. You can smell crazy on him. <br /><strong>Thor:</strong> Have care how you speak. Loki is beyond reason, but <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThickerThanWater' title='/pmwiki/pmwiki.php/Main/ThickerThanWater'>he is of Asgard, and he is my brother.</a> <br /><strong>Black Widow:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AxCrazy' title='/pmwiki/pmwiki.php/Main/AxCrazy'>He killed eighty people in two days.</a> <br /><strong>Thor:</strong> <em>[<a class='twikilink' href='/pmwiki/pmwiki.php/Main/Beat' title='/pmwiki/pmwiki.php/Main/Beat'>hesitantly</a>]</em> ...He's adopted.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IKnowYoureInThereSomewhereFight' title='/pmwiki/pmwiki.php/Main/IKnowYoureInThereSomewhereFight'>"I Know You're in There Somewhere" Fight</a>: Thor attempts this with Hulk the first time. Amusingly, the fact that Hulk sucker-punches Thor later on shows that the only thing "in there somewhere" was "the other guy".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImmuneToMindControl' title='/pmwiki/pmwiki.php/Main/ImmuneToMindControl'>Immune to Mind Control</a>: Loki tries to brainwash Tony Stark after he has had enough of Tony's attempt to distract him with an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilWillFail' title='/pmwiki/pmwiki.php/Main/EvilWillFail'>Evil Will Fail</a> lecture. This hilariously fails when his mind control scepter just does a *ping* and shuts down after coming into contact with the arc reactor in Stark's chest. He's so baffled that he even gives it a second try. Still no dice.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImpaledWithExtremePrejudice' title='/pmwiki/pmwiki.php/Main/ImpaledWithExtremePrejudice'>Impaled with Extreme Prejudice</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> is shuffled out of the picture courtesy of a spear through the back from Loki. Believe it or not, the film was actually rated R <a class='urllink' href='http://screencrush.com/avengers-rated-r/'>because of this scene<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>, at least before minor edits were made.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImportedAlienPhlebotinum' title='/pmwiki/pmwiki.php/Main/ImportedAlienPhlebotinum'>Imported Alien Phlebotinum</a>:<ul ><li> The Tesseract in general.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >The remains of the Destroyer</span>, as well.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImpossiblyCoolWeapon' title='/pmwiki/pmwiki.php/Main/ImpossiblyCoolWeapon'>Impossibly Cool Weapon</a>: Front and center (and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvokedTrope' title='/pmwiki/pmwiki.php/Main/InvokedTrope'>Invoked</a> by Method Studios <a class='urllink' href='http://www.methodstudios.com/work/the-avengers'>in the main-on-end credits<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>).<ul ><li> Captain America's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfIndestructium' title='/pmwiki/pmwiki.php/Main/MadeOfIndestructium'>Mighty</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LuckilyMyShieldWillProtectMe' title='/pmwiki/pmwiki.php/Main/LuckilyMyShieldWillProtectMe'>Shield</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Myth/NorseMythology' title='/pmwiki/pmwiki.php/Myth/NorseMythology'>Mj&ouml;lnir</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheMightyThor' title='/pmwiki/pmwiki.php/ComicBook/TheMightyThor'>Thor</a>'s <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DropTheHammer' title='/pmwiki/pmwiki.php/Main/DropTheHammer'>hammer</a>.</li><li> The <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/IronMan' title='/pmwiki/pmwiki.php/ComicBook/IronMan'>Iron Man</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoweredArmor' title='/pmwiki/pmwiki.php/Main/PoweredArmor'>armor</a>.</li><li> Coulson's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BFG' title='/pmwiki/pmwiki.php/Main/BFG'>BFG</a> which was created from the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Magitek' title='/pmwiki/pmwiki.php/Main/Magitek'>Destroyer</a> in <em>Thor</em>. Now given the name "Coulson's Revenge" in the <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/MarvelAvengersAlliance' title='/pmwiki/pmwiki.php/VideoGame/MarvelAvengersAlliance'>Marvel: Avengers Alliance</a></em> game.</li><li> Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControl' title='/pmwiki/pmwiki.php/Main/MindControl'>mind-controlling scepter</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Hawkeye' title='/pmwiki/pmwiki.php/ComicBook/Hawkeye'>Hawkeye</a>'s <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrickArrow' title='/pmwiki/pmwiki.php/Main/TrickArrow'>Trick Arrows</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/BlackWidow' title='/pmwiki/pmwiki.php/ComicBook/BlackWidow'>Black Widow</a>'s <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StaticStunGun' title='/pmwiki/pmwiki.php/Main/StaticStunGun'>taser bracelets</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk' title='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk'>Hulk.</a></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImprobableAimingSkills' title='/pmwiki/pmwiki.php/Main/ImprobableAimingSkills'>Improbable Aiming Skills</a>:<ul ><li> Hawkeye &#8212; as the name implies &#8212; carries this trope far beyond the Hollywood standard. He manages to land a USB arrow into a computer, exploit 100-mph winds to curve an explosive arrow around a ship to hit from the other side, and hits speeding enemy hovercraft unerringly. He takes down one of them simply by anticipating its flight path, while looking in the <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/OffhandBackhand' title='/pmwiki/pmwiki.php/Main/OffhandBackhand'>opposite direction.</a></em> In one scene, Hawkeye is targeting some Chitauri chasing after Iron Man.</li><li> Nick Fury lands a hit on the engine of a jet taking off, with an <em>unguided RPG launcher</em>, using <em>iron sights</em>, with <em>one eye</em>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ImprovisedLightningRod' title='/pmwiki/pmwiki.php/Main/ImprovisedLightningRod'>Improvised Lightning Rod</a>: Thor uses the Chrysler building as a makeshift lightning rod to attack the Chitauri aliens and Leviathians.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InCaseYouForgotWhoWroteIt' title='/pmwiki/pmwiki.php/Main/InCaseYouForgotWhoWroteIt'>In Case You Forgot Who Wrote It</a>: The movie's full title is <em>Marvel's The Avengers</em>, probably to help avoid confusion with the <a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheAvengers1998' title='/pmwiki/pmwiki.php/Film/TheAvengers1998'>1998 film</a> based on the <a class='twikilink' href='/pmwiki/pmwiki.php/Series/TheAvengers1960s' title='/pmwiki/pmwiki.php/Series/TheAvengers1960s'>unrelated series of the same name</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/INeedAFreakingDrink' title='/pmwiki/pmwiki.php/Main/INeedAFreakingDrink'>I Need a Freaking Drink</a>:<ul ><li> When Tony first confronts Loki to "threaten" him, part of his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CasualDangerDialogue' title='/pmwiki/pmwiki.php/Main/CasualDangerDialogue'>Casual Danger Dialogue</a> is, "Sure you don't want a drink? <em>I'm</em> having one."</li><li> Loki decides to take Tony up on his offer of a drink after <span class="spoiler" title="you can set spoilers visible by default on your profile" >he's defeated and cornered by the entire team</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InherentlyFunnyWords' title='/pmwiki/pmwiki.php/Main/InherentlyFunnyWords'>Inherently Funny Words</a>: Shawarma.<div class='indent'><strong>Tony:</strong> I don't know what it is, but I wanna try it.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InNameOnly' title='/pmwiki/pmwiki.php/Main/InNameOnly'>In Name Only</a>: The alien invaders are called the Chitauri. In the comics, the Chitauri are the Ultimate Marvel version of 616 Marvel's Skrulls, shape-shifting aliens whose modus operandi is impersonation and infiltration (see the Skrull-centric storyline <em><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/SecretInvasion' title='/pmwiki/pmwiki.php/ComicBook/SecretInvasion'>Secret Invasion</a></em>). The movie Chitauri take a blunt <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AttackAttackAttack' title='/pmwiki/pmwiki.php/Main/AttackAttackAttack'>Attack! Attack! Attack!</a> approach. They do resemble heavily-armored Skrulls, however. The movie rights to Skrulls were technically tied to the Fantastic Four, and therefore owned by Fox at the time (prior to its eventual buyout by Disney in 2019). The choice to use the Ultimate equivalent is a conscious use of this trope.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InsignificantLittleBluePlanet' title='/pmwiki/pmwiki.php/Main/InsignificantLittleBluePlanet'>Insignificant Little Blue Planet</a>: This is the Chitauri's <span class="spoiler" title="you can set spoilers visible by default on your profile" >and Thanos'</span> attitude towards Earth, until the Avengers prove them wrong.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InsistentTerminology' title='/pmwiki/pmwiki.php/Main/InsistentTerminology'>Insistent Terminology</a>: Bruce Banner does not turn into the Hulk. He turns into "the other guy". All the other characters continue to refer to his alter ego as the Hulk, however, and Bruce himself slips up once before correcting himself. This is likely <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpeakOfTheDevil' title='/pmwiki/pmwiki.php/Main/SpeakOfTheDevil'>Speak of the Devil</a> &#8212; Banner doesn't want to give the Hulk any extra power.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InspirationalMartyr' title='/pmwiki/pmwiki.php/Main/InspirationalMartyr'>Inspirational Martyr</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >S.H.I.E.L.D. agent Phil Coulson</span>'s brutal murder by Loki moves the superheroes to finally come together as a real team, as well as giving new meaning to their codename. Nick Fury even tells Rogers and Stark that <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> died believing in the idea of the Avengers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InstantAllegianceArtifact' title='/pmwiki/pmwiki.php/Main/InstantAllegianceArtifact'>Instant Allegiance Artifact</a>: The scepter Loki uses to brainwash <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye and Erik Selvig</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InstantWinCondition' title='/pmwiki/pmwiki.php/Main/InstantWinCondition'>Instant-Win Condition</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Apparently, Chitauri all die if you blow up their command ship. The leading theory is that the Chitauri are somehow linked to their home-ship, similar to the Buggers in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Literature/EndersGame' title='/pmwiki/pmwiki.php/Literature/EndersGame'>Ender's Game</a></em>. And since the Leviathan ship seemed to be biologically related to the Chitauri themselves, this is entirely plausible</span>. Joss Whedon notes in the commentary that he didn't particularly <em>want</em> to do this, but the movie was already two hours long and it was easier.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InTheBack' title='/pmwiki/pmwiki.php/Main/InTheBack'>In the Back</a>: Loki stabs <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> from behind with his scepter.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvisibilityCloak' title='/pmwiki/pmwiki.php/Main/InvisibilityCloak'>Invisibility Cloak</a>: A partial one. The underbelly of the S.H.I.E.L.D. Helicarrier displays the sky above the ship, making it invisible to ground-based observation.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvokedTrope' title='/pmwiki/pmwiki.php/Main/InvokedTrope'>Invoked Trope</a>: A favorite of Natasha's; she twice sets herself up as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DistressedDamsel' title='/pmwiki/pmwiki.php/Main/DistressedDamsel'>a weak, vulnerable girl who's in over her head</a> to get intel she needs out of her antagonists. It works both times.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IronButtmonkey' title='/pmwiki/pmwiki.php/Main/IronButtmonkey'>Iron Butt-Monkey</a>: While Loki acts the part of an intimidating villain commendably, he gets many a moment of glory and gloating snatched from him by <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's last shot, Hawkeye's surprise bomb arrow, and Hulk beating him like a rag doll.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IronicEcho' title='/pmwiki/pmwiki.php/Main/IronicEcho'>Ironic Echo</a>:<ul ><li> In Tony's introduction scene Tony is trying to convince Pepper to take some credit for the Stark Tower idea.<div class='indent'><strong>Tony:</strong> Give yourself 12%. <br /><em>[a bit later, when Agent Coulson interrupts them]</em> <br /><strong>Tony:</strong> I thought we were having a moment <br /><strong>Pepper:</strong> I was having 12% of a moment.</div></li><li> When Loki first appears, Fury tries to defuse the situation by saying "We have no quarrel with your people." Loki responds "An ant has no quarrel with a boot." When Loki is captive on the Helicarrier, Fury says that one button is all it will take to jettison the cell, Loki included, and remarks (pointing at Loki) "Ant..." (points at button) "...Boot."</li><li> "Well, let me know if 'real power' wants a magazine or something", in response to Loki's boasts.</li><li> A more serious one: while ferrying Captain Rogers to the Helicarrier, Agent Coulson says that "Maybe people need 'old-fashioned'" in response to Captain America's traditional suit, but clearly referring to the ideals Captain America represents. Later, at the team's darkest moment, Fury suggests that believing in heroes might be "an old-fashioned notion."</li><li> Tony sarcastically remarking that Coulson's first name is "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/LastNameBasis' title='/pmwiki/pmwiki.php/Main/LastNameBasis'>Agent</a>", then later, <span class="spoiler" title="you can set spoilers visible by default on your profile" >"His name was Phil." Bonus points for it being said both times in the same room</span>.</li><li> "Put on the suit." Takes on a new meaning when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Banner swiftly and painlessly transforms into The Hulk</span>.</li><li> And earlier when Rogers is challenging Tony Stark to a fight. Once stuff starts blowing up, he says it again completely seriously.</li><li> In Loki's original <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>A God Am I</a> / <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a> in Stuttgart, he says it's in humanity's nature to be subjugated. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Later a dying Phil Coulson tells Loki he will be defeated, since it's in his nature.</span></li><li> Captain America tells a police sergeant to put people in the buildings and cordon off the area and then the police sergeant asks why he should follow his orders. Some Chitauri attack and Captain America beats the tar out of them. The sergeant then orders his men to do exactly what Captain America said.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ItsPersonal' title='/pmwiki/pmwiki.php/Main/ItsPersonal'>It's Personal</a>: Tony theorizes that <span class="spoiler" title="you can set spoilers visible by default on your profile" >this was Loki's purpose in attacking the Helicarrier while getting everyone to fight amongst themselves</span>. He later congratulates Loki for making it this, as he's successfully managed to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NiceJobFixingItVillain' title='/pmwiki/pmwiki.php/Main/NiceJobFixingItVillain'>piss off every one of the Avengers</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ItsTheOnlyWayToBeSure' title='/pmwiki/pmwiki.php/Main/ItsTheOnlyWayToBeSure'>It's The Only Way To Be Sure</a>: The World Security Council decides to stop the Chitauri threat by <span class="spoiler" title="you can set spoilers visible by default on your profile" >nuking Manhattan <em>while the Avengers are still fighting there</em>. Fury dismisses this as "a stupid-ass idea." In fact, if he weren't a hands-on boss with a rocket launcher, there'd have been two incoming nukes and things might have gone very badly</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IveComeTooFar' title='/pmwiki/pmwiki.php/Main/IveComeTooFar'>I've Come Too Far</a>: Loki says this word for word to Fury when Fury tries to convince him not to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlienInvasion' title='/pmwiki/pmwiki.php/Main/AlienInvasion'>declare war on Earth</a>.<div class='indent'><strong>Fury:</strong> This doesn't have to get any messier. <br /><strong>Loki:</strong> Of course it does. I've come too far for anything else.</div></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder5');">&nbsp;&nbsp;&nbsp;&nbsp;J&nbsp;</div><div id="folder5" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JekyllAndHyde' title='/pmwiki/pmwiki.php/Main/JekyllAndHyde'>Jekyll & Hyde</a>: Banner and the Hulk. Banner's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CharacterDevelopment' title='/pmwiki/pmwiki.php/Main/CharacterDevelopment'>Character Development</a> has him realizing that the Hulk isn't some villain: he's just a part of Banner driven by the doctor's own simplest desires, which needs to be accepted rather than constantly restrained. This leads to the final battle, where <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SplitPersonalityMerge' title='/pmwiki/pmwiki.php/Main/SplitPersonalityMerge'>Banner willingly transforms to help the Avengers and the Hulk willingly follows Captain America's orders</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JerkassHasAPoint' title='/pmwiki/pmwiki.php/Main/JerkassHasAPoint'>Jerkass Has a Point</a>:<ul ><li> Black Widow's reaction when Cap asks what Tony is without his armor and he answers "Genius, billionaire, playboy, philanthropist".</li><li> Tony to Steve "You're a laboratory experiment, Rogers. Everything special about you came out of a bottle". Harsh but true, compared to Tony and Banner's intelligence-derived powers and Black Widow and Hawkeye being trained, Cap's power was handed to him for being a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NiceGuy' title='/pmwiki/pmwiki.php/Main/NiceGuy'>Nice Guy</a>.</li><li> When the Avengers learn that Fury is developing weapons based on the Tesseract and everyone <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhatTheHellHero' title='/pmwiki/pmwiki.php/Main/WhatTheHellHero'>calls him out on it</a>, he retorts that he had no other choice given how technologically inferior Earth is when compared to the other races on the universe like the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PhysicalGod' title='/pmwiki/pmwiki.php/Main/PhysicalGod'>Asgardians</a>. Given that more than a few of them are aggressive, Fury's wariness is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ProperlyParanoid' title='/pmwiki/pmwiki.php/Main/ProperlyParanoid'>hardly unjustified</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JumpScare' title='/pmwiki/pmwiki.php/Main/JumpScare'>Jump Scare</a>:<ul ><li> Earlier in the film, Bruce Banner invoked this to Natasha in his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Troll' title='/pmwiki/pmwiki.php/Main/Troll'>Troll-ish</a> moment to pretend he's gonna <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>Hulking Out</a>.<div class='indent'><strong>Bruce:</strong> <em>[in deadpan tone]</em> [Fury] needs me in a cage? <br /><strong>Natasha:</strong> No-one's gonna put you in... <br /><strong>Bruce: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuddenlyShouting' title='/pmwiki/pmwiki.php/Main/SuddenlyShouting'>STOP LYING TO ME!</a></strong> <br /><strong>Natasha:</strong> <em>[freaks out and draws her gun]</em> <br /><strong>Bruce:</strong> <em>[chuckles, looks</em> <strong>obviously</strong> <em>amused and satisfied]</em> I'm sorry, that was mean, I just wanted to see what you'd do.</div></li><li> Later in the Helicarrier, Bruce as the Hulk popping up out of nowhere and roaring at Natasha (<em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BeCarefulWhatYouWishFor' title='/pmwiki/pmwiki.php/Main/BeCarefulWhatYouWishFor'>again</a></em>).</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JurisdictionFriction' title='/pmwiki/pmwiki.php/Main/JurisdictionFriction'>Jurisdiction Friction</a>: S.H.I.E.L.D. and the World Security Council want Loki to be judged for his crimes on Earth, while Thor insists that he must "face Asgardian justice".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustPlaneWrong' title='/pmwiki/pmwiki.php/Main/JustPlaneWrong'>Just Plane Wrong</a>: The scene with the S.H.I.E.L.D. "F-35" escort aircraft:<ul ><li> The F-35 model with an internal gun is not the same model that can hover.</li><li> That hover length would have had the aircraft falling out of the sky <em>without</em> the aid of the Hulk.</li><li> The muzzle flashes come out of the jet intakes &#8212; an enormously bad idea as 1) you don't want to reduce the amount of air you can intake by having guns in there, and 2) you'll send the spent shells <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TurbineBlender' title='/pmwiki/pmwiki.php/Main/TurbineBlender'>right into the jet engine</a>.</li><li> Minor example; Aboard the helicarrier we get a glance at an AV-8 "Harrier" jump jet with "FF" blazoned on the tail. This is the emblem of the USAF First Fighter Wing, based in Langley, VA. Trouble is, the U.S. Air Force doesn't operate Harriers; First Fighter is equipped exclusively with F-22 "Raptor" fighters.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustTrainWrong' title='/pmwiki/pmwiki.php/Main/JustTrainWrong'>Just Train Wrong</a>: At the beginning of the scene introducing <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/BlackWidow' title='/pmwiki/pmwiki.php/ComicBook/BlackWidow'>Black Widow</a> we see an establishing shot of a Norfolk Southern freight train passing by the ratty looking warehouse where the heroine is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>conducting an interrogation</a>. The only problem is that the scene is set in Russia where American locomotives cannot operate (the train tracks have different widths).</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustYouAndMeAndMyGuards' title='/pmwiki/pmwiki.php/Main/JustYouAndMeAndMyGuards'>Just You and Me and My GUARDS!</a>: Black Widow seeks out Bruce Banner to recruit him with assurances it's only the two of them. Then he starts <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuddenlyShouting' title='/pmwiki/pmwiki.php/Main/SuddenlyShouting'>Suddenly Shouting</a> because he "wanted to see what she'd do." (what she does is immediately pointing a handgun at him.) Once it's clear he's not turning into an enormous green rage-monster, she tells the veritable SWAT team surrounding the house outside that they can stand down.<div class='indent'><strong>Bruce Banner:</strong> "Just you and me", huh? <em>[Black Widow is visibly mollified]</em></div></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder6');">&nbsp;&nbsp;&nbsp;&nbsp;K&nbsp;</div><div id="folder6" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KeystoneArmy' title='/pmwiki/pmwiki.php/Main/KeystoneArmy'>Keystone Army</a>: The Chitauri, apparently. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Once Iron Man nukes the mothership, all units on Earth cease functioning</span>. Whedon has said that he wasn't happy about using it, but needed a way to skip the "cleanup" phase of the battle.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KickTheDog' title='/pmwiki/pmwiki.php/Main/KickTheDog'>Kick the Dog</a>: Loki's pleasure in murder and destruction, such as the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EyeScream' title='/pmwiki/pmwiki.php/Main/EyeScream'>Eye Scream</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KidnappedScientist' title='/pmwiki/pmwiki.php/Main/KidnappedScientist'>Kidnapped Scientist</a>: Astrophysicist Dr. Erik Selvig is kidnapped and brainwashed by Loki to help build a portal device powered by the Tesseract.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KilledMidSentence' title='/pmwiki/pmwiki.php/Main/KilledMidSentence'>Killed Mid-Sentence</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson.</span> "It's alright, sir. This was never going to work unless they had something... to..." <span class="spoiler" title="you can set spoilers visible by default on your profile" >What's the betting the end of that sentence was going to be "avenge"?</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KillTheCutie' title='/pmwiki/pmwiki.php/Main/KillTheCutie'>Kill the Cutie</a>: This being a Joss Whedon production, we should have known that <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson taking a level in adorkable by fanboying over Captain America</span> was not going to end well.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KirkSummation' title='/pmwiki/pmwiki.php/Main/KirkSummation'>Kirk Summation</a>: Thor (between trading blows) tries to make Loki realize that even if the invasion succeeds, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouHaveOutLivedYourUsefulness' title='/pmwiki/pmwiki.php/Main/YouHaveOutLivedYourUsefulness'>it's highly unlikely that the bad guys he's working for will allow Loki to rule the Earth afterwards</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KissOfLife' title='/pmwiki/pmwiki.php/Main/KissOfLife'>Kiss of Life</a>: Averted, but thoroughly lampshaded and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForLaughs' title='/pmwiki/pmwiki.php/Main/PlayedForLaughs'>Played for Laughs</a> when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony Stark wakes up after falling back to Earth following him flying the nuke into the wormhole</span>:<div class='indent'><strong><span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony Stark</span>:</strong> What just happened? Please tell me nobody kissed me.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KneelBeforeZod' title='/pmwiki/pmwiki.php/Main/KneelBeforeZod'>Kneel Before Zod</a>: In Stuttgart, Loki forces <em>almost</em> an entire crowd to kneel before him and tries to do the same to Captain America.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheKnightsWhoSaySquee' title='/pmwiki/pmwiki.php/Main/TheKnightsWhoSaySquee'>The Knights Who Say "Squee!"</a>: Agent Coulson is a huge fanboy of Captain America. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MeaningfulEcho' title='/pmwiki/pmwiki.php/Main/MeaningfulEcho'>Trading cards are involved</a>. Plus, it turns out he helped design Cap's modern-day costume.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KnowWhenToFoldEm' title='/pmwiki/pmwiki.php/Main/KnowWhenToFoldEm'>Know When to Fold 'Em</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >After being blown up, beat down by Thor and the Hulk, and watching his army die, Loki wisely comes quietly</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KubrickStare' title='/pmwiki/pmwiki.php/Main/KubrickStare'>Kubrick Stare</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/TomHiddleston' title='/pmwiki/pmwiki.php/Creator/TomHiddleston'>Tom Hiddleston</a> seems to have this down to a fine art, especially the first time we see him.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KungFuSonicBoom' title='/pmwiki/pmwiki.php/Main/KungFuSonicBoom'>Kung-Fu Sonic Boom</a>: This is what we get when <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnstoppableForceMeetsImmovableObject' title='/pmwiki/pmwiki.php/Main/UnstoppableForceMeetsImmovableObject'>Thor's god-hammer Mj&ouml;lnir hits Captain America's vibranium shield</a>. It levels a good acre of forest.</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder7');">&nbsp;&nbsp;&nbsp;&nbsp;L&nbsp;</div><div id="folder7" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LampshadeHanging' title='/pmwiki/pmwiki.php/Main/LampshadeHanging'>Lampshade Hanging</a>: Quite a few subtle ones, which if you've seen the previous films, you catch right off the bat.<div class='indent'><strong>Tony Stark:</strong> Uh, <a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>Shakespeare in the park</a>? <br /><br /><strong>Natasha Romanoff:</strong> This is monsters and magic and nothing we were ever trained for.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LampshadedTheObscureReference' title='/pmwiki/pmwiki.php/Main/LampshadedTheObscureReference'>Lampshaded the Obscure Reference</a>: This is inverted with Steve. Since he's been frozen for nearly 7 decades, modern references, like <a class='twikilink' href='/pmwiki/pmwiki.php/UsefulNotes/StephenHawking' title='/pmwiki/pmwiki.php/UsefulNotes/StephenHawking'>Stephen Hawking</a> and Pilates, are lost on him, but he's giddy that he knows what Nick means by <a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheWizardOfOz' title='/pmwiki/pmwiki.php/Film/TheWizardOfOz'>flying monkeys</a>.<div class='indent'><strong>Steve:</strong> I understood that reference!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LaserGuidedKarma' title='/pmwiki/pmwiki.php/Main/LaserGuidedKarma'>Laser-Guided Karma</a>: Loki spends much of the movie belittling Bruce Banner/Hulk, basically describing him as a mindless uncontrollable subhuman to anyone within earshot, even to his very face. Loki even manages to use Banner's more vicious side to steam-roller S.H.I.E.L.D. and the Avengers. <span class="spoiler" title="you can set spoilers visible by default on your profile" >No prizes for guessing who gets to ram a thick, humbling slice of marble and concrete flavoured pie down his slimy gullet in the denouement!</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LastBreathBullet' title='/pmwiki/pmwiki.php/Main/LastBreathBullet'>Last Breath Bullet</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Downplayed' title='/pmwiki/pmwiki.php/Main/Downplayed'>Downplayed</a> and a heroic example. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> gets one of these in on Loki after being stabbed through the chest, but Loki is virtually unharmed and manages to escape anyways.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LastSecondChance' title='/pmwiki/pmwiki.php/Main/LastSecondChance'>Last-Second Chance</a>: Thor's fight with Hulk starts off as this, but Thor stops trying pretty quickly. Later he tries it with Loki and it works just as well.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLastThingYouEverSee' title='/pmwiki/pmwiki.php/Main/TheLastThingYouEverSee'>The Last Thing You Ever See</a>: Loki tells Black Widow that he has this in mind for Barton:<div class='indent'><strong>Loki:</strong> I won't touch Barton. Not until I make him kill you! Slowly. Intimately. In every way he knows you fear! And when he'll wake just long enough to see his good work, and when he screams, I'll split his skull!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LateArrivalSpoiler' title='/pmwiki/pmwiki.php/Main/LateArrivalSpoiler'>Late-Arrival Spoiler</a>: If you've missed some of the movies from the MCU, there'll be quite a few spoilers for you, particularly in regards to <em>Thor</em> and <em>Captain America: The First Avenger</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LaughablyEvil' title='/pmwiki/pmwiki.php/Main/LaughablyEvil'>Laughably Evil</a>: Loki; there's something very amusing in the way he <a class='twikilink' href='/pmwiki/pmwiki.php/Main/XanatosSpeedChess' title='/pmwiki/pmwiki.php/Main/XanatosSpeedChess'>dances circles around the heroes</a>, while gleefully mocking them at the same time</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LaymansTerms' title='/pmwiki/pmwiki.php/Main/LaymansTerms'>Layman's Terms</a>:<ul ><li> Both inverted and played straight when Tony Stark is delighted to be able to speak seemingly <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>Techno Babble</a> with Bruce Banner, much to the bemusement of Captain America.<div class='indent'><strong>Steve Rogers:</strong> Does Loki need any particular kind of power source? <br /><strong>Bruce Banner:</strong> He got to heat the cube to a hundred and twenty million Kelvin just to break through the Coulomb barrier. <br /><strong>Tony Stark:</strong> Unless <span class="spoiler" title="you can set spoilers visible by default on your profile" >Selvig</span> has figured out how to stabilize the quantum tunneling effect. <br /><strong>Bruce Banner:</strong> Well, if he could do that he could achieve Heavy Ion Fusion at any reactor on the planet. <br /><strong>Tony Stark:</strong> Finally, someone who speaks English. <br /><strong>Steve Rogers:</strong> Is that what just happened?</div></li><li> When Stark is trying to talk Rogers through helping him fix the destroyed propeller of the Helicarrier:<div class='indent'><strong>Tony Stark:</strong> Take a look at the panel and tell me what you see. <br /><strong>Cap:</strong> It appears to run on some form of electricity. <br /><strong>Tony:</strong> Well, you're not wrong.</div></li><li> Steve is forced to interrupt Tony's technobabble-laden explanation of how he's going to get back out of the engine: "Speak English!"</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LeadTheTarget' title='/pmwiki/pmwiki.php/Main/LeadTheTarget'>Lead the Target</a>: Strongly implied by Hawkeye. One shot has him rather spectacularly looking at a target while apparently pointing his bow the wrong way. Careful analysis shows that he's aiming quite in advance of his (fast-moving) target to hit it dead on.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LeaningOnTheFourthWall' title='/pmwiki/pmwiki.php/Main/LeaningOnTheFourthWall'>Leaning on the Fourth Wall</a>: Nick Fury gives a report to the World Security Council where he mentions that their Phase 1 weapons development program is nearing completion and that they are getting ready to move on to Phase 2, much like the MCU at the time of the film's release.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LeaveTheCameraRunning' title='/pmwiki/pmwiki.php/Main/LeaveTheCameraRunning'>Leave the Camera Running</a>: The entirety of the second stinger but they did do <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RuleOfThree' title='/pmwiki/pmwiki.php/Main/RuleOfThree'>three</a> separate takes so they could pick out the best.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LeeroyJenkins' title='/pmwiki/pmwiki.php/Main/LeeroyJenkins'>Leeroy Jenkins</a>: Iron Man gives us this gem after Thor arrives on Earth and snatches Loki from the quinjet:<div class='indent'><strong>Steve Rogers:</strong> We need a plan of attack! <br /><strong>Tony Stark:</strong> I <em>have</em> a plan: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AttackAttackAttack' title='/pmwiki/pmwiki.php/Main/AttackAttackAttack'>Attack</a>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Leitmotif' title='/pmwiki/pmwiki.php/Main/Leitmotif'>Leitmotif</a>:<ul ><li> Whenever Cap does anything awesome, notes of his theme plays.</li><li> Invoked by Stark when he flies in during the Captain vs. Loki fight. The stereo of the S.H.I.E.L.D. helicopter overhead is commandeered by Stark, and seconds before he shows up, "Shoot to Thrill" starts playing. It probably wouldn't count if Stark hadn't intentionally played the same song in his first scene in <em>Iron Man 2</em>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LensmanArmsRace' title='/pmwiki/pmwiki.php/Main/LensmanArmsRace'>Lensman Arms Race</a>: Thor states that S.H.I.E.L.D.'s experiments with the Tesseract have started one: it's the equivalent of an otherwise unremarkable postage stamp in Eastern Europe or Africa suddenly acquiring full nuclear capability. Once Earth re-ignited the Tesseract, it was no longer an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InsignificantLittleBluePlanet' title='/pmwiki/pmwiki.php/Main/InsignificantLittleBluePlanet'>Insignificant Little Blue Planet</a> in the <a class='urllink' href='http://en.wikipedia.org/wiki/CIA_World_Factbook'>CIA Galactic Factbook<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> &#8212; it's now a potential <em>rival</em>. And when <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Avengers wiped out an entire force of Chitauri and thus earned Thanos' attention, it was equivalent to said postage stamp wiping out a Spetsnaz unit and thus earning <em>Stalin's</em> attention!</span></li></ul><!-- <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LeParkour' title='/pmwiki/pmwiki.php/Main/LeParkour'>Le Parkour</a> goes in "P".--><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LetsGetDangerous' title='/pmwiki/pmwiki.php/Main/LetsGetDangerous'>Let's Get Dangerous!</a>: Invoked by Nick Fury at the end, that Earth is no longer an insignificant little fish in the galactic pond.<div class='indent'><strong>Director:</strong> Was that the whole point of this? A statement? <br /><strong>Nick Fury:</strong> A <em>promise.</em></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LetsYouAndHimFight' title='/pmwiki/pmwiki.php/Main/LetsYouAndHimFight'>Let's You and Him Fight</a>:<ul ><li> Thor's introduction, after Cap and Stark have "captured" the surrendering Loki, is to burst into their transport and remove his brother by force. This could prove an obstacle to saving their world, so both heroes jump out of the plane to give chase. The showdown involves a lot of snarking and pummeling, and answers the question of what happens when a near-unstoppable hammer swing meets an unbreakable shield.</li><li> Also, the Hulk briefly chases Black Widow and tangles with Thor when he first "meets" the team. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki planned to use The Hulk to destroy the Helicarrier and all of his enemies along with it</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LettingTheAirOutOfTheBand' title='/pmwiki/pmwiki.php/Main/LettingTheAirOutOfTheBand'>Letting the Air out of the Band</a>: In the "performance issue" scene, ominous music rises dramatically as Loki is about to touch Tony Stark's chest with his spear tip... and then, <em>clink</em>. Can count in-universe too with the mind-control gem emitting a humming sound just before contact, which also putters out after the clink.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LifesavingMisfortune' title='/pmwiki/pmwiki.php/Main/LifesavingMisfortune'>Lifesaving Misfortune</a>: Tony Stark implies to Bruce that his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreakLabAccident' title='/pmwiki/pmwiki.php/Main/FreakLabAccident'>Freak Lab Accident</a> might have been this.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LightningBruiser' title='/pmwiki/pmwiki.php/Main/LightningBruiser'>Lightning Bruiser</a>:<ul ><li> The Hulk is phenomenally strong (strong enough to rival mighty Thor), but the movie also does an excellent job of portraying just how dangerously <em>fast</em> he can be for his size, particularly when he's tearing things up with remarkable agility in the final battle. Also, the scene of him chasing Black Widow has her running for her life down a small corridor and Hulk catching up to her <em>while smashing through barriers.</em></li><li> Thor is the physically strongest member of the team (perhaps rivaled somewhat by the Hulk), able to break out of the Hulk's designed cell, is agile enough to dodge a plane wing hurled at him by the Hulk, and travels at great speed. He even looks like a blur when he <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigDamnHeroes' title='/pmwiki/pmwiki.php/Main/BigDamnHeroes'>saves</a> Black Widow from the Hulk. Also, he can actually harness the power of lightning with his hammer, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustForPun' title='/pmwiki/pmwiki.php/Main/JustForPun'>making this trope both figurative and literal.</a></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LikeCannotCutLike' title='/pmwiki/pmwiki.php/Main/LikeCannotCutLike'>Like Cannot Cut Like</a>: Inverted: the only thing that can breach the Tesseract-powered portal generator's barrier is the scepter, which is said to be "powered by the Tesseract" in this film and was later <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RetCon' title='/pmwiki/pmwiki.php/Main/RetCon'>retconned</a> into containing a different Infinity Stone.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LivingLegend' title='/pmwiki/pmwiki.php/Main/LivingLegend'>Living Legend</a>: All the Avengers but mostly Captain America. Tony Stark uses the phrase itself.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LivingShip' title='/pmwiki/pmwiki.php/Main/LivingShip'>Living Ship</a>: The Chitauri have the Leviathans, armored dragons that also act as transportation for ground troops. As with the Chitauri themselves, they seemed to be mechanical to some extent as they die when the mothership is destroyed.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LockAndLoadMontage' title='/pmwiki/pmwiki.php/Main/LockAndLoadMontage'>Lock-and-Load Montage</a>: When the team decides to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LetsGetDangerous' title='/pmwiki/pmwiki.php/Main/LetsGetDangerous'>collectively get dangerous</a>, we are treated to a montage of Captain America and Iron Man suiting up while Thor grabs Mj&ouml;lnir and Hawkeye checks his bow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LodgedBladeRemoval' title='/pmwiki/pmwiki.php/Main/LodgedBladeRemoval'>Lodged Blade Removal</a>: Loki and Thor fight each other and the latter implores his brother to see the horrors of his attack on New York and stop. Loki appears to be considering his words for a few moments before stabbing Thor with a push knife and getting away. Thor proceeds to simply pull it out and toss it before immediately going back to the fight, merely looking frustrated. Justified since he's a god.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LogoJoke' title='/pmwiki/pmwiki.php/Main/LogoJoke'>Logo Joke</a>:<ul ><li> The Marvel and Paramount logos are seen inside the Tesseract.</li><li> Also seen at the end of the movie. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Stark Tower's "STARK" logo gets all the consonants removed during the final fight. What's left? A very stylish 'A', similar to the one in the classic "Avengers" logo</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight' title='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight'>The Loins Sleep Tonight</a>: When Loki tries to mind control Tony Stark, it fails when the staff is blocked by the reactor in Tony's chest. He puts on a look of mock-sympathy and draws a parallel to erectile dysfunction.<div class='indent'><strong>Loki:</strong> This usually works... <br /><strong>Tony:</strong> Well, performance issues, it's not uncommon. One out of five... <br /><strong>Loki:</strong> <em>[chokes Tony]</em> You will all fall before me!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LoonyFriendsImproveYourPersonality' title='/pmwiki/pmwiki.php/Main/LoonyFriendsImproveYourPersonality'>Loony Friends Improve Your Personality</a>: Bruce "the Hulk" Banner only starts to come out of his shell when Tony "Iron Man" Stark starts teasing him &#8212; mostly because Bruce's... <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PersonOfMassDestruction' title='/pmwiki/pmwiki.php/Main/PersonOfMassDestruction'>impressive</a> anger management issues mean that people tend to walk on eggshells around him a lot, and Tony is treating him like a person, not an unexploded nuke that happens to be able to talk.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LoveIsAWeakness' title='/pmwiki/pmwiki.php/Main/LoveIsAWeakness'>Love Is a Weakness</a>: Loki claims this at every possible opportunity. He’s talking <a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>from</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LoveMakesYouCrazy' title='/pmwiki/pmwiki.php/Main/LoveMakesYouCrazy'>personal</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LoveMakesYouEvil' title='/pmwiki/pmwiki.php/Main/LoveMakesYouEvil'>experience</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LuckilyMyShieldWillProtectMe' title='/pmwiki/pmwiki.php/Main/LuckilyMyShieldWillProtectMe'>Luckily, My Shield Will Protect Me</a>: After Captain America breaks up the fight between Tony Stark and Thor and tries to convince Thor to "put the hammer down", Thor acts on those words by smashing Captain America with it. Captain America blocks it with his shield, which indeed protects him from a blow from the hammer of a Norse god &#8212; by reflecting the force of the blow in all directions in a shockwave that levels everything in the immediate area.</li></ul></div></p><p><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/TheAvengers/TropesAToD">Tropes A to D</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Film/TheAvengers2012">Film/The Avengers (2012)</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/TheAvengers/TropesMToP">Tropes M to P</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/scraper/resources/theavengers_tropesMtoP.html
+++ b/tropestogo/service/scraper/resources/theavengers_tropesMtoP.html
@@ -1,0 +1,1821 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "TheAvengers", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Tropes M to P / The Avengers - TV Tropes</title>
+            <meta name="description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesMToP" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Tropes M to P / The Avengers - TV Tropes" />
+            <meta name="twitter:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Tropes M to P / The Avengers - TV Tropes" />
+			<meta property="og:type" content="website" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesMToP" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: Spoilers from the earlier films are unmarked.  MacGuffin: The Tesseract is a powerful artifact &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "3249201cca6b7eeca1de118d08d4474b20e5ab7e",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/SmartAnimalAverageHuman" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Film/Skyline" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/TheAvengers/TropesMToP?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=TheAvengers/TropesMToP">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=TheAvengers.TropesMToP">
+                <i class="fa fa-history"></i> History</a></li><li class="link-discussion"><a href="/pmwiki/remarks.php?trope=TheAvengers.TropesMToP">
+                  <i class="fa fa-comment"></i> Discussion</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/TheAvengers/TropesMToP?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="TheAvengers"/>
+<input type="hidden" id="title-hidden" value="TropesMToP"/>
+<input type="hidden" id="article_id" value="406148" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesMToP</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>The Avengers / </strong>
+        
+        Tropes M to P
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "TheAvengers",
+                "item": "https://tvtropes.org/pmwiki/index_report.php?groupname=TheAvengers"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Tropes M to P"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+        
+                
+
+        
+            
+            <li class="more-subpages">
+                <a href="javascript:void(0);" class="subpage-toggle-button" >
+                    <span class="wrapper more">More <i class="fa fa-chevron-down"></i></span>
+                    <span class="wrapper less"><i class="fa fa-chevron-left"></i> Less</span>
+                </a>
+
+                <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);" tabindex="0">
+                    <option value="">- More -</option>
+
+                                                            <option value="/pmwiki/pmwiki.php/Castle/TropesMToP">Castle</option>
+                                                                                <option value="/pmwiki/pmwiki.php/JudgeDredd/TropesMToP">JudgeDredd</option>
+                                                                                <option value="/pmwiki/pmwiki.php/MassEffect/TropesMToP">MassEffect</option>
+                                                                                <option value="/pmwiki/pmwiki.php/OnceUponATime/TropesMToP">OnceUponATime</option>
+                                                                                <option value="/pmwiki/pmwiki.php/QuestionableContent/TropesMToP">QuestionableCo&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/RickAndMorty/TropesMToP">RickAndMorty</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StarTrekDeepSpaceNine/TropesMToP">StarTrekDeepSp&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Supernatural/TropesMToP">Supernatural</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheAvengers/TropesMToP">TheAvengers</option>
+                                                                                <option value="/pmwiki/pmwiki.php/ThisBites/TropesMToP">ThisBites</option>
+                                                                                <option value="/pmwiki/pmwiki.php/WeAreNotAlone/TropesMToP">WeAreNotAlone</option>
+                                                                                <option value="/pmwiki/pmwiki.php/ZeroPunctuation/TropesMToP">ZeroPunctuatio&#8230;</option>
+                                        
+                </select>
+
+            </li>
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/TropesMToP?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/TropesMToP?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/TropesMToP?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/TropesMToP?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/TropesMToP?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/TropesMToP?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/TropesMToP?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/TropesMToP?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/TropesMToP?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/TropesMToP?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/TropesMToP?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/TropesMToP?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/TropesMToP?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/TropesMToP?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/TropesMToP?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/TropesMToP?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/TropesMToP?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/TropesMToP?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesAToD' title='/pmwiki/pmwiki.php/TheAvengers/TropesAToD'>Tropes A to D</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesEToL' title='/pmwiki/pmwiki.php/TheAvengers/TropesEToL'>Tropes E to L</a> | <strong>Tropes M to P</strong> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesQToZ' title='/pmwiki/pmwiki.php/TheAvengers/TropesQToZ'>Tropes Q to Z</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TieIns' title='/pmwiki/pmwiki.php/TheAvengers/TieIns'>Tie Ins</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/YMMV/TheAvengers2012' title='/pmwiki/pmwiki.php/YMMV/TheAvengers2012'>YMMV</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/Trivia/TheAvengers2012' title='/pmwiki/pmwiki.php/Trivia/TheAvengers2012'>Trivia</a><hr /><h3><em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheAvengers2012' title='/pmwiki/pmwiki.php/Film/TheAvengers2012'>The Avengers</a></em> provides examples of the following tropes:</h3></p><p><div class="folderlabel" onclick="toggleAllFolders();">&nbsp;&nbsp;&nbsp;&nbsp;open/close all folders&nbsp; </div></p><p><strong>WARNING: Spoilers from the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse'>earlier films</a> are unmarked.</strong></p><p><div class="folderlabel" onclick="togglefolder('folder0');">&nbsp;&nbsp;&nbsp;&nbsp;M&nbsp;</div><div id="folder0" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MacGuffin' title='/pmwiki/pmwiki.php/Main/MacGuffin'>MacGuffin</a>: The Tesseract is a powerful artifact everyone wants.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MacrossMissileMassacre' title='/pmwiki/pmwiki.php/Main/MacrossMissileMassacre'>Macross Missile Massacre</a>: Iron Man launches one from his shoulders.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfExplodium' title='/pmwiki/pmwiki.php/Main/MadeOfExplodium'>Made of Explodium</a>: Surprisingly averted. This is actually a superhero action film where people keep shooting at cars, planes, helicopters, etc. without most of them exploding. There are even a few occurrences where the trope is downright inverted: stuff that <em>should</em> logically explode, and it looks weird and unrealistic when they don't. For example when Nick Fury shoots a rocket at a plane trying to take off with a rocket launcher and it comes out of it with only a destroyed wing and (supposedly) no harm to the pilot.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfIndestructium' title='/pmwiki/pmwiki.php/Main/MadeOfIndestructium'>Made of Indestructium</a>: Being made of Vibranium, Cap's shield is used to block or reflect nearly every attack in the movie made against him (including Mj&ouml;lnir, as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DropTheHammer' title='/pmwiki/pmwiki.php/Main/DropTheHammer'>Drop the Hammer</a> shows), and only the paint is damaged.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfIron' title='/pmwiki/pmwiki.php/Main/MadeOfIron'>Made of Iron</a>: Par for the course for a superhero movie.<ul ><li> Tony Stark takes what would be fatal impacts both in and out of his suit. A crash from exploding a Leviathan from the inside only causes minor cuts on his face. He also gets thrown onto the floor, subjected to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NeckLift' title='/pmwiki/pmwiki.php/Main/NeckLift'>Neck Lift</a> and thrown through a skyscraper window by Loki without a scratch.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Phil Coulson</span> takes a spear through the back and out the chest and survives for about 10 minutes &#8212; obviously in shock and bleeding out, but conscious.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MageInManhattan' title='/pmwiki/pmwiki.php/Main/MageInManhattan'>Mage in Manhattan</a>: In Stuttgart, Loki uses illusions to create copies of himself, surrounds a group of people, and forces them to kneel.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MagicPants' title='/pmwiki/pmwiki.php/Main/MagicPants'>Magic Pants</a>: As usual for the Hulk, except for one scene. After de-Hulking, Banner has somehow<span class="notelabel" onclick="togglenote('note02ngt');"><sup>note&nbsp;</sup></span><span id="note02ngt" class="inlinefolder" isnote="true" onclick="togglenote('note02ngt');" style="cursor:pointer;font-size:smaller;display:none;">presumably, after being stretched out, they slipped off <span class="spoiler" title="you can set spoilers visible by default on your profile" > as he plummeted from the sky</span>)</span> lost the pants and is covered by nothing but the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SceneryCensor' title='/pmwiki/pmwiki.php/Main/SceneryCensor'>Scenery Censor</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MajorInjuryUnderreaction' title='/pmwiki/pmwiki.php/Main/MajorInjuryUnderreaction'>Major Injury Underreaction</a>:<ul ><li> Thor appears to be highly annoyed after Iron Man tackles him off a cliff at high speeds. Justified in that he's a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PhysicalGod' title='/pmwiki/pmwiki.php/Main/PhysicalGod'>Physical God</a>.<div class='indent'><strong>Thor:</strong> Do not touch me again.</div></li><li> And again when Loki shanks him in the gut in the battle atop Stark Tower. He seemingly grabs his abdomen in pain, but promptly proceeds to body-slam Loki. He then removes the blade and tosses it away with a look that says "Now, I'm <em>pissed</em>!" and less "That hurt."</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MakeAnExampleOfThem' title='/pmwiki/pmwiki.php/Main/MakeAnExampleOfThem'>Make an Example of Them</a>: Loki preparing to zap a mouthy old man standing amid his flock, before Captain America intervenes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MaleGaze' title='/pmwiki/pmwiki.php/Main/MaleGaze'>Male Gaze</a>: The movie does this a great deal with Black Widow and Maria Hill seems to be walking away from the camera in a <em>lot</em> of shots. Pepper Potts wears Daisy Dukes and bare feet during her cameo.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheManBehindTheMan' title='/pmwiki/pmwiki.php/Main/TheManBehindTheMan'>The Man Behind the Man</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos is revealed to be this to Loki in The Stinger.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManBitesMan' title='/pmwiki/pmwiki.php/Main/ManBitesMan'>Man Bites Man</a>: During her scuffle with <span class="spoiler" title="you can set spoilers visible by default on your profile" >a brainwashed Hawkeye</span>, Black Widow bites his hand in order to avoid being stabbed.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Manipulative Bastard</a>:<ul ><li> Loki <em>can</em> hold his own in combat with that staff of his and his misdirecting illusions, but he prefers to trick the heroes into fighting each other.</li><li> Nick Fury, as usual, manipulates the heroes into working for S.H.I.E.L.D.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManlyTears' title='/pmwiki/pmwiki.php/Main/ManlyTears'>Manly Tears</a>:<ul ><li> Loki has tears in his eyes when he asks Thor whether he was mourned after his apparent suicide at the end of <em>Thor</em>.</li><li> After Loki traps Thor in the cage and tells him that he's going to kill him, Thor is too heartbroken to respond, simply letting his tears fall as he averts his eyes from Loki.</li><li> Tony's eyes are openly brimming with tears during the "we are not soldiers" scene after <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's death</span>, although they never fall.</li><li> Blink and you'll miss it, but a tear runs down Loki's cheek right after he stabs Thor in their fight on Stark Tower.</li><li> Tony's eyes also fill with tears when <span class="spoiler" title="you can set spoilers visible by default on your profile" >he flies the nuke into the wormhole, thinking that he will not make it back.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MarketBasedTitle' title='/pmwiki/pmwiki.php/Main/MarketBasedTitle'>Market-Based Title</a>: In the U.K. and Ireland, the film is known as <em>Avengers Assemble</em> to avoid confusion with the <a class='twikilink' href='/pmwiki/pmwiki.php/Series/TheAvengers1960s' title='/pmwiki/pmwiki.php/Series/TheAvengers1960s'>classic British TV series</a> of the same name. Strangely, the merchandising such as children's toys all still bears the <em>original</em> title, next to posters with the revised title. For some reason, both titles were used to advertise it, saying that <em>The Avengers</em> would be released on the 26th, and <em>Avengers Assemble</em> being released on the 27th.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MartyrdomCulture' title='/pmwiki/pmwiki.php/Main/MartyrdomCulture'>Martyrdom Culture</a>: Implied with the Chitauri in a deleted scene.<div class='indent'><strong>Loki:</strong> Your force lacks... finesse. <br /><strong>Other:</strong> Our warriors are fearless! They welcome a glorious death. <br /><strong>Loki:</strong> That may actually be the problem.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MassiveMultiplayerCrossover' title='/pmwiki/pmwiki.php/Main/MassiveMultiplayerCrossover'>Massive Multiplayer Crossover</a>: A rare live-action example. This movie is possible since all of these franchise characters are owned by Marvel, and also because the previous films of the team's big four (Iron Man, Hulk, Thor and Captain America, in this order) all lead up to this.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MatchCut' title='/pmwiki/pmwiki.php/Main/MatchCut'>Match Cut</a>:<ul ><li> There is a closeup of Loki's scepter, that cuts to the scepter showing up on the readings of a quinjet being crewed by his brainwashed posse, indicating this is how they tracked down the helicarrier.</li><li> The ending credits before the first Stinger ends up with a close-up of Tony's round ARC reactor which cut to a far-away moon <span class="spoiler" title="you can set spoilers visible by default on your profile" >seen from Thanos's lair</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MaybeMagicMaybeMundane' title='/pmwiki/pmwiki.php/Main/MaybeMagicMaybeMundane'>Maybe Magic, Maybe Mundane</a>: Downplayed, but present. Even with our current understanding of science fiction, some things the Asgardians do are just easier to explain with magic. People refer to Loki as "casting spells", often in the same scene as discussing Asgardian technology.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MeaningfulBackgroundEvent' title='/pmwiki/pmwiki.php/Main/MeaningfulBackgroundEvent'>Meaningful Background Event</a>: When Loki is talking to the Other, at one point, one of the Leviathans flies past in the background. In the attack on New York, they end up using those things as weapons.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MeaningfulEcho' title='/pmwiki/pmwiki.php/Main/MeaningfulEcho'>Meaningful Echo</a>:<ul ><li> Fury says that when Coulson died, he lost his one good eye. In <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan2' title='/pmwiki/pmwiki.php/Film/IronMan2'>Iron Man 2</a></em>, as he's leaving Coulson to watch over Stark, he reminds Tony, "Remember, I've got my eye on you."</li><li> When Fury explains the Avengers Initiative, he finishes by saying, "It was an old-fashioned idea," echoing Coulson's remark that "Maybe we could use a little old-fashioned." when Captain expressed doubt about the bright, old-fashioned color scheme of his new outfit.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MeaninglessVillainVictory' title='/pmwiki/pmwiki.php/Main/MeaninglessVillainVictory'>Meaningless Villain Victory</a>: Tony Stark points out the futility of Loki's plan, because even if he wins, he's never going to be able to rule over <em>anyone</em>. Humanity would rather just <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumansAreWarriors' title='/pmwiki/pmwiki.php/Main/HumansAreWarriors'>keep fighting</a> until the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DefiantToTheEnd' title='/pmwiki/pmwiki.php/Main/DefiantToTheEnd'>bitter end</a>. And the Avengers, regardless of whatever else happens, will be gunning for <em>him</em>:<div class='indent'><strong>Tony:</strong> You're missing the point — there's no throne, there is <em>no</em> version of this where you come out on top! <em>Maybe</em> your army comes, and <em>maybe</em> it's too much for us, but it's all on you... 'Cause if we can't protect the Earth, you can be damn sure we'll avenge it!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MegatonPunch' title='/pmwiki/pmwiki.php/Main/MegatonPunch'>Megaton Punch</a>: Hulk does this to <span class="spoiler" title="you can set spoilers visible by default on your profile" >a Leviathan</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MerchandiseDriven' title='/pmwiki/pmwiki.php/Main/MerchandiseDriven'>Merchandise-Driven</a>: Every single returning character has a new costume/uniform. Even Black Widow gets an altered black catsuit and a new haircut. <a class='urllink' href='http://worrierprincessme.files.wordpress.com/2012/04/scarlett-johansson-black-widow-009-1.jpg'>Compare<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a><small>&#9674;</small> and <a class='urllink' href='http://images.wikia.com/scratchpad/images/1/19/The-avengers-black-widow-scarlett-johansson.jpg'>contrast<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a><small>&#9674;</small>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MetronomicManMashing' title='/pmwiki/pmwiki.php/Main/MetronomicManMashing'>Metronomic Man Mashing</a>: The climax has the Hulk <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TalkToTheFist' title='/pmwiki/pmwiki.php/Main/TalkToTheFist'>shutting</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShutUpHannibal' title='/pmwiki/pmwiki.php/Main/ShutUpHannibal'>up</a> Loki by smashing him to the floor left and right, interrupting the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>A God Am I</a> monologue he was warming up to.<div class='indent'><strong>Hulk:</strong> Puny god.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MickeyMousing' title='/pmwiki/pmwiki.php/Main/MickeyMousing'>Mickey Mousing</a>: The action in the scene where Loki crashes a formal ball matches the music being played by the string quartet surprisingly well.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MidairRepair' title='/pmwiki/pmwiki.php/Main/MidairRepair'>Midair Repair</a>: Iron Man gets to repair the Hellicarrier: Restarting a damaged turbine, which becomes increasingly important once another (of the four) is taken out, and increasingly dangerous as he has to bring it up to speed <em>inside it</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MidSeasonUpgrade' title='/pmwiki/pmwiki.php/Main/MidSeasonUpgrade'>Mid-Season Upgrade</a>: Iron Man upgrades to the Mark VII armor right before the climactic battle starts. It can fly by itself when deployed by Jarvis, track and line itself up with Stark using a pair of bracelets he wears, and assemble itself around him. Now Stark can don the armor no matter where he is. Also, the Mark VII's laser lenses do not eject after use, implying that they are now limited only by the suit's power source.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MildlyMilitary' title='/pmwiki/pmwiki.php/Main/MildlyMilitary'>Mildly Military</a>: S.H.I.E.L.D. uses both Men-in-Black-type agents as well as paramilitary uniformed ones. The uniform insignia reverses the eagle's head on the left shoulder patch, keeping it facing the front of the individual, just like real military uniforms.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MilitariesAreUseless' title='/pmwiki/pmwiki.php/Main/MilitariesAreUseless'>Militaries Are Useless</a>: The National Guard moves out immediately once the Chitauri invasion in New York City starts, but they're away from the city so the Avengers and NYPD have to do the initial fighting. Subverted in a deleted scene that shows that once they do arrive, they put up a good fight as the Chitauri soldiers and aircraft can be readily destroyed with modern weapons.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MillionairePlayboy' title='/pmwiki/pmwiki.php/Main/MillionairePlayboy'>Millionaire Playboy</a>: Tony Stark describes himself as a "billionaire playboy" as well as "genius philanthropist."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControlEyes' title='/pmwiki/pmwiki.php/Main/MindControlEyes'>Mind-Control Eyes</a>: When Loki controls people with the scepter their eyes first turn pitch black, then their irises and pupils turn the same shade of blue as the shell covering the scepter's gem.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindRape' title='/pmwiki/pmwiki.php/Main/MindRape'>Mind Rape</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye</span>'s description of what it felt like to be brainwashed by Loki definitely gets into this territory.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MineralMacGuffin' title='/pmwiki/pmwiki.php/Main/MineralMacGuffin'>Mineral MacGuffin</a>: The Iridium that Loki has Hawkeye steal in Germany to stabilize the portal. <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> even calls it <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AppliedPhlebotinum' title='/pmwiki/pmwiki.php/Main/AppliedPhlebotinum'>Phlebotinum and MacGuffinum</a> in the DVD Commentary.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MirthlessLaughter' title='/pmwiki/pmwiki.php/Main/MirthlessLaughter'>Mirthless Laughter</a>: Hiddleston's performance includes Loki doing the nervous laughter variant of this whenever flustered or wrongfooted &#8212; he usually uses it to play off Thor's attempts to reach out to him, but he also does it to pretend he isn't afraid of something.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MisappliedPhlebotinum' title='/pmwiki/pmwiki.php/Main/MisappliedPhlebotinum'>Misapplied Phlebotinum</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForLaughs' title='/pmwiki/pmwiki.php/Main/PlayedForLaughs'>Played for Laughs</a> when Tony Stark calls out a S.H.I.E.L.D. agent on the Helicarrier for using some of the most advanced computers in the world, surpassed only by Stark's own, to play <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a></em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MisfitMobilizationMoment' title='/pmwiki/pmwiki.php/Main/MisfitMobilizationMoment'>Misfit Mobilization Moment</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's death finally motivates the heroes to get together and, yes, avenge him. Thor sees the Son of Coul get skewered as he watched helplessly. Tony gets roused to action because Tony knew him the longest of all. Cap gets motivation from the bloodstained Captain America trading cards that Coulson so eagerly wanted him to sign. Romanoff and Barton have plenty motivation because they were all longstanding comrades in the agency. Only Bruce Banner isn't motivated by this event, because he wasn't there for it; he <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChangedMyMindKid' title='/pmwiki/pmwiki.php/Main/ChangedMyMindKid'>came back</a> for other reasons.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MistakenForAliens' title='/pmwiki/pmwiki.php/Main/MistakenForAliens'>Mistaken for Aliens</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForLaughs' title='/pmwiki/pmwiki.php/Main/PlayedForLaughs'>Played for Laughs</a> with Bruce Banner. As the Hulk, he lands on a warehouse, half-destroys it and becomes human again. Then, he speaks to an old man, the security guard, who believes that Bruce is some sort of alien. The security guard is played by Harry Dean Stanton, who was in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/Alien' title='/pmwiki/pmwiki.php/Film/Alien'>Alien</a></em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MistakenForSuicidal' title='/pmwiki/pmwiki.php/Main/MistakenForSuicidal'>Mistaken for Suicidal</a>: After Selvig wakes up from Loki's brainwashing, Natasha finds him looking over the edge of Stark Tower's roof, like he's thinking about jumping. Natasha tries to talk him down, only for him to reveal that he's not looking at the ground; he's looking at Loki's scepter a few stories down, which is the key to closing the portal.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MomentKiller' title='/pmwiki/pmwiki.php/Main/MomentKiller'>Moment Killer</a>: Coulson drops in on Tony during a romantic interlude with Pepper. Luckily, it was only <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrickJoke' title='/pmwiki/pmwiki.php/Main/BrickJoke'>"12% of a moment."</a></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MomentOfSilence' title='/pmwiki/pmwiki.php/Main/MomentOfSilence'>Moment of Silence</a>: After <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson dies.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MonumentalDamage' title='/pmwiki/pmwiki.php/Main/MonumentalDamage'>Monumental Damage</a>:<ul ><li> Grand Central Station is a wash.</li><li> N.Y.'s new landmark, Stark Tower, gets trashed, as well as some famous real-world buildings in Manhattan.</li><li> Stark Tower itself is built on top of the Metlife building. Part of the background set up by the designers for the movie was that Stark literally built his tower <em>over</em> it, meaning the bottom of it would still be the real-life landmark.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MoodLighting' title='/pmwiki/pmwiki.php/Main/MoodLighting'>Mood Lighting</a>: The scene where Hawkeye wakes up in the Helicarrier's infirmary uses an odd, <em>extremely</em> unsettling color palette to indicate how mentally 'off' he still is. The colors gradually revert to normal as the last traces of the Mindstone's effects fade from his mind.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MoodWhiplash' title='/pmwiki/pmwiki.php/Main/MoodWhiplash'>Mood Whiplash</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> indulges his penchant for intentionally derailing dramatic moments with a witty one-liners. They're better heard than read.</li><li> The TV cut of the movie in Brazil cut the credits, making the viewer watch the ominous scene <span class="spoiler" title="you can set spoilers visible by default on your profile" >of The Other informing Thanos of the defeat of Loki and the Chitauri army being succeeded by the Avengers silently eating shawarma in the restaurant Stark mentioned earlier, completely unaware of the threat coming to Earth.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Mooks' title='/pmwiki/pmwiki.php/Main/Mooks'>Mooks</a>: The Chitauri.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MoreThanMindControl' title='/pmwiki/pmwiki.php/Main/MoreThanMindControl'>More than Mind Control</a>: Loki's scepter needs to touch someone to fully control them, but just being in its presence can mess with someone's head.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MotivationalLie' title='/pmwiki/pmwiki.php/Main/MotivationalLie'>Motivational Lie</a>: After <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson dies at Loki's hands</span>, Fury tosses a small pile of bloodstained vintage Captain America trading cards at Cap, as part of his attempt to use it to galvanize the Avengers. The cards were not on <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's</span> person at the time, but in his locker.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheMountainsOfIllinois' title='/pmwiki/pmwiki.php/Main/TheMountainsOfIllinois'>The Mountains of Illinois</a>: The Skyscrapers of Stuttgart, Ohio. Loki's first attack on earth was stated to be in Stuttgart, Germany, but it quite clearly was filmed in <a class='twikilink' href='/pmwiki/pmwiki.php/UsefulNotes/Cleveland' title='/pmwiki/pmwiki.php/UsefulNotes/Cleveland'>Cleveland</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MouthOfSauron' title='/pmwiki/pmwiki.php/Main/MouthOfSauron'>Mouth of Sauron</a>: The Other, a go-between for Loki and his new boss, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span>. He even looks like Peter Jackson's version of the Mouth; nasty skin, covered-up eyes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MovieSuperheroesWearBlack' title='/pmwiki/pmwiki.php/Main/MovieSuperheroesWearBlack'>Movie Superheroes Wear Black</a>:<ul ><li> Hawkeye wears a black outfit instead of his classic purple one from the comics. Also lampshaded by Captain America.<div class='indent'><strong>Captain America:</strong> Aren't the stars and stripes a little... old-fashioned? <br /><strong>Agent Coulson:</strong> With everything that's happening, people might just need a little old-fashioned.</div></li><li> Inverted by the superhuman members of the main cast &#8212; Hulk, Iron Man, Thor, and Captain America wear pretty flamboyant, colorful attires (or <em>are</em> colorful in the case of Hulk). All protagonists clad head to toe in black (Black Widow, Hawkeye, Nick Fury, Agent Coulson) are <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Badass Normal</a> at best.</li><li> Tony lampshades the trope by mocking Thor's "Shakespearean" attire, and Steve Rogers' "spangly outfit" (noting that Rogers wears the "Captain America" uniform constantly, as if it's casual attire).</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MrFanservice' title='/pmwiki/pmwiki.php/Main/MrFanservice'>Mr. Fanservice</a>: Ladies, take your pick. The blond, clean-cut, blue-eyed, all-American <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NiceGuy' title='/pmwiki/pmwiki.php/Main/NiceGuy'>Nice Guy</a>? The <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TallDarkAndSnarky' title='/pmwiki/pmwiki.php/Main/TallDarkAndSnarky'>tall, dark</a>, and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeadpanSnarker' title='/pmwiki/pmwiki.php/Main/DeadpanSnarker'>snarky</a> genius billionaire playboy philanthropist? The hunky god with an accent? The <img src="/images/article-hreficon-ymmv.png" class="ymmv1 rounded" title="This example contains a YMMV entry. It should be moved to the YMMV tab."><a class='twikilink' href='/pmwiki/pmwiki.php/Main/DracoInLeatherPants' title='/pmwiki/pmwiki.php/Main/DracoInLeatherPants'>Draco in Leather Pants</a> pretty boy <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBad' title='/pmwiki/pmwiki.php/Main/BigBad'>Big Bad</a>? The stoic, "cool loner" archer? The bespectacled scientist? Almost all of whom are incredibly buff and march around in skin-tight clothing, shiny badass armor, and/or sleeveless wardrobe with arms the size of tree trunks?</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MsFanservice' title='/pmwiki/pmwiki.php/Main/MsFanservice'>Ms. Fanservice</a>: Black Widow, Pepper Potts and Maria Hill all receive some <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MaleGaze' title='/pmwiki/pmwiki.php/Main/MaleGaze'>Male Gaze</a>. Pepper Potts, in particular, shows up to a meeting with Tony Stark wearing daisy dukes and no shoes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MyGodWhatHaveIDone' title='/pmwiki/pmwiki.php/Main/MyGodWhatHaveIDone'>My God, What Have I Done?</a>: Poor Selvig, awakening from Loki's mind control to the sight of Manhattan being devastated by the Chitauri he'd helped unleash.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MythologyGag' title='/pmwiki/pmwiki.php/Main/MythologyGag'>Mythology Gag</a>:<ul ><li> The Tesseract facility at the beginning of the film is revealed to be Project Pegasus, a S.H.I.E.L.D. research site from the comics.</li><li> While discussing the Tesseract, Dr. Selvig claims it will unveil a path to a "<a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheNewUniverse' title='/pmwiki/pmwiki.php/ComicBook/TheNewUniverse'>new universe</a>".</li><li> "You have reached the Life Model Decoy of Tony Stark." Life Model Decoy is the term used for an entire sub-set of robotic "clones" featured in the comics.</li><li> Georgi Luchkow, the Russian who Black Widow beats up early in the movie, shares his name with a minor Black Widow villain from the early '90s.</li><li> When The Other threatens Loki to make him "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/FateWorseThanDeath' title='/pmwiki/pmwiki.php/Main/FateWorseThanDeath'>long for something sweet as pain</a>" should he fail, one of the Chitauri's giant snakes can be seen moving through the background. In Norse Mythology, Loki is punished for his role in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Gotterdammerung' title='/pmwiki/pmwiki.php/Main/Gotterdammerung'>Ragnar&ouml;k</a> by having a snake drip venom in his eyes for all eternity.</li><li> During Thor and Loki's conversation on the cliffside, two ravens fly past, evoking Odin's two ravens in <a class='twikilink' href='/pmwiki/pmwiki.php/Myth/NorseMythology' title='/pmwiki/pmwiki.php/Myth/NorseMythology'>Norse Mythology</a>.</li><li> Where the last couple <em>Hulk</em> movies referenced the character's iconic purple pants; <em>Avengers</em> reference is subtler by having Banner wear a purple shirt for most of the film.</li><li> The fact that the first Antagonist that the Avengers face together as a team is Loki, as well as Loki's attempt to use the Hulk against the other members, can be seen as a Homage to the first Avengers Issue!</li><li> The air-dropped prison intended to kill the Hulk if necessary references the way that Hulk died in <a class='twikilink' href='/pmwiki/pmwiki.php/Series/TheIncredibleHulk1977' title='/pmwiki/pmwiki.php/Series/TheIncredibleHulk1977'>the TV show</a>: He fell out of an aircraft as Hulk and landed as Banner. The glass cell itself is also inspired by a containment cell designed for the Hulk that was built in the Triskelion in <em><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheUltimates' title='/pmwiki/pmwiki.php/ComicBook/TheUltimates'>The Ultimates</a></em>.</li><li> This one is half-Mythology Gag, half-Continuity Nod; <span class="spoiler" title="you can set spoilers visible by default on your profile" >Banner mentions that at one point, he tried to kill himself with a pistol "and the other guy spat out the bullet."</span> This was going to be the opening scene in <em>The Incredible Hulk</em> film (and actually appeared in the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlternateUniverse' title='/pmwiki/pmwiki.php/Main/AlternateUniverse'>Alternate Universe</a> miniseries "Banner!") but was cut because Louis Leterrier, who directed this <em>Hulk</em> film, thought it would be too dark (and yet that scene showed up in the video game tie-in, as well as the novelization). Years earlier, this also happened in the comics.</li><li> Within the movie continuity, Hulk chasing Black Widow through a narrow corridor can bring to mind a similar scene from <em>Iron Man</em> where Iron Monger chases Pepper.</li><li> The Captain America trading cards display artwork by <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JackKirby' title='/pmwiki/pmwiki.php/Creator/JackKirby'>Jack Kirby</a>, save for the one that has a picture of Cap in his stage show outfit.</li><li> When giving <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a> to Loki, a dying <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span> mentions, "<a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Thanos' title='/pmwiki/pmwiki.php/ComicBook/Thanos'>You're going to lose. It's in your nature.</a>"</li><li> From a deleted scene: The security guard asks Bruce "<a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/AntMan' title='/pmwiki/pmwiki.php/ComicBook/AntMan'>Are you a big guy that gets all little? Or a little guy who sometimes blows up to be all big</a>?"</li><li> While talking to Loki, Tony refers to the Avengers as "Earth's mightiest heroes", a moniker that has followed the team since day one.</li><li> The idea of Tony's Iron Man armor being a flying module that unfolds and wraps around Tony, armoring him up, <a class='urllink' href='http://www.ironmanarmory.com/HR_Armoring_Up.html'>dates back to the late 90s<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> (after the <em>Heroes Reborn</em> period).</li><li> Banner mentions that he's <span class="spoiler" title="you can set spoilers visible by default on your profile" >always angry, can transform into the Hulk at will, and implies that the two personalities are more or less on the same wavelength</span>; the <em><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/WorldWarHulk' title='/pmwiki/pmwiki.php/ComicBook/WorldWarHulk'>World War Hulk</a></em> arc is built around this.</li><li> During <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheOner' title='/pmwiki/pmwiki.php/Main/TheOner'>The Oner</a> across NYC, Captain America and Iron Man pull off a fusion move lifted directly from <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/MarvelUltimateAlliance' title='/pmwiki/pmwiki.php/VideoGame/MarvelUltimateAlliance'>Marvel Ultimate Alliance</a></em>.</li><li> While Hulk never says "Hulk smash!", or "Puny humans!", his two most famous catch phrases in the comics, both of them are alluded to. Captain America commands Hulk to smash (his exact words being, "and Hulk... Smash."), and Hulk calls Loki a "puny god".</li><li> James Eckhouse appears as Senator Boynton, a minor character during the <em>Armor Wars</em> storyline. He is seen <span class="spoiler" title="you can set spoilers visible by default on your profile" >near the end, asking on a cable news show about where the Avengers are and who they should be accountable to.</span></li><li> Romy Rosemont appears as Shawna Lynde, a Thor supporting character during the 1980s.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki has his mouth sealed shut at the end of the film, echoing <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MouthStitchedShut' title='/pmwiki/pmwiki.php/Main/MouthStitchedShut'>his mouth being sewn shut</a> by dwarves in <a class='twikilink' href='/pmwiki/pmwiki.php/Myth/NorseMythology' title='/pmwiki/pmwiki.php/Myth/NorseMythology'>Norse Mythology</a>.</span></li><li> At the end of the movie, Nick Fury says that all this was a message to the universe: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumansAreSpecial' title='/pmwiki/pmwiki.php/Main/HumansAreSpecial'>Humans Are Special</a>, defy the odds, and nobody should try to go to war with them. There was a similar premise at the end of the <em><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/UltimateGalactusTrilogy' title='/pmwiki/pmwiki.php/ComicBook/UltimateGalactusTrilogy'>Ultimate Galactus Trilogy</a></em>. <span class="spoiler" title="you can set spoilers visible by default on your profile" >However, the unwanted consequence of this message, attracting the interest of Thanos, is a twist exclusive of the movie.</span></li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >"To challenge them is to court death." The primary aspect of Thanos' motivations in the comic books is that he saw the personification of death when he was young... and fell in love with her. Now you know why he's smiling.</span></li><li> Remember that scene when Loki claims to be so superior to Hulk, followed by Hulk tossing him around like a rag doll and making a "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShutUpHannibal' title='/pmwiki/pmwiki.php/Main/ShutUpHannibal'>Shut Up, Hannibal!</a>!" scene? Well, in <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheUltimates' title='/pmwiki/pmwiki.php/ComicBook/TheUltimates'>The Ultimates</a> Hulk had done a similar thing to the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBad' title='/pmwiki/pmwiki.php/Main/BigBad'>Big Bad</a>, Herr Kleiser, but much more devastating. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Let's just say that Loki ended unconscious; Kleiser ended up dead and eaten by Hulk</span></li></ul></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder1');">&nbsp;&nbsp;&nbsp;&nbsp;N&nbsp;</div><div id="folder1" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NakedPeopleAreFunny' title='/pmwiki/pmwiki.php/Main/NakedPeopleAreFunny'>Naked People Are Funny</a>: Dr. Banner's nudity after crashing through the factory is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedForLaughs' title='/pmwiki/pmwiki.php/Main/PlayedForLaughs'>Played for Laughs</a> by the security guard.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName' title='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName'>A Nazi by Any Other Name</a>: One of the first things Loki does on earth is to force a crowd of Germans to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KneelBeforeZod' title='/pmwiki/pmwiki.php/Main/KneelBeforeZod'>kneel before him</a> while performing <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BreakingSpeech' title='/pmwiki/pmwiki.php/Main/BreakingSpeech'>a speech</a> about how humans "were born to be ruled". One <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBystander' title='/pmwiki/pmwiki.php/Main/BadassBystander'>old German</a> calls him out on this while refusing to kneel:<div class='indent'><strong>Old German:</strong> Not to men like you. <br /><strong>Loki:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AGodAmI' title='/pmwiki/pmwiki.php/Main/AGodAmI'>There are no men like me.</a> <br /><strong>Old German:</strong> There are <a class='twikilink' href='/pmwiki/pmwiki.php/UsefulNotes/AdolfHitler' title='/pmwiki/pmwiki.php/UsefulNotes/AdolfHitler'>always men like you.</a></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NeckLift' title='/pmwiki/pmwiki.php/Main/NeckLift'>Neck Lift</a>: Loki does this to Tony, right before <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DestinationDefenestration' title='/pmwiki/pmwiki.php/Main/DestinationDefenestration'>tossing him out of the Stark Tower window</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NervesOfSteel' title='/pmwiki/pmwiki.php/Main/NervesOfSteel'>Nerves of Steel</a>: The <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Badass Normals</a> of the group keep their cool when surrounding by an alien invasion and lacking superpowers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NeverFoundTheBody' title='/pmwiki/pmwiki.php/Main/NeverFoundTheBody'>Never Found the Body</a>: Downplayed. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson</span> <em>appears</em> to die, but the scene cuts away before we find out whether he was really <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OnlyMostlyDead' title='/pmwiki/pmwiki.php/Main/OnlyMostlyDead'>Only Mostly Dead</a> and taken to a hospital room. Fury plays the death for all it's worth in getting the bickering heroes to put aside their differences but is explicitly shown to be a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ConsummateLiar' title='/pmwiki/pmwiki.php/Main/ConsummateLiar'>Consummate Liar</a> about other things <span class="spoiler" title="you can set spoilers visible by default on your profile" >(including lying about the Captain America trading cards being taken from Coulson's body, rather than his locker!)</span>. Later events in the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse'>MCU</a> confirm that he did, in fact, die. <span class="spoiler" title="you can set spoilers visible by default on your profile" >But <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ComicBookDeath' title='/pmwiki/pmwiki.php/Main/ComicBookDeath'>he got better.</a></span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NeverSpeakIllOfTheDead' title='/pmwiki/pmwiki.php/Main/NeverSpeakIllOfTheDead'>Never Speak Ill of the Dead</a>: In contrast to his teammates, Tony calls <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson</span> an idiot for trying to take Loki on alone but it quickly becomes clear that this is really just Tony's way of trying to ensure the cracks in his usual snarky facade don't overwhelm him completely.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NeverTrustATrailer' title='/pmwiki/pmwiki.php/Main/NeverTrustATrailer'>Never Trust a Trailer</a>:<ul ><li> That scene where Black Widow stands in front of an explosion? It's not in the film. Many alternate takes are used as well.</li><li> Coulson never suggests a "time out".</li><li> Stark's listing of the Avengers members includes himself ("And then there's me...") in the trailer version. In the film, <span class="spoiler" title="you can set spoilers visible by default on your profile" >he names Coulson instead.</span></li><li> The circumstances surrounding the Hulk catching Iron Man are different from what the trailers would have you believe. It's a case of clever editing. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man's falling because he's out of power after a long fight, ending with his delivering a nuke to the Chitauri control ship, not because he was shot out of the sky.</span> See also <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrailersAlwaysSpoil' title='/pmwiki/pmwiki.php/Main/TrailersAlwaysSpoil'>Trailers Always Spoil</a>.</li><li> The editing would also have you believe that Loki was smirking at the Black Widow when he first escorted into the helicarrier, when in fact he is smiling at Bruce Banner.</li><li> Editing suggests Thor laughs at Tony's rebuttal when Captain America asks what use he is without his armor. In the movie, Black Widow is the one shown amused by the response, though it's much more muted. Thor is actually laughing at how "You people are so petty... and tiny."</li><li> Tony's delivery of his rebuttal in the trailers is calm and just a little snarky, while in the actual movie it's much quicker and a bit more mean-spirited.</li><li> Steve and Tony's curt introduction to each other ("Mr. Stark." "Captain.") occurs not on the Helicarrier when they're out of uniform, but in Stuttgart while they're both suited up.</li><li> In the trailer Tony says "Guys, I'm bringing the party to you", but in the movie it's "Then tell <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk' title='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk'>him</a> to suit up, I'm bringing the party to you."</li><li> Nick Fury's speech is longer in the movie:<div class='indent'><strong>Nick Fury:</strong> <em>[trailer]</em> There was an idea to bring together a group of remarkable people, so when we needed them, they could fight the battles that we never could. <br /><strong>Nick Fury:</strong> <em>[movie]</em> There was an idea, Stark knows this, called the Avengers Initiative. The idea was to bring together a group of remarkable people. See if they could become something more. See if they could work together when we needed them to, to fight the battles that we never could. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Phil Coulson died still believing in heroes... Well, it's an old-fashioned notion.</span></div></li><li> In the teaser trailer, Fury says, "Gentlemen, you're up." This was actually two separate lines clipped together. In the actual movie, he says, "Gentlemen" when Rogers and Banner first step on to the Helicarrier bridge, and "Captain, you're up" when they find Loki in Germany.</li><li> That strange chord that plays when the Leviathan rounds the building chasing Iron Man doesn't play in the film. It's been replaced with a roar.</li><li> The trailer adds an eerie green glow to the shot of the S.H.I.E.L.D. agents outside the shack where Widow is talking Banner, implying he Hulks out at this point. In the film, he does not.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NewscasterCameo' title='/pmwiki/pmwiki.php/Main/NewscasterCameo'>Newscaster Cameo</a>: MSNBC's Thomas Roberts and NY1's Pat Kiernan both cover the aftermath of the final battle. Kiernan would later become the go-to person whenever the MCU needs an American newscaster to report on events.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NiceJobFixingItVillain' title='/pmwiki/pmwiki.php/Main/NiceJobFixingItVillain'>Nice Job Fixing It, Villain</a>: Loki's scheme helps bring the Avengers together, which pays homage to Loki's role in the <em>Avengers</em> comic-book origin, where he brings the team together even more accidentally.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheNicknamer' title='/pmwiki/pmwiki.php/Main/TheNicknamer'>The Nicknamer</a>: Tony calls Loki "<a class='twikilink' href='/pmwiki/pmwiki.php/WesternAnimation/RudolphTheRedNosedReindeer' title='/pmwiki/pmwiki.php/WesternAnimation/RudolphTheRedNosedReindeer'>Reindeer Games</a>" (because of the horns on his helmet) and "<a class='twikilink' href='/pmwiki/pmwiki.php/Film/RockOfAges' title='/pmwiki/pmwiki.php/Film/RockOfAges'>Rock of Ages</a>" (because of the hair), his scepter "the Glowstick of Destiny" (because of its Mind Control properties and how it <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PowerGlows' title='/pmwiki/pmwiki.php/Main/PowerGlows'>glows</a>, and also a reference to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSpearOfDestiny' title='/pmwiki/pmwiki.php/Main/TheSpearOfDestiny'>The Spear of Destiny</a>), refers to Steve being frozen as a "Capsicle", he calls Thor "<a class='twikilink' href='/pmwiki/pmwiki.php/Film/PointBreak1991' title='/pmwiki/pmwiki.php/Film/PointBreak1991'>Point Break</a>" (because of his long blonde hair, muscles and beard), and Clint Barton "<a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheLordOfTheRings' title='/pmwiki/pmwiki.php/Film/TheLordOfTheRings'>Legolas</a>" (because of his bow and arrow). It <em>is</em> a <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> movie, after all.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NinjaPirateZombieRobot' title='/pmwiki/pmwiki.php/Main/NinjaPirateZombieRobot'>Ninja Pirate Zombie Robot</a>:<ul ><li> Tony Stark, a self-described "genius billionaire playboy philanthropist" who is also a super hero.</li><li> The Leviathans which are something like giant cyborg space snakes that serve as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AwesomePersonnelCarrier' title='/pmwiki/pmwiki.php/Main/AwesomePersonnelCarrier'>Awesome Personnel Carriers.</a></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoEndorHolocaust' title='/pmwiki/pmwiki.php/Main/NoEndorHolocaust'>No Endor Holocaust</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DefiedTrope' title='/pmwiki/pmwiki.php/Main/DefiedTrope'>Defied Trope</a>.<ul ><li> During the massive superhero battle in the middle of Manhattan, no civilian casualties are shown. However, in the aftermath, the news footage includes several shots of people lighting candles and putting up messages on memorial walls. A framed <em>Bulletin</em> front page that Ben Urich keeps in his office in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/Daredevil2015' title='/pmwiki/pmwiki.php/Series/Daredevil2015'>Daredevil (2015)</a></em> says that hundreds of people were killed. When the Leviathans die, they are shown then crashing to ground <span class="spoiler" title="you can set spoilers visible by default on your profile" >and Captain America urges Black Widow to close the portal so the nuclear explosion doesn't come back to Earth.</span></li><li> <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/Daredevil2015' title='/pmwiki/pmwiki.php/Series/Daredevil2015'>Daredevil (2015)</a></em> established that Hell's Kitchen took a lot of damage from the invasion, and Wilson Fisk is taking advantage of bid rigging on reconstruction contracts.</li><li> Joss Whedon didn't want any of the jets to fall off the Helicarrier because that also would be an aversion. He commented that it would kill innocent people, and he didn't want viewers blaming the Avengers or S.H.I.E.L.D. for that. Prior to take off workers are shown strapping the jets down, which is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TruthInTelevision' title='/pmwiki/pmwiki.php/Main/TruthInTelevision'>Truth in Television</a> for procedure for securing an aircraft exposed to winds that strong that are not intended to experience lift.</li><li> <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/SpiderManHomecoming' title='/pmwiki/pmwiki.php/Film/SpiderManHomecoming'>Spider-Man: Homecoming</a></em> reveals that a black market sprung up selling weapons made from alien tech left behind by the invasion, giving New York's criminals more firepower than they ever could have dreamed of.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoHoldsBarredBeatdown' title='/pmwiki/pmwiki.php/Main/NoHoldsBarredBeatdown'>No-Holds-Barred Beatdown</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hulk grabs Loki by the ankle and slams him into the floor like a rag doll about five times.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoodleIncident' title='/pmwiki/pmwiki.php/Main/NoodleIncident'>Noodle Incident</a>: Black Widow and Hawkeye make numerous references to these from their partnership.<div class='indent'><strong>Black Widow:</strong> This is just like Budapest all over again. <br /><strong>Hawkeye:</strong> You and I remember Budapest <em>very</em> differently.</div><dl ><dt></dt><dd> Earlier, in a video file, you see the two in a similar situation, caught between cars and firing in all directions.</dd></dl></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoOSHACompliance' title='/pmwiki/pmwiki.php/Main/NoOSHACompliance'>No OSHA Compliance</a>: The Helicarrier's angled flight deck leads directly to one of the huge rotors. This means that pilots making use of the flight deck better pray that they land the first time because overshooting will mean getting sucked into a rotor designed to <em>pull the air above it and direct it down with enough force to lift an aircraft carrier.</em> The helicarrier <em>can</em> apparently stay in the air with one of the rotors turned off to make landings safer, but that endangers the entire helicarrier, and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ArsonMurderAndJaywalking' title='/pmwiki/pmwiki.php/Main/ArsonMurderAndJaywalking'>leads to uneven wear</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoPartyGiven' title='/pmwiki/pmwiki.php/Main/NoPartyGiven'>No Party Given</a>: Averted. Senator Boynton, the politician criticizing the Avengers at the end of the movie, is explicitly labeled as a Democrat though if you blink, you miss it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoSell' title='/pmwiki/pmwiki.php/Main/NoSell'>No-Sell</a>:<ul ><li> Thor's lightning is <span class="spoiler" title="you can set spoilers visible by default on your profile" >absorbed by Tony's Arc Reactor, charging his suit up to 400% capacity</span>. <em>Neither</em> of them actually saw that coming. This might double as a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MythologyGag' title='/pmwiki/pmwiki.php/Main/MythologyGag'>Mythology Gag</a> or <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ContinuityNod' title='/pmwiki/pmwiki.php/Main/ContinuityNod'>Continuity Nod</a>, since in <em>Iron Man 2</em> it was indicated (in the notes that are briefly shown on screen) that his father developed the Arc Reactor technology from reverse engineering the Tesseract. So, his suit was built as a knock-off of Asgardian technology... so Asgardian lightning charging it up actually makes sense.</li><li> Iron Man attempts to overpower Thor via headbutting, and Thor simply gives him an incredulous look akin to "Seriously?" He then returns the favour to greater effectiveness.</li><li> The Hulk gets shot at by a jet's gatling gun in order to distract him and keep him from wreaking havoc on the Helicarrier. He doesn't appear to even notice until he hears the bullets bouncing off of him. During the final battle he also takes a couple of shots from the Chitauri foot soldiers arm-cannons, and it does absolutely nothing.</li><li> Loki gets a very unpleasant surprise when <span class="spoiler" title="you can set spoilers visible by default on your profile" >his mind-control powers are blocked by Tony's Arc Reactor</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoSuchThingAsSpaceJesus' title='/pmwiki/pmwiki.php/Main/NoSuchThingAsSpaceJesus'>No Such Thing as Space Jesus</a>: As Captain America prepares to dive into a battle involving Thor and Loki:<div class='indent'><strong>Black Widow:</strong> These guys are from legends. They're basically gods. <br /><strong>Captain America:</strong> There's only one God, ma'am. And I'm pretty sure He doesn't dress like that.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NothingCanStopUsNow' title='/pmwiki/pmwiki.php/Main/NothingCanStopUsNow'>Nothing Can Stop Us Now!</a>: Loki gives one of these to Tony Stark just before the Chitauri invasion. True to form, Tony never loses his cool.<div class='indent'><strong>Loki:</strong> I have an army. <br /><strong>Tony:</strong> We have a Hulk.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NotSoDifferentRemark' title='/pmwiki/pmwiki.php/Main/NotSoDifferentRemark'>"Not So Different" Remark</a>: Tony and Loki, much to Tony's chagrin.<div class='indent'><strong>Tony:</strong> ... And Loki, he's a full-tilt diva! He wants flowers, he wants parades, he wants a monument built to the skies with his name plastered on&#8212; <br /><em>[realizes he's describing Stark Tower and in turn, himself]</em> <br /><strong>Tony:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExplainExplainOhCrap' title='/pmwiki/pmwiki.php/Main/ExplainExplainOhCrap'>Sonofabitch</a>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NotThatKindOfDoctor' title='/pmwiki/pmwiki.php/Main/NotThatKindOfDoctor'>Not That Kind of Doctor</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Inverted' title='/pmwiki/pmwiki.php/Main/Inverted'>Inverted</a> by Bruce Banner: he's a physicist, but is seen practicing medicine in the slums of Calcutta.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NotTheFallThatKillsYou' title='/pmwiki/pmwiki.php/Main/NotTheFallThatKillsYou'>Not the Fall That Kills You…</a>: Played straight for the most part, except for one instance where <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Hulk rescues a falling Iron Man by sliding down a building to slow his fall, then sliding several hundred yards down the street before finally coming to a stop. He then just drops Iron Man on the ground</span>.</li></ul><!-- The Scottish Trope is more appropriate than Not Using The Zed Word.--><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NukeEm' title='/pmwiki/pmwiki.php/Main/NukeEm'>Nuke 'em</a>: Zigzag'ed. <span class="spoiler" title="you can set spoilers visible by default on your profile" >The World Security Council</span>'s solution to the alien threat is to target <span class="spoiler" title="you can set spoilers visible by default on your profile" >Manhattan</span> with a nuclear missile. Nick Fury mentions how monumentally stupid it is. <span class="spoiler" title="you can set spoilers visible by default on your profile" >However, Iron Man re-appropriates the nuke to strike the Chitauri mothership instead, though it wasn't absolutely necessary for victory (Black Widow was about to close the portal).</span></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder2');">&nbsp;&nbsp;&nbsp;&nbsp;O&nbsp;</div><div id="folder2" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ObfuscatingStupidity' title='/pmwiki/pmwiki.php/Main/ObfuscatingStupidity'>Obfuscating Stupidity</a>: Black Widow was introduced during an interrogation with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheMafiya' title='/pmwiki/pmwiki.php/Main/TheMafiya'>a Russian mobster type</a> who calls her "just another pretty face" while she manipulates information out of him by pretending to be a naive prisoner. She later uses a similar interrogation technique on Loki, playing up her vulnerability until he feels the need to threaten her and reveal something of his plan.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ObstructiveBureaucrat' title='/pmwiki/pmwiki.php/Main/ObstructiveBureaucrat'>Obstructive Bureaucrat</a>: The World Security Council. Styling themselves like an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OmniscientCouncilOfVagueness' title='/pmwiki/pmwiki.php/Main/OmniscientCouncilOfVagueness'>Omniscient Council of Vagueness</a> is bad enough, but then they go and act like complete jerks.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ObviousStuntDouble' title='/pmwiki/pmwiki.php/Main/ObviousStuntDouble'>Obvious Stunt Double</a>: Near the start of the film, Black Widow is being awesome. Only, <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/ScarlettJohansson' title='/pmwiki/pmwiki.php/Creator/ScarlettJohansson'>Scarlett Johansson</a> isn't. It's her stunt double, Heidi Moneymaker. Usually, you'd be too enthralled by the fact they're flipping around strapped to a chair, but the change in hair color and the additional muscle makes it a bit obvious.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OccultBlueEyes' title='/pmwiki/pmwiki.php/Main/OccultBlueEyes'>Occult Blue Eyes</a>: When Loki mind-controls someone, their eyes glow bright blue as an indication (the same color as the shell covering the gem in Loki's staff and the color of the Tesseract), and when released from the mind-control, the eyes turn back to normal.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OddFriendship' title='/pmwiki/pmwiki.php/Main/OddFriendship'>Odd Friendship</a>: Pretty much any pairing minus Black Widow and Hawkeye. A standout though is Tony and Bruce, who bond over their <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CursedWithAwesome' title='/pmwiki/pmwiki.php/Main/CursedWithAwesome'>physical handicaps</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ProperlyParanoid' title='/pmwiki/pmwiki.php/Main/ProperlyParanoid'>shared suspicion of S.H.I.E.L.D.</a>, and that they're the only ones who actually "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>speaks English</a>".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OffhandBackhand' title='/pmwiki/pmwiki.php/Main/OffhandBackhand'>Offhand Backhand</a>:<ul ><li> Thor does this to Iron Man right before he "drops" his hammer on Cap.</li><li> Hawkeye does it with arrows. <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> admitted outright to really enjoying having him do that, purely for <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RuleOfCool' title='/pmwiki/pmwiki.php/Main/RuleOfCool'>Rule of Cool</a>.</li><li> After the two kick some serious Chitauri ass together, Hulk punches Thor <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/PunchedAcrossTheRoom' title='/pmwiki/pmwiki.php/Main/PunchedAcrossTheRoom'>right out of the shot</a></em> as the dust settles, for no reason other than there being nothing else around to punch.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OffscreenVillainDarkMatter' title='/pmwiki/pmwiki.php/Main/OffscreenVillainDarkMatter'>Offscreen Villain Dark Matter</a>: Selvig asks Hawkeye where they got all these advanced supplies to help Loki's scheme. Hawkeye responds that <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Handwave' title='/pmwiki/pmwiki.php/Main/Handwave'>S.H.I.E.L.D. has many enemies</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OhCrap' title='/pmwiki/pmwiki.php/Main/OhCrap'>Oh, Crap!</a>:<ul ><li> Natasha's reaction when she realizes that she's been tasked with recruiting The Hulk.<div class='indent'><strong>Natasha:</strong> Bozhe moi... <span class="notelabel" onclick="togglenote('note1zrz0');"><sup>note&nbsp;</sup></span><span id="note1zrz0" class="inlinefolder" isnote="true" onclick="togglenote('note1zrz0');" style="cursor:pointer;font-size:smaller;display:none;">Russian for "Oh my God"</span></div></li><li> Loki has this look on his face when Thor arrives on Earth and lands on the Quinjet to take Loki with him.</li><li> Tony has a blink and you'll miss it one when <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thor starts crushing his gauntlet.</span></li><li> When Banner informs the others that he once tried to commit suicide by sticking a gun in his mouth and "the other guy" spit out the bullet, everyone stares at him in silence as a quasi-godlike alien who spent centuries fighting giant monsters for amusement, a super-soldier used to taking on ridiculous odds, a cocky genius who tried to deliberately provoke him into changing into the Hulk for a laugh, and a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MagnificentBastard' title='/pmwiki/pmwiki.php/Main/MagnificentBastard'>Magnificent Bastard</a> superspy all suddenly realize what the mild-mannered guy they've pretty much been taking for granted could likely do if he gets annoyed. <span style="display:none">invoked</span></li><li> When she's pinned down <span class="spoiler" title="you can set spoilers visible by default on your profile" >during the attack on the Helicarrier, within a few feet from Banner, <em>and he's changing</em>.</span></li><li> Thor has a dawning realization of just how much <strong>rage</strong> Hulk has when he looks Hulk in the eye for the first time.</li><li> The S.H.I.E.L.D. pilot's reaction when he tries to distract the Hulk by shooting at him with a Gatling gun <span class="spoiler" title="you can set spoilers visible by default on your profile" >and the Hulk jumps toward the plane</span>:<div class='indent'><strong>Pilot:</strong> Target angry! <em>Target angry!!</em></div></li><li> Tony has a humorous one when Cap is the only one around to fix some some highly advanced equipment. When Tony asks what it's doing, Cap replies that he's out of his depth.<div class='indent'><strong>Captain America:</strong> It seems to be powered by some sort of electricity! <br /><strong>Tony:</strong> Well... you're not wrong.</div></li><li> Tony Stark gets one when <span class="spoiler" title="you can set spoilers visible by default on your profile" >the blades of the turbine that he's been pushing start picking up speed, with him briefly getting carried along by one.</span><div class='indent'><strong>Tony:</strong> Uh oh.</div></li><li> He gets a brief one when it looks like Loki is about to mind-control him with the scepter, only for his arc reactor to block it.</li><li> He gets another right after <span class="spoiler" title="you can set spoilers visible by default on your profile" >he blasts Loki with the new Mk. VII armor... then sees the portal opening overhead, reminding him that the Chitauri are coming.</span><div class='indent'><strong>Tony:</strong> ...Right... <em>[HUD goes into battle mode]</em> ...<em>army</em>...</div></li><li> After Tony <span class="spoiler" title="you can set spoilers visible by default on your profile" >takes the Nuke through the portal. Before it blows up, he gets a brief glimpse of the world on the other side and the look in his eyes pretty much screams that.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OldSoldier' title='/pmwiki/pmwiki.php/Main/OldSoldier'>Old Soldier</a>: Black Widow is a lot less concerned about the Chitauri than you'd expect from a mundane soldier. She claims she saw worse in Budapest.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OmnidisciplinaryScientist' title='/pmwiki/pmwiki.php/Main/OmnidisciplinaryScientist'>Omnidisciplinary Scientist</a>: Bruce Banner is a physicist whose special field is radiation, while Tony Stark is an engineer specializing in weapons, robotics, and electricity generation, yet upon meeting each other for the first time, the two are immediately able to speak (and bond over) the same <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>Techno Babble</a>. Banner was also introduced (in the TV show) as "Physician, Scientist".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OnceMoreWithClarity' title='/pmwiki/pmwiki.php/Main/OnceMoreWithClarity'>Once More, with Clarity!</a>: Just like in <em>Thor</em>, a Stinger from a previous movie (<em>Thor</em> itself in this case) is fully elaborated here.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OneHitPolykill' title='/pmwiki/pmwiki.php/Main/OneHitPolykill'>One-Hit Polykill</a>: Hawkeye has a trick arrow that fires submunitions to achieve this effect.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OneManArmy' title='/pmwiki/pmwiki.php/Main/OneManArmy'>One-Man Army</a>: Each of the Avengers is a One-Man Army in their own right, but Tony Stark specifically describes the Hulk as one in the climax.<div class='indent'><strong>Loki:</strong> I have an army. <br /><strong>Tony:</strong> We have a <em>Hulk</em>.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheOner' title='/pmwiki/pmwiki.php/Main/TheOner'>The Oner</a>: There are a couple of notable ones. Joss is a fan.<ul ><li> On the Helicarrier, half of <span class="spoiler" title="you can set spoilers visible by default on your profile" >the blowout between all the Avengers</span> is a single shot, including the upside-down parts. The director's commentary mentions filming it was <em>crazy</em>.</li><li> We start with <span class="spoiler" title="you can set spoilers visible by default on your profile" >Black Widow riding a hijacked Chitauri craft... to Iron Man covering her back by blasting chasing craft... to Iron Man landing next to Captain America and reflecting his beam off of Cap's shield to clear out enemies... to Hawkeye picking off Chitauri from nearby and far... to Thor and Hulk fighting on top of a Leviathan and ultimately using a concerted effort to bring the monster down.</span> Marvel released this scene to the press to promote the Blu-Ray/DVD edition.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OnlyAFleshWound' title='/pmwiki/pmwiki.php/Main/OnlyAFleshWound'>Only a Flesh Wound</a>: Cap gets shot, and later Thor is stabbed, both in the abdomen. They suffer only momentarily since both are wearing armor.</li></ul><!-- <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheOtherDarrin' title='/pmwiki/pmwiki.php/Main/TheOtherDarrin'>The Other Darrin</a> is trivia.--><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OOCIsSeriousBusiness' title='/pmwiki/pmwiki.php/Main/OOCIsSeriousBusiness'>O.O.C. Is Serious Business</a>: Fury and the other Avengers are momentary shocked out of their psychically-induced squabbling when the gentle, easygoing Bruce Banner snarls, "In case you had to kill me. But you can't: <em>I've tried."</em></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OrbitalShot' title='/pmwiki/pmwiki.php/Main/OrbitalShot'>Orbital Shot</a>: During Nick Fury's famous quote &#8212; "I recognize the council has made a decision, but given that it's a stupid-ass decision, I've elected to ignore it." &#8212; the camera is orbiting around him and the holographic screens showing the council.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OrificeInvasion' title='/pmwiki/pmwiki.php/Main/OrificeInvasion'>Orifice Invasion</a>: Tony can't break through the armor and thick skin of the leviathan alien, so when it opens its mouth, Tony flies in there to see if its insides are vulnerable. It works.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OrganDodge' title='/pmwiki/pmwiki.php/Main/OrganDodge'>Organ Dodge</a>: Loki's mind-control staff works by poking the target over the heart. It doesn't work on Tony Stark because his implanted arc reactor is in the way.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OutOfFocus' title='/pmwiki/pmwiki.php/Main/OutOfFocus'>Out of Focus</a>:<ul ><li> Thor is used sparingly compared to the rest of the Avengers. <a class='twikilink' href='/pmwiki/pmwiki.php/Administrivia/TropesAreTools' title='/pmwiki/pmwiki.php/Administrivia/TropesAreTools'>This works nicely</a> &#8212; since Loki is the main villain, the film could have risked being <em>Thor 2</em> if he'd had too much screentime, and his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CharacterDevelopment' title='/pmwiki/pmwiki.php/Main/CharacterDevelopment'>Character Development</a> is mostly shown through body language and facial expressions. It also helps that the extended cast from his movie is inaccessible; Selvig is in enemy hands, Jane is MIA because Natalie Portman was pregnant during filming, and the rest of Asgard are stuck there due to the trashed Bifr&ouml;st (Thor got to Earth through a far less efficient method due to the emergency). The only person on the Helicarrier he knows is Agent Coulson. He does get a scene with Phil discussing his feelings about Loki targeting Earth.</li><li> Also Captain America, even though he has the most screentime, is usually not the focus on whatever scene he is in.</li><li> The real offender of this though is Hawkeye who, despite being one of the six featured leads, spends the first two acts under mind control. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EleventhHourRanger' title='/pmwiki/pmwiki.php/Main/EleventhHourRanger'>He doesn't really come into play until the climax.</a></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OutdatedOutfit' title='/pmwiki/pmwiki.php/Main/OutdatedOutfit'>Outdated Outfit</a>: Steve's fashions are hopelessly out of date and what he deems "casual" (long-sleeve collared shirts, maybe with the sleeves rolled up and slacks) seems stuffy and formal compared to Tony and Clint. Cap himself suggests that his old stars-and-stripes uniform is a bit old-fashioned. Coulson doesn't argue, but suggests that with everything that's happened, people "might need a little old-fashioned."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OutrunTheFireball' title='/pmwiki/pmwiki.php/Main/OutrunTheFireball'>Outrun the Fireball</a>:<ul ><li> During the prologue, <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Tesseract's deactivation leaves a remnant of portal energy, which builds up into a massively destructive blast which implodes the facility and forces everyone to outrace the collapse</span>.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >When the Chitauri mothership is destroyed by a nuclear missile, Captain America orders the portal closed to prevent the explosion from coming through to Earth. As the offline Iron Man falls back, not only does he have to get through the portal to come back home, but also to escape the nuclear explosion himself (he makes it with half a second to spare.)</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OutsideContextProblem' title='/pmwiki/pmwiki.php/Main/OutsideContextProblem'>Outside-Context Problem</a>: Oddly, both sides of the conflict are this to each other:<ul ><li> The human Avengers have only ever fought other humans, occasionally ones armed with fantastic science. Thor is the only one from the same <em>genre</em> as them, and even he has no idea where exactly they came from or who they answer to.<div class='indent'><strong>Steve:</strong> An army. From outer space.</div></li><li> The Avengers to the Chitauri's invasion force. It is made very clear that the Chitauri were expecting to simply waltz in and easily conquer the human race. Instead, their invasion is repelled in less than an hour by a team comprised of two <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Badass Normal</a> soldiers, an Asgardian warrior, a guy in powered armour, a super-soldier... and the Hulk. Best summed up in <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>The Stinger</a>;<div class='indent'><strong>The Other:</strong> To challenge them is to court death.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OutsideGenreFoe' title='/pmwiki/pmwiki.php/Main/OutsideGenreFoe'>Outside-Genre Foe</a>: Loki is, as S.H.I.E.L.D. agent Natasha Romanova (a.k.a. Black Widow) puts it, "nothing we were trained for" — most of the eponymous superteam are used to terrorists with fancy weapons, not mad physical gods from another dimension. Fortunately, Loki's elder brother Thor has dealt with his crap before and joins the human heroes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OutsideRide' title='/pmwiki/pmwiki.php/Main/OutsideRide'>Outside Ride</a>:<ul ><li> Black Widow hops on the back of an alien glider, though to be fair those don't really have an "inside" to begin with.</li><li> Also, Hulk and Thor both hop onto a Leviathan and take it apart.</li><li> Then there's the scene in which Thor lands on top of the Quinjet.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OverlyLongGag' title='/pmwiki/pmwiki.php/Main/OverlyLongGag'>Overly-Long Gag</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >The second stinger shows the the Avengers sitting quietly in a Shawarma restaurant, eating.</span></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder3');">&nbsp;&nbsp;&nbsp;&nbsp;P&nbsp;</div><div id="folder3" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PacManFever' title='/pmwiki/pmwiki.php/Main/PacManFever'>Pac Man Fever</a>: Downplayed. Tony Stark points out that one of the Helicarrier's crewmen is playing <a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a>. When he leaves, the crewman looks around and then goes back to his game. When he does, the sound of a tractor beam can be heard, but there aren't any on the screen.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PainfulTransformation' title='/pmwiki/pmwiki.php/Main/PainfulTransformation'>Painful Transformation</a>: The Hulk's first transformation looks excruciating and takes a long time, because Banner is fighting it the whole time.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ParallelConflictSequence' title='/pmwiki/pmwiki.php/Main/ParallelConflictSequence'>Parallel Conflict Sequence</a>: Happens a couple of times, with the first time being the downed helicarrier scene when Thor fights Hulk, Black Widow fights Hawkeye, and Iron Man and Captain America try to get the broken propellor back to full function. It is displayed briefly during the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FinalBattle' title='/pmwiki/pmwiki.php/Main/FinalBattle'>Final Battle</a> as well when Loki is fought by Thor (and later Hulk in a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbstompBattle' title='/pmwiki/pmwiki.php/Main/CurbstompBattle'>Curbstomp Battle</a>) while the other Avengers fight the Chitauri army.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LeParkour' title='/pmwiki/pmwiki.php/Main/LeParkour'>Le Parkour</a>: Cap engages in this when New York becomes a war zone and the streets are littered with cars and debris.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PassThePopcorn' title='/pmwiki/pmwiki.php/Main/PassThePopcorn'>Pass the Popcorn</a>: Loki sitting comfortably to enjoy the fight between Thor and Iron Man.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PercussiveShutdown' title='/pmwiki/pmwiki.php/Main/PercussiveShutdown'>Percussive Shutdown</a>: Subverted in Tony's attempt to destroy the portal generator. Double subverted in that his attempt brought <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Selvig</a> to his senses, leading to the portal generator being shut down by more conventional means.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PercussiveTherapy' title='/pmwiki/pmwiki.php/Main/PercussiveTherapy'>Percussive Therapy</a>: In the beginning, Steve Rogers is using said therapy to deal with the loss of his familiar world after waking 70 years later. He gets so into it he literally knocks a heavy punching bag off its stand. He even takes one home.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PetTheDog' title='/pmwiki/pmwiki.php/Main/PetTheDog'>Pet the Dog</a>: Tony offering to fly Phil Coulson on a private jet to Portland, apparently having overheard his earlier conversation with Pepper where he mentioned that he'd had to break it off with his girlfriend after she'd moved there.<div class='indent'><strong>Tony:</strong> I'll fly you to Portland, keep the love alive!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PhraseCatcher' title='/pmwiki/pmwiki.php/Main/PhraseCatcher'>Phrase Catcher</a>: At the climax, when Cap is divvying up tasks. Last up is the Hulk:<div class='indent'><strong>Cap:</strong> And Hulk... <em>[Hulk turns to Cap]</em> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheBigGuy' title='/pmwiki/pmwiki.php/Main/TheBigGuy'>Smash.</a></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PillarOfLight' title='/pmwiki/pmwiki.php/Main/PillarOfLight'>Pillar of Light</a>: The Tesseract beam fires up toward the sky <span class="spoiler" title="you can set spoilers visible by default on your profile" >while creating the portal</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PitifulWorms' title='/pmwiki/pmwiki.php/Main/PitifulWorms'>Pitiful Worms</a>: Loki has this opinion about the humans:<div class='indent'><strong>Fury:</strong> We have no quarrel with your people. <br /><strong>Loki:</strong> An ant has no quarrel with a boot.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayfulHacker' title='/pmwiki/pmwiki.php/Main/PlayfulHacker'>Playful Hacker</a>: Tony Stark points out that if S.H.I.E.L.D. expects him to be effective, he needs to know <em>everything</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayingGamesAtWork' title='/pmwiki/pmwiki.php/Main/PlayingGamesAtWork'>Playing Games at Work</a>: After <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/IronMan' title='/pmwiki/pmwiki.php/ComicBook/IronMan'>Tony Stark</a> comes aboard the Helicarrier, he gleefully points out that one of the bridge deckhands is playing <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a></em> at their desk. Shortly after the scene ends and the heroes leave, the deckhand turns their screen back to <em>Galaga</em> again.<span class="notelabel" onclick="togglenote('note2p6nk');"><sup>note&nbsp;</sup></span><span id="note2p6nk" class="inlinefolder" isnote="true" onclick="togglenote('note2p6nk');" style="cursor:pointer;font-size:smaller;display:none;">The line was <img src="/images/article-hreficon-trivia.png" class="trivia1 rounded" title="This example contains a TRIVIA entry. It should be moved to the TRIVIA tab."><a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThrowItIn' title='/pmwiki/pmwiki.php/Main/ThrowItIn'>an ad-lib</a> by <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/RobertDowneyJr' title='/pmwiki/pmwiki.php/Creator/RobertDowneyJr'>Robert Downey Jr.</a>, and later while editing, director <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> found a shot of a deckhand extra looking shifty, so he edited <em>Galaga</em> onto their screen.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlotTailoredToTheParty' title='/pmwiki/pmwiki.php/Main/PlotTailoredToTheParty'>Plot Tailored to the Party</a>: Played with. While there are few obstacles that can be overcome only by a specific superhero, it is unavoidable due to the very nature of the set-up. As Fury points out, the entire idea of the Avengers is to be a versatile and flexible response team.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PocketProtector' title='/pmwiki/pmwiki.php/Main/PocketProtector'>Pocket Protector</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony's Arc Reactor performs like one against Loki's brainwashing scepter</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PocketRocketLauncher' title='/pmwiki/pmwiki.php/Main/PocketRocketLauncher'>Pocket Rocket Launcher</a>: Tony's Mark V suit goes full <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MacrossMissileMassacre' title='/pmwiki/pmwiki.php/Main/MacrossMissileMassacre'>Macross Missile Massacre</a> against a swarm of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlienInvasion' title='/pmwiki/pmwiki.php/Main/AlienInvasion'>Chitauri</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HoverBike' title='/pmwiki/pmwiki.php/Main/HoverBike'>hover bikes</a>, but he runs out of ammunition before he can make much of a dent in their numbers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoisonousCaptive' title='/pmwiki/pmwiki.php/Main/PoisonousCaptive'>Poisonous Captive</a>: Loki will taunt you and demoralize you and lead his minions to you.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoliticallyIncorrectVillain' title='/pmwiki/pmwiki.php/Main/PoliticallyIncorrectVillain'>Politically Incorrect Villain</a>: Loki calling Natasha a "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/CountryMatters' title='/pmwiki/pmwiki.php/Main/CountryMatters'>mewling quim</a>".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PopCulturalOsmosisFailure' title='/pmwiki/pmwiki.php/Main/PopCulturalOsmosisFailure'>Pop-Cultural Osmosis Failure</a>: Steve doesn't get a lot of references the other characters make, like Pilates. When Fury puzzles Thor by mentioning <a class='twikilink' href='/pmwiki/pmwiki.php/Literature/TheWonderfulWizardOfOz' title='/pmwiki/pmwiki.php/Literature/TheWonderfulWizardOfOz'>"flying monkeys"</a>, Steve's happy that he finally got one. It also goes the other way, when Thor describes an Asgardian beast that Coulson is unfamiliar with.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThePowerOfFriendship' title='/pmwiki/pmwiki.php/Main/ThePowerOfFriendship'>The Power of Friendship</a>: Obviously a major theme in the movie. Tony Stark's kindness towards and acceptance of Bruce Banner/The Hulk, refusing to treat him like a ticking time bomb the way everyone else is, has drastic consequences later on, as not only does his insistence that the Hulk can be used for good get through to Bruce, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChangedMyMindKid' title='/pmwiki/pmwiki.php/Main/ChangedMyMindKid'>who decides to come back to help during the final battle</a>, but the Hulk <em>remembers</em> Tony and winds up saving his life.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThePowerOfTrust' title='/pmwiki/pmwiki.php/Main/ThePowerOfTrust'>The Power of Trust</a>: Between Stark and Banner. In this movie, Stark makes a point of offering Banner trust (even his poke in the stomach can be seen as a demonstration of his confidence in Banner's self control). Banner repays it in <em>spades</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PowerTrio' title='/pmwiki/pmwiki.php/Main/PowerTrio'>Power Trio</a>: Iron Man fits <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheKirk' title='/pmwiki/pmwiki.php/Main/TheKirk'>The Kirk</a>, and Captain America fits <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheMcCoy' title='/pmwiki/pmwiki.php/Main/TheMcCoy'>The McCoy</a>. Given that Thor is calculative and likes control, and that Banner (when he's not Hulk) is calm and logical, either one could be <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSpock' title='/pmwiki/pmwiki.php/Main/TheSpock'>The Spock</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PowerWalk' title='/pmwiki/pmwiki.php/Main/PowerWalk'>Power Walk</a>: Right before the final battle, Cap, Black Widow and Hawkeye walk out all together in full badassery.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PreAsskickingOneLiner' title='/pmwiki/pmwiki.php/Main/PreAsskickingOneLiner'>Pre-Asskicking One-Liner</a>:<ul ><li> Props to another Cap and Hulk scene at the beginning of the final battle where Cap asks Bruce how he manages to stay calm.<div class='indent'><strong>Captain America:</strong> Dr. Banner, now might be a good time to get angry. <br /><em>[Banner looks over his shoulder at Cap]</em> <br /><strong>Banner:</strong> That's my secret, Cap... I'm always angry. <br /><em>[Banner faces the gargantuan Chitauri ship, simultaneously turns into the Hulk, and stops its onslaught with a single punch]</em></div></li><li> Captain America gives one to the Hulk near the end of the film as he's giving the other heroes tasks to accomplish.<div class='indent'><strong>Captain America:</strong> And Hulk... <br /><em>[Hulk turns to face him]</em> <br /><strong>Captain America:</strong> Smash. <br /><em>[Hulk smirks and leaps towards some Chitauri]</em></div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PrecisionGuidedBoomerang' title='/pmwiki/pmwiki.php/Main/PrecisionGuidedBoomerang'>Precision-Guided Boomerang</a>: Both Thor and Cap toss their weapons around with this effect. Thor is justified by it being a magic hammer that he can summon to his hand whenever he wants. Cap is apparently really good at calculating ricochet angles in fractions of a second, for instance when he breaks up the Thor/Iron Man fight by bouncing it off both of their heads.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PreemptiveShutUp' title='/pmwiki/pmwiki.php/Main/PreemptiveShutUp'>Preemptive "Shut Up"</a>: Delivered by Cap to a S.H.I.E.L.D. pilot, who tries to tell Cap that he isn't authorized to take the Quinjet.<div class='indent'><strong>Captain America:</strong> Son, just don't.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PreviewsPulse' title='/pmwiki/pmwiki.php/Main/PreviewsPulse'>Previews Pulse</a>: The second trailer <a class='urllink' href='https://www.youtube.com/watch?v=eOrNdBpGMv8'>had some instances of this<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>, coupled with Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HannibalLecture' title='/pmwiki/pmwiki.php/Main/HannibalLecture'>Hannibal Lecture</a>. <a class='urllink' href='https://www.youtube.com/watch?v=B8PVqw2jfrI'>So did its third trailer<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PrimalStance' title='/pmwiki/pmwiki.php/Main/PrimalStance'>Primal Stance</a>: The Hulk in assumes a hunched, almost gorilla-stance. He even slams both fists into the ground and grunts at one point.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ProductionThrowback' title='/pmwiki/pmwiki.php/Main/ProductionThrowback'>Production Throwback</a>:<ul ><li> "Does anybody feel like <em>shawarma</em>? I feel some <em>shawarma</em> coming on." was evidently the line that got Nicholas Brendon cast as Xander on <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/BuffyTheVampireSlayer' title='/pmwiki/pmwiki.php/Series/BuffyTheVampireSlayer'>Buffy the Vampire Slayer</a></em>.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson</span>'s dying speech to Loki is inverted in an older Whedon production, <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/Angel' title='/pmwiki/pmwiki.php/Series/Angel'>Angel</a></em>, at the end of the aptly-titled "Conviction": The <em>villain</em> lectures the hero about a lack of "conviction" to his cause, ensuring that evil will always triumph. Both scenes end in the same way, with the good character silencing the villain with a well-placed shot.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheEngineer' title='/pmwiki/pmwiki.php/Main/TheEngineer'>The Engineer</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheBigGuy' title='/pmwiki/pmwiki.php/Main/TheBigGuy'>The Big Guy</a> have to do some hasty work on their vehicle's engine. The big guy opens a panel and tries to make sense of a mind-boggling mess of circuitry. In <em><a class='twikilink' href='/pmwiki/pmwiki.php/Series/Firefly' title='/pmwiki/pmwiki.php/Series/Firefly'>Firefly</a></em>, it was <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WrenchWench' title='/pmwiki/pmwiki.php/Main/WrenchWench'>Kaylee</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BookDumb' title='/pmwiki/pmwiki.php/Main/BookDumb'>Jayne</a>, in this film, it's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GadgeteerGenius' title='/pmwiki/pmwiki.php/Main/GadgeteerGenius'>Tony Stark</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater' title='/pmwiki/pmwiki.php/Main/FishOutOfTemporalWater'>Steve Rogers.</a></li><li> Loki's mind-controlling scepter works by poking people in the heart. <span class="spoiler" title="you can set spoilers visible by default on your profile" >It doesn't work on Tony Stark because his arc reactor blocks it</span>. Joss Whedon's earlier work <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/Serenity' title='/pmwiki/pmwiki.php/Film/Serenity'>Serenity</a></em> features a bad guy whose signature move is jamming people's nerves to paralyze them, <span class="spoiler" title="you can set spoilers visible by default on your profile" >and a hero with a missing nerve cluster that makes him immune to this</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ProductPlacement' title='/pmwiki/pmwiki.php/Main/ProductPlacement'>Product Placement</a>:<ul ><li> During the final battle, one of the only buildings with no noticeable damage sports the motto for Farmers Insurance, which all of New York would need by this point.</li><li> The Chitauri fly across a clearly placed Dr. Pepper truck, which they blow up along the way.</li><li> Tony Stark drives an Acura in this movie instead of the Audis from the <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/IronMan' title='/pmwiki/pmwiki.php/Film/IronMan'>Iron Man</a></em> films. S.H.I.E.L.D. also uses Acura cars, and in a deleted scene, Steve (mulling over his past) walks past a showroom with the Acura RDX 2012 model prominently displayed, along with the company's logo.</li><li> Tony Stark's bracelets are Colantotte bracelets, which are supposed to administer magnetic therapy for healthier blood flow. A tie-in comic explains that Pepper bought them for Tony's birthday, and their magnetic properties inspired him to build the Mark VII.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ProlongedPrologue' title='/pmwiki/pmwiki.php/Main/ProlongedPrologue'>Prolonged Prologue</a>: The movie begins with The Other explaining to <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span> (and the audience) what their <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilPlan' title='/pmwiki/pmwiki.php/Main/EvilPlan'>Evil Plan</a> is. Then we cut to Nick Fury arriving at a joint S.H.I.E.L.D./NASA/Project Pegasus research facility being evacuated. Then Loki arrives, <span class="spoiler" title="you can set spoilers visible by default on your profile" >takes control of Hawkeye and Dr. Selvig,</span> and escapes with the Tesseract as the entire facility collapses. Finally Coulson asks Fury "What now?" and we get an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AnswerCut' title='/pmwiki/pmwiki.php/Main/AnswerCut'>Answer Cut</a> to the title "The Avengers", a moment made even cooler in the UK release as the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MarketBasedTitle' title='/pmwiki/pmwiki.php/Main/MarketBasedTitle'>title</a> is "Avengers Assemble".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Protectorate' title='/pmwiki/pmwiki.php/Main/Protectorate'>Protectorate</a>: The whole world is this to the eponymous team, but especially to Thor:<div class='indent'><strong>Thor:</strong> So you take the world I love as recompense for your imagined slights? No! The Earth is under my protection, Loki!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PsychologicalProjection' title='/pmwiki/pmwiki.php/Main/PsychologicalProjection'>Psychological Projection</a>: Loki's default mode:<ul ><li> He gives the crowd of Germans a lecture on how the mad scramble for power and identity diminishes their life's joy, something he is reluctant to admit about himself.</li><li> He refers to Bruce Banner/Hulk as a "mindless beast" that "makes play he's still a man," asks how desperate Nick Fury is to summon "such lost creatures" to defend him and constantly taunts Banner with looks. When Black Widow calls Loki a monster he just replies "No, you've brought the monster." In <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>Thor</a></em>, Loki <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IAmAMonster' title='/pmwiki/pmwiki.php/Main/IAmAMonster'>called himself a monster</a> after finding out his true parentage, and in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/ThorTheDarkWorld' title='/pmwiki/pmwiki.php/Film/ThorTheDarkWorld'>Thor: The Dark World</a></em> he says that Thor must be truly desperate to come to <em>him</em> for help.</li><li> During his speech to Black Widow, he's as much talking about himself as he's talking about her. Bonus points for showing his own reflection in the glass that separates them:<div class='indent'><strong>Loki:</strong> Your ledger is dripping, it's gushing red. [...] You lie and kill in the service of liars and killers. You pretend to be separate, to have your own code, something that makes up for the horrors. But they are a part of you, and they will never go away!</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PsychoticSmirk' title='/pmwiki/pmwiki.php/Main/PsychoticSmirk'>Psychotic Smirk</a>:<ul ><li> Loki's entrance comes adorned with an epic one. Many more follow. They stop once <span class="spoiler" title="you can set spoilers visible by default on your profile" >Hawkeye takes advantage of his nature to stop and do this by blowing him out of the sky</span>.</li><li> The Hulk sports one after Cap's order to defeat the Chitauri is merely: "And Hulk... Smash."</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos gives one as he is revealed in The Stinger, just after the Other says that attacking Earth is to "court death".</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PunchCatch' title='/pmwiki/pmwiki.php/Main/PunchCatch'>Punch Catch</a>:<ul ><li> Loki catches Captain America's fist during their scuffle.</li><li> Thor also catches Iron Man's punch the first time they fight. Iron Man responds with a repulsor blast to the face.</li><li> Later, Thor catches Hulk's fist and tries to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IKnowYoureInThereSomewhereFight' title='/pmwiki/pmwiki.php/Main/IKnowYoureInThereSomewhereFight'>talk to Banner</a> before Hulk slugs him with his free hand.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PunchedAcrossTheRoom' title='/pmwiki/pmwiki.php/Main/PunchedAcrossTheRoom'>Punched Across the Room</a>: For half the main characters, this is the basic at-will attack.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PunyEarthlings' title='/pmwiki/pmwiki.php/Main/PunyEarthlings'>Puny Earthlings</a>:<ul ><li> The Chitauri had been told that humans were those but changed their mind after their invasion of New York faced the Avengers and Iron Man <span class="spoiler" title="you can set spoilers visible by default on your profile" >nuked their command ship</span>.</li><li> Also <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InvertedTrope' title='/pmwiki/pmwiki.php/Main/InvertedTrope'>inverted</a> when the Hulk <span class="spoiler" title="you can set spoilers visible by default on your profile" >smashes Loki and calls him a "Puny God".</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PureEnergy' title='/pmwiki/pmwiki.php/Main/PureEnergy'>Pure Energy</a>: When Tony tries to blast the portal generator with his repulsors, they are blocked by a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeflectorShield' title='/pmwiki/pmwiki.php/Main/DeflectorShield'>Deflector Shield</a>. Jarvis points out that the repulsors will have no effect, as the shield is made of pure energy.</li></ul></div></p><p><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/TheAvengers/TropesEToL">Tropes E to L</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Film/TheAvengers2012">Film/The Avengers (2012)</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/TheAvengers/TropesQToZ">Tropes Q to Z</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/scraper/resources/theavengers_tropesQtoZ.html
+++ b/tropestogo/service/scraper/resources/theavengers_tropesQtoZ.html
@@ -1,0 +1,1860 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "TheAvengers", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Tropes Q to Z / The Avengers - TV Tropes</title>
+            <meta name="description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesQToZ" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Tropes Q to Z / The Avengers - TV Tropes" />
+            <meta name="twitter:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Tropes Q to Z / The Avengers - TV Tropes" />
+			<meta property="og:type" content="website" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesQToZ" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="Tropes A to D | Tropes E to L | Tropes M to P | Tropes Q to Z | Tie Ins | YMMV | TriviaThe Avengers provides examples of the following tropes: WARNING: Spoilers from the earlier films are unmarked.  Ragtag Bunch of Misfits: Lampshaded regularly &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "3249201cca6b7eeca1de118d08d4474b20e5ab7e",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/FightingSpirit" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Film/TheWitches1990" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/TheAvengers/TropesQToZ?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=TheAvengers/TropesQToZ">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=TheAvengers.TropesQToZ">
+                <i class="fa fa-history"></i> History</a></li><li class="link-discussion"><a href="/pmwiki/remarks.php?trope=TheAvengers.TropesQToZ">
+                  <i class="fa fa-comment"></i> Discussion</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/TheAvengers/TropesQToZ?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="TheAvengers"/>
+<input type="hidden" id="title-hidden" value="TropesQToZ"/>
+<input type="hidden" id="article_id" value="406150" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/TheAvengers/TropesQToZ</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>The Avengers / </strong>
+        
+        Tropes Q to Z
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "TheAvengers",
+                "item": "https://tvtropes.org/pmwiki/index_report.php?groupname=TheAvengers"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Tropes Q to Z"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+        
+                
+
+        
+            
+            <li class="more-subpages">
+                <a href="javascript:void(0);" class="subpage-toggle-button" >
+                    <span class="wrapper more">More <i class="fa fa-chevron-down"></i></span>
+                    <span class="wrapper less"><i class="fa fa-chevron-left"></i> Less</span>
+                </a>
+
+                <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);" tabindex="0">
+                    <option value="">- More -</option>
+
+                                                            <option value="/pmwiki/pmwiki.php/AbraxasHrodvitnon/TropesQToZ">AbraxasHrodvit&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/AmbienceAFleetSymphony/TropesQToZ">AmbienceAFleet&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Animorphs/TropesQToZ">Animorphs</option>
+                                                                                <option value="/pmwiki/pmwiki.php/AtopTheFourthWall/TropesQToZ">AtopTheFourthW&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/AvatarTheLastAirbender/TropesQToZ">AvatarTheLastA&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/BabylonFive/TropesQToZ">BabylonFive</option>
+                                                                                <option value="/pmwiki/pmwiki.php/BioShockInfinite/TropesQToZ">BioShockInfini&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/BurnNotice/TropesQToZ">BurnNotice</option>
+                                                                                <option value="/pmwiki/pmwiki.php/CalvinAndHobbes/TropesQToZ">CalvinAndHobbe&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Castle/TropesQToZ">Castle</option>
+                                                                                <option value="/pmwiki/pmwiki.php/ChildOfTheStorm/TropesQToZ">ChildOfTheStor&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/CodeGeassThePreparedRebellion/TropesQToZ">CodeGeassThePr&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DannyPhantom/TropesQToZ">DannyPhantom</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Daredevil2015/TropesQToZ">Daredevil2015</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DisneyAnimatedCanon/TropesQToZ">DisneyAnimated&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DragonBallZ/TropesQToZ">DragonBallZ</option>
+                                                                                <option value="/pmwiki/pmwiki.php/DungeonKeeperAmi/TropesQToZ">DungeonKeeperA&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/EdEddNEddy/TropesQToZ">EdEddNEddy</option>
+                                                                                <option value="/pmwiki/pmwiki.php/EverybodyLovesRaymond/TropesQToZ">EverybodyLoves&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Exalted/TropesQToZ">Exalted</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Fallout4/TropesQToZ">Fallout4</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FamilyGuy/TropesQToZ">FamilyGuy</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FinalFantasyIX/TropesQToZ">FinalFantasyIX</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FistOfTheNorthStar/TropesQToZ">FistOfTheNorth&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/FullmetalAlchemist/TropesQToZ">FullmetalAlche&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/GhostsOfThePast/TropesQToZ">GhostsOfThePas&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/GlobalGuardiansPBEMUniverse/TropesQToZ">GlobalGuardian&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/GodzillaKingOfTheMonsters2019/TropesQToZ">GodzillaKingOf&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/HeyArnold/TropesQToZ">HeyArnold</option>
+                                                                                <option value="/pmwiki/pmwiki.php/JudgeDredd/TropesQToZ">JudgeDredd</option>
+                                                                                <option value="/pmwiki/pmwiki.php/LawAndOrderSVU/TropesQToZ">LawAndOrderSVU</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Merlin/TropesQToZ">Merlin</option>
+                                                                                <option value="/pmwiki/pmwiki.php/MyLittlePonyFriendshipIsMagic/TropesQToZ">MyLittlePonyFr&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/PhineasAndFerb/TropesQToZ">PhineasAndFerb</option>
+                                                                                <option value="/pmwiki/pmwiki.php/PonyPOVSeries/TropesQToZ">PonyPOVSeries</option>
+                                                                                <option value="/pmwiki/pmwiki.php/ReadyJetGo/TropesQToZ">ReadyJetGo</option>
+                                                                                <option value="/pmwiki/pmwiki.php/RickAndMorty/TropesQToZ">RickAndMorty</option>
+                                                                                <option value="/pmwiki/pmwiki.php/RuneScape/TropesQToZ">RuneScape</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SaturdayNightLive/TropesQToZ">SaturdayNightL&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/SpongeBobSquarePants/TropesQToZ">SpongeBobSquar&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StarTrekDeepSpaceNine/TropesQToZ">StarTrekDeepSp&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/StarWarsTheOldRepublic/TropesQToZ">StarWarsTheOld&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/Supernatural/TropesQToZ">Supernatural</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TeamFortress2/TropesQToZ">TeamFortress2</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheAvengers/TropesQToZ">TheAvengers</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheCinemaSnob/TropesQToZ">TheCinemaSnob</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheOuterLimits1995/TropesQToZ">TheOuterLimits&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheTwilightZone1959/TropesQToZ">TheTwilightZon&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TheTwilightZone1985/TropesQToZ">TheTwilightZon&#8230;</option>
+                                                                                <option value="/pmwiki/pmwiki.php/TotalDrama/TropesQToZ">TotalDrama</option>
+                                                                                <option value="/pmwiki/pmwiki.php/WeAreNotAlone/TropesQToZ">WeAreNotAlone</option>
+                                        
+                </select>
+
+            </li>
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/TropesQToZ?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/TropesQToZ?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/TropesQToZ?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/TropesQToZ?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/TropesQToZ?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/TropesQToZ?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/TropesQToZ?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/TropesQToZ?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/TropesQToZ?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/TropesQToZ?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/TropesQToZ?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/TropesQToZ?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/TropesQToZ?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/TropesQToZ?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/TropesQToZ?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/TropesQToZ?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/TropesQToZ?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/TropesQToZ?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesAToD' title='/pmwiki/pmwiki.php/TheAvengers/TropesAToD'>Tropes A to D</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesEToL' title='/pmwiki/pmwiki.php/TheAvengers/TropesEToL'>Tropes E to L</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TropesMToP' title='/pmwiki/pmwiki.php/TheAvengers/TropesMToP'>Tropes M to P</a> | <strong>Tropes Q to Z</strong> | <a class='twikilink' href='/pmwiki/pmwiki.php/TheAvengers/TieIns' title='/pmwiki/pmwiki.php/TheAvengers/TieIns'>Tie Ins</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/YMMV/TheAvengers2012' title='/pmwiki/pmwiki.php/YMMV/TheAvengers2012'>YMMV</a> | <a class='twikilink' href='/pmwiki/pmwiki.php/Trivia/TheAvengers2012' title='/pmwiki/pmwiki.php/Trivia/TheAvengers2012'>Trivia</a><hr /><h3><em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/TheAvengers2012' title='/pmwiki/pmwiki.php/Film/TheAvengers2012'>The Avengers</a></em> provides examples of the following tropes:</h3></p><p><div class="folderlabel" onclick="toggleAllFolders();">&nbsp;&nbsp;&nbsp;&nbsp;open/close all folders&nbsp; </div></p><p><strong>WARNING: Spoilers from the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse'>earlier films</a> are unmarked.</strong></p><p><div class="folderlabel" onclick="togglefolder('folder0');">&nbsp;&nbsp;&nbsp;&nbsp;R&nbsp;</div><div id="folder0" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RagtagBunchOfMisfits' title='/pmwiki/pmwiki.php/Main/RagtagBunchOfMisfits'>Ragtag Bunch of Misfits</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Lampshaded' title='/pmwiki/pmwiki.php/Main/Lampshaded'>Lampshaded</a> regularly by Loki, Nick Fury, Bruce Banner and every other character, but none so much as <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> himself.<div class='indent'><strong>Joss:</strong> The Avengers is a terrible idea for a superhero team. They really don't belong in the same movie, let alone in the same room.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RatedMForManly' title='/pmwiki/pmwiki.php/Main/RatedMForManly'>Rated M for Manly</a>: The super heroes, the explosions, the fighting, and the general epic scale.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReachingTowardsTheAudience' title='/pmwiki/pmwiki.php/Main/ReachingTowardsTheAudience'>Reaching Towards the Audience</a>: Iron Man, in the official poster.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheRealHeroes' title='/pmwiki/pmwiki.php/Main/TheRealHeroes'>The Real Heroes</a>: During the Chitauri invasion of Manhattan, New York's fire department tries to ameliorate the disaster under fire while the NYPD try to fight back even if they only have their side arms. Eventually, the US Army and/or National Guard manage to get troops in for some fire support for the Avengers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RealLifeWritesThePlot' title='/pmwiki/pmwiki.php/Main/RealLifeWritesThePlot'>Real Life Writes the Plot</a>:<ul ><li> Natalie Portman was enthusiastic about returning to the role of Thor's human love interest Jane Foster, but was heavily pregnant during filming. Jane was thus <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PutOnABus' title='/pmwiki/pmwiki.php/Main/PutOnABus'>Put on a Bus</a> to a conference in Troms&oslash;, away from the action of the movie.</li><li> Chris Evans quickly grew a full beard once filming was complete, so Cap keeps his face hidden from the camera during <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>The Stinger</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RealMenLoveJesus' title='/pmwiki/pmwiki.php/Main/RealMenLoveJesus'>Real Men Love Jesus</a>: Shortly after Thor nabs Loki from the transport, after Black Widow explains that Thor's basically a god, Captain America states that there's only one God in existence, and it's pretty clear that he's referring to the Judeo-Christian <a class='twikilink' href='/pmwiki/pmwiki.php/Main/God' title='/pmwiki/pmwiki.php/Main/God'>God</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RealTime' title='/pmwiki/pmwiki.php/Main/RealTime'>Real Time</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >The S.H.I.E.L.D. pilot fires the nuke and announces it will detonate in two minutes thirty seconds. That's how much movie time elapses until it hits the Chitauri ship.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a>:<ul ><li> Loki's <em>other</em> other favorite tactic: He tells everyone and the human race itself that they suck and he is so much better than them.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Agent Coulson</a> gives one right back to Loki, punctuated with a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BFG' title='/pmwiki/pmwiki.php/Main/BFG'>BFG</a>, <em><span class="spoiler" title="you can set spoilers visible by default on your profile" >while bleeding to death</span></em>.<div class='indent'><strong>Agent Coulson:</strong> You're going to lose. It's in your nature. You lack conviction.</div></li><li> Steve gives one to Tony that stings:<div class='indent'><strong>Steve Rogers:</strong> Big man in a suit of armor. Take that away, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RhetoricalQuestionBlunder' title='/pmwiki/pmwiki.php/Main/RhetoricalQuestionBlunder'>what are you?</a> <br /><strong>Tony Stark:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GadgeteerGenius' title='/pmwiki/pmwiki.php/Main/GadgeteerGenius'>Genius</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Fiction500' title='/pmwiki/pmwiki.php/Main/Fiction500'>billionaire</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThePornomancer' title='/pmwiki/pmwiki.php/Main/ThePornomancer'>playboy</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnclePennybags' title='/pmwiki/pmwiki.php/Main/UnclePennybags'>philanthropist</a>. <br /><strong>Steve Rogers:</strong> I know guys with none of that worth ten of you.</div></li><li> Even Stark's answer about how <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MundaneSolution' title='/pmwiki/pmwiki.php/Main/MundaneSolution'>he would just cut</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeAThirdOption' title='/pmwiki/pmwiki.php/Main/TakeAThirdOption'>the barbed wire</a> rather than <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HeroicSacrifice' title='/pmwiki/pmwiki.php/Main/HeroicSacrifice'>lie down on it and allow other soldiers to walk over him</a> to achieve the mission gets an angry quip from Captain America.<div class='indent'><strong>Steve Rogers</strong>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Always looking for an angle</a>.</div></li><li> Stark proceeds to fire right back at him.<div class='indent'><strong>Tony Stark:</strong> Everything special about you came out of a <em>bottle</em>.</div></li><li> And of course, Tony's speech about how Loki sucks because he provoked six of the most dangerous people in the world and thinks he's going to come out on top.<div class='indent'><strong>Tony:</strong> Not a great plan.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReasonableAuthorityFigure' title='/pmwiki/pmwiki.php/Main/ReasonableAuthorityFigure'>Reasonable Authority Figure</a>: Nick Fury plays this role. <span class="spoiler" title="you can set spoilers visible by default on your profile" >As Tony notes, Nick Fury is a top spy, so everything he says is loaded with half-truths, misdirections, omissions, and good old-fashioned lies, but he has everyone's best interests at heart.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RedemptionRejection' title='/pmwiki/pmwiki.php/Main/RedemptionRejection'>Redemption Rejection</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >When Thor fights Loki on Stark Tower, he tells him it's not too late to turn back. For a second Loki seems to be considering it. Then he stabs Thor in the stomach</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RedOniBlueOni' title='/pmwiki/pmwiki.php/Main/RedOniBlueOni'>Red Oni, Blue Oni</a>: Iron Man is the red to Captain America's blue. Heck, they're even <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColorCodedCharacters' title='/pmwiki/pmwiki.php/Main/ColorCodedCharacters'>Color-Coded Characters</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RedShirtArmy' title='/pmwiki/pmwiki.php/Main/RedShirtArmy'>Red Shirt Army</a>: S.H.I.E.L.D. comes across as one because only the named agents (Black Widow, Hawkeye, Hill, Coulson) ever achieve anything.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReflexiveResponse' title='/pmwiki/pmwiki.php/Main/ReflexiveResponse'>Reflexive Response</a>: Twice.<ul ><li> Nick Fury takes out a fight jet about to launch a nuke with a rocket launcher. As soon as he sees a second, he automatically pulls out his sidearm, only to realize the jet is already far out of range of a handgun.</li><li> During the battle in New York, Hawkeye is startled to realize he's been pulling arrows out of his quiver so fast he's run out of them.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RelocatingTheExplosion' title='/pmwiki/pmwiki.php/Main/RelocatingTheExplosion'>Relocating the Explosion</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man does it with a nuke, taking it through the portal to the Chitauri mothership.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RenegadeRussian' title='/pmwiki/pmwiki.php/Main/RenegadeRussian'>Renegade Russian</a>: The Russian who was interrogating Black Widow was wearing a Russian military uniform and running what is strongly implied to be an illegal arms dealing business.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RetractableWeapon' title='/pmwiki/pmwiki.php/Main/RetractableWeapon'>Retractable Weapon</a>: Hawkeye's bow can retract for easy storage and deploy, bowstring ready, with the press of a switch.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReveal' title='/pmwiki/pmwiki.php/Main/TheReveal'>The Reveal</a>:<ul ><li> Banner's secret for how he's avoided getting angry for so long: <span class="spoiler" title="you can set spoilers visible by default on your profile" >he hasn't. He's <em>always</em> angry, he's just made peace with his anger enough to avoid Hulking out. Until he <em>needs</em> to.</span></li><li> The true master of the Chitauri is <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Thanos' title='/pmwiki/pmwiki.php/ComicBook/Thanos'>Thanos</a> the mad titan</span>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Revenge' title='/pmwiki/pmwiki.php/Main/Revenge'>Revenge</a>:<ul ><li> Thor states that this is part of Loki's reason for wanting to invade Earth, since Thor has become very <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Protectorate' title='/pmwiki/pmwiki.php/Main/Protectorate'>protective of Earth</a>.</li><li> Invoked in-universe: "Because if we can't protect the Earth, you can be damn well sure we'll avenge it."</li><li> After the Hulk and Thor work together for a brief to moment, they stand watching something and facing the camera for a second. Cue the Hulk punching Thor out of the shot offhand still staring forward, in revenge for a vicious fight earlier in the movie.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RevengeByProxy' title='/pmwiki/pmwiki.php/Main/RevengeByProxy'>Revenge by Proxy</a>: Loki's plot to take control of Earth in The Avengers is largely driven by jealousy and resentment towards his adoptive brother Thor, as well as rage at being deceived about his true ancestry. He wants to subjugate the entire population of Earth &#8212; a planet which Thor treasures and protects &#8212; thereby wiping out many of the people that Thor cares about. In addition, Loki feels that he was cheated out of his rightful place as the ruler of Asgard.<div class='indent'><strong>Thor:</strong> So you take the world I love as recompense for your imagined slights?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReversePolarity' title='/pmwiki/pmwiki.php/Main/ReversePolarity'>Reverse Polarity</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Downplayed' title='/pmwiki/pmwiki.php/Main/Downplayed'>Downplayed</a>. The phrase "reverse the polarity" is used by Tony Stark in a less unacceptable context &#8212; Stark in giving Captain America instructions to slow down a turbine engine/motor. Reversing the polarity on a basic DC motor will reverse the direction of its rotation, which has the immediate effect of slowing its motion.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RevolvingDoorRevolution' title='/pmwiki/pmwiki.php/Main/RevolvingDoorRevolution'>Revolving Door Revolution</a>: In response to a query by Loki during the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a> scene, Natasha claims this of Russia:<div class='indent'><strong>Natasha:</strong> Regimes fall every day. I tend not to weep over them; I'm Russian. Or, I was.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RewatchBonus' title='/pmwiki/pmwiki.php/Main/RewatchBonus'>Rewatch Bonus</a>: The World Security Council's decision to nuke New York makes far more sense <span class="spoiler" title="you can set spoilers visible by default on your profile" >after watching <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheWinterSoldier'>Captain America: The Winter Soldier</a></em> with the revelation that it and S.H.I.E.L.D. are both heavily infiltrated by HYDRA. Destroying a major city in a seemingly justifiable action like that would have played into their long-term goals quite well</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RhetoricalQuestionBlunder' title='/pmwiki/pmwiki.php/Main/RhetoricalQuestionBlunder'>Rhetorical Question Blunder</a>: Subverted. Rogers doesn't let himself get sidetracked by Tony's witty reply, continuing the original discussion about the flaws in Tony's view of heroism.<div class='indent'><strong>Steve Rogers:</strong> Big man in a suit of armour. Take that off, what are you? <br /><strong>Tony Stark:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GadgeteerGenius' title='/pmwiki/pmwiki.php/Main/GadgeteerGenius'>Genius</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Fiction500' title='/pmwiki/pmwiki.php/Main/Fiction500'>billionaire</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThePornomancer' title='/pmwiki/pmwiki.php/Main/ThePornomancer'>playboy</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnclePennybags' title='/pmwiki/pmwiki.php/Main/UnclePennybags'>philanthropist</a>?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RoundhouseKick' title='/pmwiki/pmwiki.php/Main/RoundhouseKick'>Roundhouse Kick</a>: When Loki is fighting Captain America in Stuttgart after he demands that Cap kneels before him, Cap responses with a roundhouse to Loki's face.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RuleOfCool' title='/pmwiki/pmwiki.php/Main/RuleOfCool'>Rule of Cool</a>: A standard in super hero movies. Hawkeye shooting a Chitauri when his head was <em>facing the other way</em> is a prime example (and something <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AuthorAppeal' title='/pmwiki/pmwiki.php/Main/AuthorAppeal'>Whedon really liked</a>).</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RuleOfThree' title='/pmwiki/pmwiki.php/Main/RuleOfThree'>Rule of Three</a>: Phil Coulson seems to have a romantic relationship with a cellist that is mentioned thrice throughout the film. Each time it's mentioned it corresponds to a particular part of the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThreeActStructure' title='/pmwiki/pmwiki.php/Main/ThreeActStructure'>Three-Act Structure</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RustProofBlood' title='/pmwiki/pmwiki.php/Main/RustProofBlood'>Rust Proof Blood</a>: The blood on <span class="spoiler" title="you can set spoilers visible by default on your profile" >Coulson's Captain America cards</span> is still bright red long after it should have dried up. <span class="spoiler" title="you can set spoilers visible by default on your profile" >It's our first clue that Fury wasn't telling the truth about where he found them. Note that it smears on the glass table when Steve picks them up.</span></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder1');">&nbsp;&nbsp;&nbsp;&nbsp;S&nbsp;</div><div id="folder1" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SacrificialLion' title='/pmwiki/pmwiki.php/Main/SacrificialLion'>Sacrificial Lion</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson is killed by Loki when he tries to stop Loki from dropping Thor off the Helicarier.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SameCharacterButDifferent' title='/pmwiki/pmwiki.php/Main/SameCharacterButDifferent'>Same Character, But Different</a>: Hawkeye is shown to be a serious S.H.I.E.L.D. agent and one of Nick Fury's most trusted men. His comic book inspiration is an ex-criminal with a distinct dislike for bureaucracy and military structure.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SatelliteCharacter' title='/pmwiki/pmwiki.php/Main/SatelliteCharacter'>Satellite Character</a>: Hawkeye, compared to the other characters, really lacks a dynamic plot arc. He's defined entirely by Black Widow's desire to save him. Prior to <em>The Avengers</em>, his only development was appearing for five minutes in <em>Thor</em> (and even then, the average viewer most likely didn't realize who he was in that movie). Come time for this movie, <span class="spoiler" title="you can set spoilers visible by default on your profile" >he spends the first two acts under mind control from Loki.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SayMyName' title='/pmwiki/pmwiki.php/Main/SayMyName'>Say My Name</a>: Initially, Tony gets angry and jealous because Pepper calls Coulson by his first name. Later on, when facing Loki in full Mark VI suit, Tony utterly delivers a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PreAsskickingOneLiner' title='/pmwiki/pmwiki.php/Main/PreAsskickingOneLiner'>Pre-Asskicking One-Liner</a> to him:<div class='indent'><strong>Tony:</strong> And there's someone else you've pissed off. His name was Phil.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SceneryCensor' title='/pmwiki/pmwiki.php/Main/SceneryCensor'>Scenery Censor</a>: Transforming back from the Hulk after his fall to earth, Bruce Banner's nudity is conveniently blocked by debris.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SceneryGorn' title='/pmwiki/pmwiki.php/Main/SceneryGorn'>Scenery Gorn</a>: Most of Midtown Manhattan becomes this by the end of the movie.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SchizoTech' title='/pmwiki/pmwiki.php/Main/SchizoTech'>Schizo Tech</a>: S.H.I.E.L.D.'s "Helicarrier" is an otherwise contemporary aircraft carrier that can <em>fly and turn invisible</em>. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RuleOfCool' title='/pmwiki/pmwiki.php/Main/RuleOfCool'>Because it's cool</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ScienceFoils' title='/pmwiki/pmwiki.php/Main/ScienceFoils'>Science Foils</a>: As soon as the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GeniusBruiser' title='/pmwiki/pmwiki.php/Main/GeniusBruiser'>Genius Bruiser</a> Bruce Banner (a nuclear physicist) and the insufferably suave <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GadgeteerGenius' title='/pmwiki/pmwiki.php/Main/GadgeteerGenius'>Gadgeteer Genius</a> Tony Stark (a weapons engineer) meet, they strike up an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OddFriendship' title='/pmwiki/pmwiki.php/Main/OddFriendship'>Odd Friendship</a> based on mutual geekery and work together for the rest of the film, even driving off together at the end.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ScienceHero' title='/pmwiki/pmwiki.php/Main/ScienceHero'>Science Hero</a>: Bruce Banner and Tony Stark. Erik Selvig also gets a moment to shine.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheScottishTrope' title='/pmwiki/pmwiki.php/Main/TheScottishTrope'>The Scottish Trope</a>: Bruce refuses to call his alter ego Hulk. Instead, he refers to him as "the <em>other</em> guy". He only slips once, and immediately corrects himself. Though he has made his peace with the Hulk, he still doesn't like it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ScottyTime' title='/pmwiki/pmwiki.php/Main/ScottyTime'>Scotty Time</a>: Fury asks Coulson how long it will take to evacuate the research campus and immediately demands that he "do better." Indeed, the Tesseract blows up in less than half that time and many people are killed.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ScrewTheRulesImDoingWhatsRight' title='/pmwiki/pmwiki.php/Main/ScrewTheRulesImDoingWhatsRight'>Screw the Rules, I'm Doing What's Right!</a>:<ul ><li> The entire team, even Captain America. This almost sets the Avengers <em>against</em> S.H.I.E.L.D. in the middle of the film.</li><li> The council has made its decision, but given that it's a "stupid-ass decision", Director Fury has merely elected to ignore it, even going so far as to shoot down one of his own birds to curtail it.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SealTheBreach' title='/pmwiki/pmwiki.php/Main/SealTheBreach'>Seal the Breach</a>: The Avengers rush to close a wormhole above Manhattan to prevent disaster.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SeasonFinale' title='/pmwiki/pmwiki.php/Main/SeasonFinale'>Season Finale</a>: For Phase One of the <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelCinematicUniverse'>Marvel Cinematic Universe</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SeenItAll' title='/pmwiki/pmwiki.php/Main/SeenItAll'>Seen It All</a>: Captain America thinks he's this. Nick Fury is happy to show him otherwise.<div class='indent'><strong>Cap:</strong> At this point, I doubt anything would surprise me. <br /><strong>Nick Fury:</strong> Ten bucks says you're wrong.</div><ul ><li> Coulson's non-reaction to hearing Black Widow in a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KungFoley' title='/pmwiki/pmwiki.php/Main/KungFoley'>big, loud fight</a> on the other end of a phone line is an absolutely glorious example of this trope.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SelfServingMemory' title='/pmwiki/pmwiki.php/Main/SelfServingMemory'>Self-Serving Memory</a>: Loki accuses Thor of throwing him into the wormhole at the end of <a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>their movie</a>. In reality, he <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DrivenToSuicide' title='/pmwiki/pmwiki.php/Main/DrivenToSuicide'>let go deliberately</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SequelEscalation' title='/pmwiki/pmwiki.php/Main/SequelEscalation'>Sequel Escalation</a>: The film involves stakes and action about an order of magnitude higher than any of the previous MCU films.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SequelHook' title='/pmwiki/pmwiki.php/Main/SequelHook'>Sequel Hook</a>: Two at the end of the film.<ul ><li> Tony starts remodeling Stark Tower into "Avengers Tower", <span class="spoiler" title="you can set spoilers visible by default on your profile" >the team's future headquarters in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/AvengersAgeOfUltron' title='/pmwiki/pmwiki.php/Film/AvengersAgeOfUltron'>Avengers: Age of Ultron</a></em>.</span></li><li> The mid-credits <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>stinger</a> reveals the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GalacticConqueror' title='/pmwiki/pmwiki.php/Main/GalacticConqueror'>Galactic Conqueror</a> behind Loki, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span>, is now interested in Earth <em>in and of itself,</em> not just the Tesseract.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SerkisFolk' title='/pmwiki/pmwiki.php/Main/SerkisFolk'>Serkis Folk</a>: The Incredible Hulk, with Mark Ruffalo himself doing most of the motion capture work.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShadowArchetype' title='/pmwiki/pmwiki.php/Main/ShadowArchetype'>Shadow Archetype</a>: Loki works as a twisted mirror to the Avengers more than once. He's an example of different parts of their personalities, like Thor's values about becoming king, Black Widow's past murderous life or Tony's big ego, with the incident that led to him becoming Iron Man.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SharpDressedMan' title='/pmwiki/pmwiki.php/Main/SharpDressedMan'>Sharp-Dressed Man</a>: Just like in <em>Thor</em>, whenever he's not wearing his conqueror gear (with the horned helmet), Loki prefers a suave and classy longcoat that would be right at home for a night at the opera.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShellShockSilence' title='/pmwiki/pmwiki.php/Main/ShellShockSilence'>Shell-Shock Silence</a>: A subdued example after a bomb explodes near Captain America.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SherlockScan' title='/pmwiki/pmwiki.php/Main/SherlockScan'>Sherlock Scan</a>: Tony Stark demonstrates this several times, often referring to a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FunnyBackgroundEvent' title='/pmwiki/pmwiki.php/Main/FunnyBackgroundEvent'>Funny Background Event</a> that no-one else noticed. Fittingly, <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/RobertDowneyJr' title='/pmwiki/pmwiki.php/Creator/RobertDowneyJr'>Robert Downey Jr.</a> has twice played the trope namer, <a class='twikilink' href='/pmwiki/pmwiki.php/Film/SherlockHolmes2009' title='/pmwiki/pmwiki.php/Film/SherlockHolmes2009'>Sherlock Holmes</a>.<div class='indent'><strong>Tony:</strong> That man is playing <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a></em>! Thought we wouldn't notice, but we did!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShoutOut' title='/pmwiki/pmwiki.php/Main/ShoutOut'>Shout-Out</a>: Collected in <a class='twikilink' href='/pmwiki/pmwiki.php/ShoutOut/TheAvengers2012' title='/pmwiki/pmwiki.php/ShoutOut/TheAvengers2012'>their own subpage</a> for this movie.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShownTheirWork' title='/pmwiki/pmwiki.php/Main/ShownTheirWork'>Shown Their Work</a>:<ul ><li> Shortly before the movie was made, New York changed license-plate designs, and what you see on the streets is a mix of old and new. Which is what you see in the movie as well.</li><li> Selvig's information about <a class='urllink' href='http://en.wikipedia.org/wiki/Iridium'>iridium<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> is accurate. It is indeed found mostly from meteorites, produces antiprotons, matches its appearance in the film, is one of the rarest elements on Earth, and would be useful for his work with the Tesseract because of its high melting point.</li><li> So is Tony and Banner's conversation aboard the Helicarrier about <a class='urllink' href='http://swingeth.wordpress.com/2012/05/09/super-science/'>bypassing the Coulomb barrier through quantum tunneling<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>, which is often easily mistaken for <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>Techno Babble</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShowyInvincibleHero' title='/pmwiki/pmwiki.php/Main/ShowyInvincibleHero'>Showy Invincible Hero</a>: The Hulk. The only time he's even remotely in trouble is in his fight with Thor or when he is briefly pinned down by a dozen or so Chitauri gliders.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShutUpHannibal' title='/pmwiki/pmwiki.php/Main/ShutUpHannibal'>Shut Up, Hannibal!</a>: This happens to Loki <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ButtMonkey' title='/pmwiki/pmwiki.php/Main/ButtMonkey'>on five separate occasions</a>:<ul ><li> As Loki gives his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill' title='/pmwiki/pmwiki.php/Main/TheEvilsOfFreeWill'>The Evils of Free Will</a> speech in Germany, an old man stands up and says he will not <a class='twikilink' href='/pmwiki/pmwiki.php/Main/KneelBeforeZod' title='/pmwiki/pmwiki.php/Main/KneelBeforeZod'>kneel before men like him</a>. When Loki declares that the old man has never met a man like him, he responds, “<a class='twikilink' href='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName' title='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName'>There are</a> <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName' title='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName'>always</a></em> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName' title='/pmwiki/pmwiki.php/Main/ANaziByAnyOtherName'>men like you</a>."</li><li> As Loki is giving a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ToThePain' title='/pmwiki/pmwiki.php/Main/ToThePain'>To the Pain</a> speech to Black Widow, she cuts him off and reveals this was all a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a> to get Loki to reveal his plan.</li><li> Both Coulson and Hulk do this through <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TalkToTheFist' title='/pmwiki/pmwiki.php/Main/TalkToTheFist'>Talk to the Fist</a>: Coulson with a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BFG' title='/pmwiki/pmwiki.php/Main/BFG'>BFG</a>, the Hulk with a hilarious <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CurbStompBattle' title='/pmwiki/pmwiki.php/Main/CurbStompBattle'>Curb-Stomp Battle</a>.<div class='indent'><strong>Hulk:</strong> Puny god.</div></li><li> Tony interrupts, cuts off, and/or retorts Loki's every sentence during the confrontation scene at Stark Tower. It doubles as a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassBoast' title='/pmwiki/pmwiki.php/Main/BadassBoast'>Badass Boast</a></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SideBet' title='/pmwiki/pmwiki.php/Main/SideBet'>Side Bet</a>: Nick Fury offers to bet Steve Rogers &#36;10 that there's still surprises left in the world for Steve. We don't see Steve accept, but after the Helicarrier takes off Steve walks onto the bridge and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrickJoke' title='/pmwiki/pmwiki.php/Main/BrickJoke'>silently hands Fury a ten-dollar bill</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SigilSpam' title='/pmwiki/pmwiki.php/Main/SigilSpam'>Sigil Spam</a>: The S.H.I.E.L.D. eagle is prominently plastered all over the Helicarrier. The bridge of the Helicarrier is even shaped like the logo. This is most easily visible in the pullback shot at the end of the movie.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SignsOfDisrepair' title='/pmwiki/pmwiki.php/Main/SignsOfDisrepair'>Signs of Disrepair</a>: Invoked. After the final battle, the <strong>STARK</strong> on Stark Tower is reduced to an <strong>A</strong> for Avengers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SilentWhisper' title='/pmwiki/pmwiki.php/Main/SilentWhisper'>Silent Whisper</a>:<ul ><li> Pepper does this to Tony towards the beginning when motivating him to finish his "homework" quickly. Judging by the shocked, delighted look on his face and Coulson looking away in embarrassment, it was something quite dirty (though this scene also lent itself to some "Hail HYDRA" parodies a few years later).</li><li> In a possible reference to <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/ScarlettJohansson' title='/pmwiki/pmwiki.php/Creator/ScarlettJohansson'>Scarlett Johansson</a>'s role in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/LostInTranslation' title='/pmwiki/pmwiki.php/Film/LostInTranslation'>Lost in Translation</a></em>, Black Widow whispers something to Hawkeye right before Loki is sent back from whence he came.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SillyRabbitIdealismIsForKids' title='/pmwiki/pmwiki.php/Main/SillyRabbitIdealismIsForKids'>Silly Rabbit, Idealism Is for Kids!</a>: Both Black Widow and Loki are firm believers in this, which makes their clash all the more spectacular:<div class='indent'><strong>Natasha:</strong> Love is for children. I owe him a debt. <br /><strong>Loki:</strong> [...] and you think saving a man no more virtuous than yourself will change anything? This is the basest sentimentality. This is a child at prayer... PATHETIC!</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SingleTear' title='/pmwiki/pmwiki.php/Main/SingleTear'>Single Tear</a>: Loki has one after he stabs Thor on the Stark Tower.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SlasherSmile' title='/pmwiki/pmwiki.php/Main/SlasherSmile'>Slasher Smile</a>:<ul ><li> Loki's is coming along.</li><li> Hulk gets a brief but effective one when Cap <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BorrowedCatchPhrase' title='/pmwiki/pmwiki.php/Main/BorrowedCatchPhrase'>tells him to smash</a>.</li><li> And in the stinger, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span> shows his off against the backdrop of a shattered planet.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SleevesAreForWimps' title='/pmwiki/pmwiki.php/Main/SleevesAreForWimps'>Sleeves Are for Wimps</a>:<ul ><li> Thor in this incarnation, looking more like the original costume in the comics. He actually gets the sleeves back when things get serious.</li><li> Hawkeye's costume is based on his original <em>Ultimates</em> uniform, although his 616 costume is often sleeveless as well.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SmugSuper' title='/pmwiki/pmwiki.php/Main/SmugSuper'>Smug Super</a>:<ul ><li> Loki <em>will</em> remind you at any opportunity that he is a god.</li><li> Tony is much the same, and doesn't hesitate to brag about his accomplishments and/or his abilities at any given moment.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSmurfettePrinciple' title='/pmwiki/pmwiki.php/Main/TheSmurfettePrinciple'>The Smurfette Principle</a>: The casting for the film is even <em>less</em> balanced than the Sixties teams. While the original team had a 4-1 ratio (Hulk left almost as soon as Captain America joined) and the second had a 3-1 ratio, the movie's inclusion of <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/NickFury' title='/pmwiki/pmwiki.php/ComicBook/NickFury'>Nick Fury</a> and Agent Coulson as "title" characters put the central cast at <em>7</em>-1. Needless to say, some chunks of fandom took note. Maria Hill was added to adjust the ratio a little. <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a> himself was not happy about this, and has said he chose to add <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/ScarletWitch' title='/pmwiki/pmwiki.php/ComicBook/ScarletWitch'>Scarlet Witch</a> to <a class='twikilink' href='/pmwiki/pmwiki.php/Film/AvengersAgeOfUltron' title='/pmwiki/pmwiki.php/Film/AvengersAgeOfUltron'>the sequel</a> partially for this reason.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheSnackIsMoreInteresting' title='/pmwiki/pmwiki.php/Main/TheSnackIsMoreInteresting'>The Snack Is More Interesting</a>: While Steve is chewing Tony out for attempting to provoke the Hulk from Banner, Tony shows him how much he doesn't care by obviously, gratuitously, and sloppily palming blueberries into his mouth throughout the entire speech. He even offers some to Steve while Cap is in the middle of talking.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SnarkToSnarkCombat' title='/pmwiki/pmwiki.php/Main/SnarkToSnarkCombat'>Snark-to-Snark Combat</a>: Quite a bit of the movie has all the main characters (particularly between Tony and Steve) do this to each other. And it's hilarious.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SoftGlass' title='/pmwiki/pmwiki.php/Main/SoftGlass'>Soft Glass</a>: While Hulk and the Chitauri grunts bash through windows with no problem, and Hawkeye isn't visibly injured by his attempt, though <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JeremyRenner' title='/pmwiki/pmwiki.php/Creator/JeremyRenner'>his actor</a> at least has the sense to look like it hurt. Tony also gets thrown out of a window made of fairly thick glass from Stark Tower while not suited up. It doesn't hurt him at all and he seems much more worried about falling to his death.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SomeKindOfForceField' title='/pmwiki/pmwiki.php/Main/SomeKindOfForceField'>Some Kind of Force Field</a>: The <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DeflectorShields' title='/pmwiki/pmwiki.php/Main/DeflectorShields'>Deflector Shield</a> surrounding the portal-opening machine powered by the Tesseract only appears when something touches it, as seen when Iron Man tries to destroy it, and his repulsor blasts are sent back at him.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SomeoneHasToDie' title='/pmwiki/pmwiki.php/Main/SomeoneHasToDie'>Someone Has to Die</a>: At the end, <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony grabs the nuke and flies it into space</span> in spite of Natasha's warnings that anything going out of the wormhole is on a "one way trip" because <span class="spoiler" title="you can set spoilers visible by default on your profile" >everyone on Manhattan Island would've been killed otherwise</span>, even if Natasha managed to close the portal in time to stop the rest of the invading army. It's unsaid, but notable, that <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thor</span> also had the capability to do this, and <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony</span> could've refused to <span class="spoiler" title="you can set spoilers visible by default on your profile" >catch the nuke</span> and instead flown away from the city in time to save himself, yet chose not to.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SomethingWeForgot' title='/pmwiki/pmwiki.php/Main/SomethingWeForgot'>Something We Forgot</a>: After successfully repelling an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlienInvasion' title='/pmwiki/pmwiki.php/Main/AlienInvasion'>Alien Invasion</a>, Tony Stark proposes that he and his teammates celebrate with shawarma. Then Thor says that it's not over yet, because there's still one member of the invaders still alive: Loki, who's back at Stark Tower after a thrashing from the Hulk earlier.<div class='indent'><strong>Tony</strong>: And then shawarma after?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SophisticatedAsHell' title='/pmwiki/pmwiki.php/Main/SophisticatedAsHell'>Sophisticated as Hell</a>: Loki and Fury have their moments:<ul ><li> During his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HannibalLecture' title='/pmwiki/pmwiki.php/Main/HannibalLecture'>Hannibal Lecture</a> to Black Widow:<div class='indent'><strong>Loki:</strong> This is my bargain, you mewling quim!</div></li><li> When the World Security Council has decided to throw a nuke at Manhattan to stop the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AlienInvasion' title='/pmwiki/pmwiki.php/Main/AlienInvasion'>Alien Invasion</a>:<div class='indent'><strong>Fury:</strong> I recognize that the Council has made a decision, but given that it's a <em>stupid-ass</em> decision, I've elected to ignore it.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SoundtrackDissonance' title='/pmwiki/pmwiki.php/Main/SoundtrackDissonance'>Soundtrack Dissonance</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Elegant classical music plays when Loki and Brainwashed!Hawkeye are killing people at a party in Germany. It gives the scene a very surreal feeling.</span></li><li> Inverted during Natasha's chair-bound fight scene. When Agent Coulson calls her, she says, "Let me put you on hold." She then proceeds to fight Russian thugs, accompanied by racing, staccato music. When the scene switches to Coulson listening to the fight, the music continues, sounding like (peculiar) on-hold music.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpaceWhale' title='/pmwiki/pmwiki.php/Main/SpaceWhale'>Space Whale</a>: The Chitauri's giant living assault ships, with elements of <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GiantFlyer' title='/pmwiki/pmwiki.php/Main/GiantFlyer'>Giant Flyer</a>, Giant Worm and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OurDragonsAreDifferent' title='/pmwiki/pmwiki.php/Main/OurDragonsAreDifferent'>Our Dragons Are Different</a> mixed in. A <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LivingShip' title='/pmwiki/pmwiki.php/Main/LivingShip'>Living Ship</a>?</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpandexLatexOrLeather' title='/pmwiki/pmwiki.php/Main/SpandexLatexOrLeather'>Spandex, Latex, or Leather</a>: Take your pick. There's at least one character who has you covered. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FullFrontalAssault' title='/pmwiki/pmwiki.php/Main/FullFrontalAssault'>Except the Hulk.</a></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpeakOfTheDevil' title='/pmwiki/pmwiki.php/Main/SpeakOfTheDevil'>Speak of the Devil</a>: Banner refuses to call the Hulk by name, referring to him as "the other guy" and correcting himself the one time he does slip in a "he who must not be named" kind of a way.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpiceUpTheSubtitles' title='/pmwiki/pmwiki.php/Main/SpiceUpTheSubtitles'>Spice Up the Subtitles</a>: The Swedish (cinematic) subitles spice up Loki's infamous "You mewling quim" to Black Widow by rendering as "Din fega fitta" ("cowardly cunt"). Well, it's technically correct...</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpotlightStealingSquad' title='/pmwiki/pmwiki.php/Main/SpotlightStealingSquad'>Spotlight-Stealing Squad</a>: While Captain America receives <a class='urllink' href='http://www.vulture.com/2012/05/how-much-screen-time-does-each-avenger-get.html'>thirty more seconds of screentime<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> and directs the battle during the climax, Tony Stark has many of the movie's crucial scenes such as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CharacterDevelopment' title='/pmwiki/pmwiki.php/Main/CharacterDevelopment'>arresting Loki and saving Manhattan with a near-Heroic Sacrifice</a>. At an earlier point, Tony Stark was to have an even greater role. Mark Ruffalo's Banner and Hulk were extremely well-received, considering that Hulk's movies did relatively poorly, and Hulk has some of the most memorable scenes. Hawkeye has the least screentime of each hero, but this works considerably to his favor.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SpyCatsuit' title='/pmwiki/pmwiki.php/Main/SpyCatsuit'>Spy Catsuit</a>: Black Widow and Maria Hill.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StaredownFaceoff' title='/pmwiki/pmwiki.php/Main/StaredownFaceoff'>Staredown Faceoff</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/CaptainAmerica' title='/pmwiki/pmwiki.php/ComicBook/CaptainAmerica'>Steve Rogers</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/IronMan' title='/pmwiki/pmwiki.php/ComicBook/IronMan'>Tony Stark</a> get into a rather heated argument, getting extremely close to one another in the process, after both uncover SHIELD's plans to use HYDRA technology to build energy weapons; on Steve's part, he believes Tony is only pretending to be a hero for the sake of his own vanity, while Tony's resentment of Steve stems from Tony's father constantly comparing Tony to Steve as Tony was growing up. The two would have gone to blows were it not for a brainwashed Clint attacking <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier' title='/pmwiki/pmwiki.php/Main/AirborneAircraftCarrier'>the helicarrier</a>.<div class='indent'><strong>Steve Rogers:</strong> Always a way out. You know, you may not be a threat, but you'd better stop pretending to be a hero.</div><div class='indent'><strong>Tony Stark:</strong> A hero? Like you? You're a laboratory experiment, Rogers. Everything special about you came out of a bottle.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StealthPun' title='/pmwiki/pmwiki.php/Main/StealthPun'>Stealth Pun</a>:<ul ><li> Tony offering blueberries to Captain America. Who's wearing blue.</li><li> During the end where Tony is seen making plans to rebuild Stark Tower to the Avengers base, the only letter from the Stark sign that survived the destruction during the film's climax was "A".</li><li> Shawarma is basically a type of gyro, which rhymes with "hero".</li><li> In the first <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>stinger,</a> <span class="spoiler" title="you can set spoilers visible by default on your profile" >the Other says challenging Earth would be "to court death" while talking to Thanos, the one being who, in the comics, does this literally.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStinger' title='/pmwiki/pmwiki.php/Main/TheStinger'>The Stinger</a>:<ul ><li> <a class='urllink' href='https://www.youtube.com/watch?v=vRqiklDdS3Q&amp;feature=g-user-u'>One mid-credits<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>, revealing that the entire Loki-led Chitauri invasion was in fact orchestrated by <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos.</span></li><li> A second one after the end of the credits, where <span class="spoiler" title="you can set spoilers visible by default on your profile" >the crew eats at the shawarma place Tony suggests at the end of the final battle</span>. Whilst it was originally only in the US-release of the film theatrically, it's included in all versions of the home release.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StockShoutouts' title='/pmwiki/pmwiki.php/Main/StockShoutouts'>Stock Shoutouts</a>:<ul ><li> A113 appears in the upper left corner of Fury's video screen as he's having his last video conference with The Council.</li><li> And the Tesseract, a source of infinite power and knowledge with alien origins? Yeah, it's in the S.H.I.E.L.D. books as item #<a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/TheHitchhikersGuideToTheGalaxy' title='/pmwiki/pmwiki.php/Franchise/TheHitchhikersGuideToTheGalaxy'>42</a>.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StoutStrength' title='/pmwiki/pmwiki.php/Main/StoutStrength'>Stout Strength</a>: In a departure from the previous film (and most of his comics, really) The Hulk has a noticeable layer of fat around his massive trunk, though his muscles still show.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheStraightAndArrowPath' title='/pmwiki/pmwiki.php/Main/TheStraightAndArrowPath'>The Straight and Arrow Path</a>: While Hawkeye does have a service handgun, he spends most of the time firing arrows.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/StrangerInAFamiliarLand' title='/pmwiki/pmwiki.php/Main/StrangerInAFamiliarLand'>Stranger in a Familiar Land</a>: Steve Rogers tells Fury that he doubts anything they're about to face will surprise him after all the strange things the 21st century has already thrown at him. It doesn't help that, this being a Joss Whedon script, people keep making <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PopCulturalOsmosisFailure' title='/pmwiki/pmwiki.php/Main/PopCulturalOsmosisFailure'>pop-culture references he doesn't understand</a>. (He does eventually get a small victory when he <a class='twikilink' href='/pmwiki/pmwiki.php/Literature/TheWonderfulWizardOfOz' title='/pmwiki/pmwiki.php/Literature/TheWonderfulWizardOfOz'>understands a reference</a> that Thor doesn't.)</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TraumaCongaLine' title='/pmwiki/pmwiki.php/Main/TraumaCongaLine'>Stress Conga Line</a>: It took quite a bit for Loki to get Banner to Hulk out. Being more or less drafted into S.H.I.E.L.D, shoved onto a flying helicarrier (Banner hates submarines and planes alike), getting into a shouting match with the other Avengers, picking up <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EvilIsNotAToy' title='/pmwiki/pmwiki.php/Main/EvilIsNotAToy'>Loki's scepter</a>, and then banging his head on a wall when the Helicarrier lurches from an explosion eventually does him in.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuddenlyShouting' title='/pmwiki/pmwiki.php/Main/SuddenlyShouting'>Suddenly Shouting</a>:<ul ><li> Earlier in the film, Bruce Banner in his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Troll' title='/pmwiki/pmwiki.php/Main/Troll'>Troll-ish</a> moment to pretend he's gonna <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>Hulking Out</a>:<div class='indent'><strong>Bruce:</strong> <em>[in low deadpan tone]</em> [Fury] needs me in a cage? <br /><strong>Natasha:</strong> No-one's gonna put you in... <br /><strong>Bruce: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuddenlyShouting' title='/pmwiki/pmwiki.php/Main/SuddenlyShouting'>STOP LYING TO ME!</a></strong> <br /><strong>Natasha:</strong> <em>[<a class='twikilink' href='/pmwiki/pmwiki.php/Main/JumpScare' title='/pmwiki/pmwiki.php/Main/JumpScare'>freaks out and draws her gun</a>]</em> <br /><strong>Bruce:</strong> <em>[chuckles, looks</em> <strong>obviously</strong> <em>amused and satisfied]</em> I'm sorry, that was mean, I just wanted to see what you'd do.</div></li><li> Loki, when he is commanding a group of people in Stuttgart to kneel:<div class='indent'><strong>Loki:</strong> Kneel before me! I said... KNEEEEL!</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SunglassesAtNight' title='/pmwiki/pmwiki.php/Main/SunglassesAtNight'>Sunglasses at Night</a>: Agent Coulson in his first appearance in the film. He's not just doing it to look cool, though; he has the landing lights of Fury's helicopter in his face, and takes the shades off once he's no longer running the risk of being blinded.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperheroPackingHeat' title='/pmwiki/pmwiki.php/Main/SuperheroPackingHeat'>Superhero Packing Heat</a>: Nick Fury and Black Widow. Captain America to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DownplayedTrope' title='/pmwiki/pmwiki.php/Main/DownplayedTrope'>a much lesser extent</a> than in his previous film (he uses an assault rifle in one scene). Hawkeye also wears a sidearm, though he prefers using his bow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperheroParadox' title='/pmwiki/pmwiki.php/Main/SuperheroParadox'>Superhero Paradox</a>: Invoked by Thor. According to him, when S.H.I.E.L.D. activated the Tesseract to <span class="spoiler" title="you can set spoilers visible by default on your profile" >create weapons capable of defending themselves from Asgardian-level threats</span>, they ironically sent the message to everyone in the galaxy that the Earth "is ready for a higher form of war". Nick Fury, in turn, cites Thor himself and his arrival on Earth in New Mexico as an example of this trope and the reason S.H.I.E.L.D. was escalating in the first place, since Thor's fight with the Destroyer showed everyone that Earth is "hopelessly, hilariously outgunned" by pretty much every alien race out there.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperStrength' title='/pmwiki/pmwiki.php/Main/SuperStrength'>Super Strength</a>: At least half of the main cast has this trait, which is perhaps best displayed when Thor tackles The Hulk <em>through a metal barrier.</em> Also subverted (though definitely justified) when Hulk, in the ensuing brawl with Thor, attempts to lift Thor's hammer off the floor, and the damn thing <em>doesn't even budge</em> (for the curious, <a class='urllink' href='http://insignificantknowledge.blogspot.com/2011/01/incredible-feats-of-hulk.html'>here's a great blog that lists Hulk's feats of strength throughout the years.<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> Yes, you read that right&#8212; <em>The Hulk holds up a 150 billion ton mountain</em>). This, more than anything, is proof that physical strength means nothing in this context &#8212; only a warrior (and possibly only an Asgardian one) worthy of wielding the hammer can lift it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperTeam' title='/pmwiki/pmwiki.php/Main/SuperTeam'>Super Team</a>: The Avengers Initiative.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperToughness' title='/pmwiki/pmwiki.php/Main/SuperToughness'>Super Toughness</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki, being a Frost Giant, shrugs off small-arms and assault rifle fire, but is thrown around by explosions. He also understandably gets beaten up by the Hulk, but lives to tell the tale and is able to crawl under his own power by the time he's captured again in the finale.</span></li><li> This is half of the reason S.H.I.E.L.D. is so worried about Banner <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HulkingOut' title='/pmwiki/pmwiki.php/Main/HulkingOut'>Hulking Out</a> in uncontrolled circumstances. He survived firing a bullet into his own mouth by transforming involuntarily, and in the movie he survives a nearly 30,000 foot drop with no ill effect.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SupervillainLair' title='/pmwiki/pmwiki.php/Main/SupervillainLair'>Supervillain Lair</a>: Loki sets up shop in a warehouse somewhere, loaded to the gills with equipment and mindwiped servants. Oddly, he never seems to return to it after Stuttgart, so there's no scene of the heroes <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ExploringTheEvilLair' title='/pmwiki/pmwiki.php/Main/ExploringTheEvilLair'>Exploring the Evil Lair</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperWeaponAverageJoe' title='/pmwiki/pmwiki.php/Main/SuperWeaponAverageJoe'>Super Weapon, Average Joe</a>: Coulson wields a gun that was created from the remains of The Destroyer.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperWindowJump' title='/pmwiki/pmwiki.php/Main/SuperWindowJump'>Super Window Jump</a>: After running out of arrows, Hawkeye swings down and crashes right through a massive window. He isn't badly hurt, but his pained body language seems to imply that he got poked by a few pieces of glass.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SurprisinglySuperToughThing' title='/pmwiki/pmwiki.php/Main/SurprisinglySuperToughThing'>Surprisingly Super-Tough Thing</a>: Thor is surprised when the containment cell built for the Hulk actually holds against his first hammer hit when Thor tries to break out. After he's been dumped with the cell into free-fall, he adjusts his technique and flies straight at the crack he made with the first hit, breaking through.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SurveillanceStationSlacker' title='/pmwiki/pmwiki.php/Main/SurveillanceStationSlacker'>Surveillance Station Slacker</a>: Tony Stark calls out a S.H.I.E.L.D. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MissionControl' title='/pmwiki/pmwiki.php/Main/MissionControl'>Mission Control</a> op for playing <em><a class='twikilink' href='/pmwiki/pmwiki.php/VideoGame/Galaga' title='/pmwiki/pmwiki.php/VideoGame/Galaga'>Galaga</a></em> while on duty. The guy goes right back to playing the game after Tony leaves.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuspiciouslySpecificDenial' title='/pmwiki/pmwiki.php/Main/SuspiciouslySpecificDenial'>Suspiciously Specific Denial</a>: Pepper asks Coulson if he's come to get Tony to join the Avengers, which of course she knows nothing about.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuspiciouslySmallArmy' title='/pmwiki/pmwiki.php/Main/SuspiciouslySmallArmy'>Suspiciously Small Army</a>: No more than a few hundred Chitauri are <a class='urllink' href='http://www.dailymotion.com/video/x1947pd'>ever visible on-screen in total<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a>, even after Loki orders them to "send in the rest." Even when we get a look at their home dimension with the rest of the invasion force, we only see eight additional Leviathans, a few dozen space speeders similar in speed and armament to WW-2 prop planes, and a mothership that is <a class='urllink' href='https://forums.spacebattles.com/threads/loki-and-chitauri-vs-steppenwolf-and-parademons.588681/page-4#post-41651091'>not particularly huge<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> and couldn't possibly hold more than tens of thousands of additional troops at most. This makes their desire to conquer an entire planet with hundreds of millions of soldiers quite questionable. Justified by the Other and Loki being ill-informed of Earth's capabilities and small armies being the norm in the majority of the Marvel Cinematic Universe's civilizations, such as the Einherjar of Asgard.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SwirlyEnergyThingy' title='/pmwiki/pmwiki.php/Main/SwirlyEnergyThingy'>Swirly Energy Thingy</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Selvig opening a vortex over Stark Tower.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SwordLimbo' title='/pmwiki/pmwiki.php/Main/SwordLimbo'>Sword Limbo</a>: During the fight between Thor and the Hulk aboard the Helicarrier, the Hulk rips a wing off a fighter jet and throws it frisbee-style at Thor. Thor goes to his knees and bends backwards almost double to let the flying wing pass over him.</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder2');">&nbsp;&nbsp;&nbsp;&nbsp;T&nbsp;</div><div id="folder2" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Tagline' title='/pmwiki/pmwiki.php/Main/Tagline'>Tagline</a>: "Some Assembly Required."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TailorMadePrison' title='/pmwiki/pmwiki.php/Main/TailorMadePrison'>Tailor-Made Prison</a>: The S.H.I.E.L.D. helicarrier has a cell designed to hold and theoretically kill the Hulk. It's strong enough to stand up to a blow from Thor's hammer with only a crack to show for it, and set up to be dropped from the helicarrier at high altitude if it's damaged in any way. It gets used to hold Loki instead, and Banner doubts its effectiveness on the Hulk when it comes up in conversation.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeAThirdOption' title='/pmwiki/pmwiki.php/Main/TakeAThirdOption'>Take a Third Option</a>:<ul ><li> Tony Stark's favorite tactic. It disgusts Captain America during his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech' title='/pmwiki/pmwiki.php/Main/TheReasonYouSuckSpeech'>"The Reason You Suck" Speech</a> to Stark, because in his mind this means that Stark would never be willing to make a sacrifice if it came down to it.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Fury wants to fight the Chitauri off with the Avengers, while the WSC wants to nuke Manhattan to make sure the aliens are defeated. Iron Man proceeds to grab the nuke after it's been shot, fly through the wormhole and chuck it at the Chitauri fleet, thus managing to both take a third option and make a sacrifice play.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeOverTheWorld' title='/pmwiki/pmwiki.php/Main/TakeOverTheWorld'>Take Over the World</a>: Loki wants to conquer Earth and reign over it as an absolute ruler.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeThat' title='/pmwiki/pmwiki.php/Main/TakeThat'>Take That!</a>: Coulson's "I watched you while you were sleeping" line to Captain Steve Rogers could be a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeThat' title='/pmwiki/pmwiki.php/Main/TakeThat'>Take That!</a> to <em><a class='twikilink disambiglink' href='/pmwiki/pmwiki.php/Literature/Twilight' title='/pmwiki/pmwiki.php/Literature/Twilight'>Twilight</a></em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakingYouWithMe' title='/pmwiki/pmwiki.php/Main/TakingYouWithMe'>Taking You with Me</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Discussed' title='/pmwiki/pmwiki.php/Main/Discussed'>Discussed</a> by Tony when he tells Loki that even if the Chitauri do take over Earth, Loki himself wouldn't profit, because they'd make sure to avenge Earth by at least taking Loki out as well.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TalkToTheFist' title='/pmwiki/pmwiki.php/Main/TalkToTheFist'>Talk to the Fist</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >A dying Phil Coulson shooting Loki in the middle of a sentence</span>.</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki is <em>just</em> warming up to his favorite theme of humanity's inferiority when the Hulk gets bored and just starts flailing him around like a rag doll.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TameHisAnger' title='/pmwiki/pmwiki.php/Main/TameHisAnger'>Tame His Anger</a>: The secret on how Bruce has been able to control his anger and keep himself from hulking out most of the time?<div class='indent'><strong>Bruce:</strong> <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/TranquilFury' title='/pmwiki/pmwiki.php/Main/TranquilFury'>I'm always angry</a>.</span></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TapOnTheHead' title='/pmwiki/pmwiki.php/Main/TapOnTheHead'>Tap on the Head</a>: Black Widow knocks out Hawkeye during their fistfight. Unusual for the trope, it takes two blows to knock him completely out.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TeamDad' title='/pmwiki/pmwiki.php/Main/TeamDad'>Team Dad</a>: Chris Hemsworth sees Tony Stark as "the godfather of the Avengers", which would explain why he's always arguing with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLeader' title='/pmwiki/pmwiki.php/Main/TheLeader'>The Leader</a> Steve Rogers over what's best for the proverbial kids, like Dr. Banner.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TeamPrimaDonna' title='/pmwiki/pmwiki.php/Main/TeamPrimaDonna'>Team Prima Donna</a>: <em>All</em> the Avengers are rather skeptical of the others' abilities and convinced their concerns are the most important ones, but especially Thor and Tony.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TeamTitle' title='/pmwiki/pmwiki.php/Main/TeamTitle'>Team Title</a>: <em>The Avengers</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheTeaser' title='/pmwiki/pmwiki.php/Main/TheTeaser'>The Teaser</a>: Loki <span class="spoiler" title="you can set spoilers visible by default on your profile" >stealing the Tesseract from under S.H.I.E.L.D.'s nose.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnoBabble' title='/pmwiki/pmwiki.php/Main/TechnoBabble'>Techno Babble</a>:<ul ><li> As one of their many, myriad differences, it's another of the wedges between Iron Man and Captain America.<div class='indent'><strong>Tony:</strong> That stator control unit can reverse the polarity long enough to disengage maglev and that shou&#8212; <br /><strong>Steve:</strong> Speak English! <br /><strong>Tony:</strong> ...See that red lever?</div></li><li> Tony and Bruce bond over their shared understanding of it. Funnily enough, it's not truly Technobabble; see <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShownTheirWork' title='/pmwiki/pmwiki.php/Main/ShownTheirWork'>Shown Their Work</a>.<div class='indent'><strong>Tony Stark:</strong> Finally! Someone who speaks English. <br /><strong>Steve Rogers:</strong> ...is that what just happened?</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnologyPorn' title='/pmwiki/pmwiki.php/Main/TechnologyPorn'>Technology Porn</a>:<ul ><li> The S.H.I.E.L.D Helicarrier.</li><li> All the various Stark technologies.</li><li> Hawkeye's special quiver that can attach <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrickArrow' title='/pmwiki/pmwiki.php/Main/TrickArrow'>different types of arrowheads</a> to a shaft.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TeethClenchedTeamwork' title='/pmwiki/pmwiki.php/Main/TeethClenchedTeamwork'>Teeth-Clenched Teamwork</a>: For most of the movie. By the final act, the heroes learn to work together.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThatCameOutWrong' title='/pmwiki/pmwiki.php/Main/ThatCameOutWrong'>That Came Out Wrong</a>: Agent Coulson is a big fan of Captain America, and watched him while he was sleeping.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheyCallMeMisterTibbs' title='/pmwiki/pmwiki.php/Main/TheyCallMeMisterTibbs'>They Call Me MISTER Tibbs!</a>: Tony Stark doesn't like how Pepper Potts is on <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FirstNameBasis' title='/pmwiki/pmwiki.php/Main/FirstNameBasis'>First-Name Basis</a> with S.H.I.E.L.D agent Phil Coulson, and insists that his first name is "Agent".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThisIsGonnaSuck' title='/pmwiki/pmwiki.php/Main/ThisIsGonnaSuck'>This Is Gonna Suck</a>:<ul ><li> Black Widow reacts with horror when Coulson informs her that whatever "compromised" Barton is <em>so</em> bad that <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GodzillaThreshold' title='/pmwiki/pmwiki.php/Main/GodzillaThreshold'>they need Bruce Banner.</a></li><li> While Loki's sitting in the S.H.I.E.L.D. transport, having "surrendered", and notices the raging storm outside, he cottons on that he's about to have an uncomfortable reunion...<div class='indent'><strong>Steve Rogers:</strong> Scared of a little lightning? <br /><strong>Loki:</strong> I'm not overly fond of <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheMightyThor' title='/pmwiki/pmwiki.php/ComicBook/TheMightyThor'>what follows</a>...</div></li><li> Also, Black Widow's response to Iron Man's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CasualDangerDialogue' title='/pmwiki/pmwiki.php/Main/CasualDangerDialogue'>"party"</a> of a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AwesomePersonnelCarrier' title='/pmwiki/pmwiki.php/Main/AwesomePersonnelCarrier'>Leviathan</a> chasing him, as shown in the trailers.<div class='indent'><strong>Black Widow:</strong> I... I don't see how that's a party.</div></li><li> Captain America's and Black Widow's realization that the latter has to to steal one of the Chitauri crafts to get back atop Stark Tower.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThisIsNotADrill' title='/pmwiki/pmwiki.php/Main/ThisIsNotADrill'>This Is Not a Drill</a>: This phrase blares over speakers as the Project P.E.G.A.S.U.S. faculty is being evacuated due to the Tesseract "misbehaving".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThoseWereOnlyTheirScouts' title='/pmwiki/pmwiki.php/Main/ThoseWereOnlyTheirScouts'>Those Were Only Their Scouts</a>: New York is invaded by several aliens, and a flying creature that seems immune to missiles, laser beams, repulsor beams, it's all useless. Nobody can stop that thing... except a lone guy <a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk' title='/pmwiki/pmwiki.php/ComicBook/TheIncredibleHulk'>who is always angry</a>. The creature is destroyed, but Loki simply summons more like them from the portal.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThreeActStructure' title='/pmwiki/pmwiki.php/Main/ThreeActStructure'>Three-Act Structure</a>: In this case it was something of an <a class='twikilink' href='/pmwiki/pmwiki.php/Main/EnforcedTrope' title='/pmwiki/pmwiki.php/Main/EnforcedTrope'>Enforced Trope</a>. According to Joss Whedon <a class='urllink' href='http://www.wired.com/underwire/2012/04/ff_whedon/all/'>in an article<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> in <em>Wired</em> magazine, Marvel Studios wanted three basic things to happen in the script: a big fight among the Avengers, a set piece in the middle that tore the team apart somehow, and a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigBadassBattleSequence' title='/pmwiki/pmwiki.php/Main/BigBadassBattleSequence'>Big Badass Battle Sequence</a>. Joss goes, "Great, you just gave me your three acts."<ul ><li> The Setup: The heroes gather and capture Loki.</li><li> The Confrontation: S.H.I.E.L.D. interrogates Loki and they get more than what they bargained for.</li><li> The Resolution: The big battle in Manhattan.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThreePointLanding' title='/pmwiki/pmwiki.php/Main/ThreePointLanding'>Three-Point Landing</a>:<ul ><li> Naturally, this is a movie featuring Iron Man, so you can be sure this he'll take the pose on landing. Notably to conclude his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigEntrance' title='/pmwiki/pmwiki.php/Main/BigEntrance'>Big Entrance</a> in Stuttgart.</li><li> Thor also lands in this position on top of the Quinjet the first time he shows up, chasing after Loki.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThrowingDownTheGauntlet' title='/pmwiki/pmwiki.php/Main/ThrowingDownTheGauntlet'>Throwing Down the Gauntlet</a>: During a particularly heated argument, Captain America demands Stark put on his armor so they can fight. Tony refuses, however, saying he "isn't afraid to punch an old man" without putting on the suit. The line "put on the suit" takes on a very different meaning almost immediately after this, when an explosion rocks the entire transport. This time, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/IronicEcho' title='/pmwiki/pmwiki.php/Main/IronicEcho'>Tony quickly agrees</a> and puts on the suit.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThrownFromTheZeppelin' title='/pmwiki/pmwiki.php/Main/ThrownFromTheZeppelin'>Thrown from the Zeppelin</a>: When Loki tries to awe and frighten a crowd of German citizens into becoming his first subjects, one old man defies him, refusing to be led by “men like you.” The old man is only saved from being vaporized by the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BigDamnHeroes' title='/pmwiki/pmwiki.php/Main/BigDamnHeroes'>Big Damn Heroes</a> arrival of the Avengers.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TitleDrop' title='/pmwiki/pmwiki.php/Main/TitleDrop'>Title Drop</a>: Unless you saw it in a market which used the title "<em>Avengers Assemble</em>". <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DoubleSubverted' title='/pmwiki/pmwiki.php/Main/DoubleSubverted'>Double Subverted</a>. While the term "The Avengers" is mentioned casually many times, it's not until Nick Fury and Tony Stark's speeches that the title is given gravitas.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ToBeLawfulOrGood' title='/pmwiki/pmwiki.php/Main/ToBeLawfulOrGood'>To Be Lawful or Good</a>: A three-way argument to this effect is briefly had between Cap, Stark and Banner.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TokenGoodTeammate' title='/pmwiki/pmwiki.php/Main/TokenGoodTeammate'>Token Good Teammate</a>: On a team plagued with detachment from humanity, egotism, anger issues, guilt, and a seething desire for revenge, Captain America stands out because his only flaw is that he's a little old-fashioned. As such, he's the first to realize Loki is playing them against each other, and later on, the team (appropriately) accepts him as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLeader' title='/pmwiki/pmwiki.php/Main/TheLeader'>The Leader</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TooCleverByHalf' title='/pmwiki/pmwiki.php/Main/TooCleverByHalf'>Too Clever by Half</a>: Loki clearly thinks he's really cool, catching Barton's arrow like that. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DidntSeeThatComing' title='/pmwiki/pmwiki.php/Main/DidntSeeThatComing'>He wasn't expecting it to explode.</a></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TooDumbToLive' title='/pmwiki/pmwiki.php/Main/TooDumbToLive'>Too Dumb to Live</a>:<ul ><li> Hill specifically tells a pilot not to get too close to the Hulk when he distracts him. Despite the mini-gun having a range of hundreds of meters, the pilot opens up his visor and gets to stone-throw range before using it. He <em>nearly</em> dies when he succeeds. However, it does get the Hulk off the Helicarrier before he "tears it to pieces".</li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki antagonizing the Hulk might also count. Even though it might have been a surprise just how quickly he got beaten to a pulp, nobody could have been particularly surprised that it happened. On the other hand, he was probably going to get beaten up <em>anyway</em> and was probably just displaying false bravado in a (doomed) last-ditch attempt to intimidate him.</span></li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Tony accuses Agent Coulson of having been this for going up alone against Loki, although Tony seems to be trying to hide his grief over Coulson's death through his trademark snark.</span></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TookALevelInBadass' title='/pmwiki/pmwiki.php/Main/TookALevelInBadass'>Took a Level in Badass</a>: Loki's first scene, and thus the first scene in the movie, is dedicated to this. He forces his way into a S.H.I.E.L.D. base, wipes out a bunch of agents, mind controls the rest, and steals the Tesseract. This is far greater physical power and ferocity than he demonstrated in <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>Thor</a></em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TookALevelInDumbass' title='/pmwiki/pmwiki.php/Main/TookALevelInDumbass'>Took a Level in Dumbass</a>: Loki <em>still</em> plays <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DivideAndConquer' title='/pmwiki/pmwiki.php/Main/DivideAndConquer'>Divide and Conquer</a> against the Avengers in the first half of the film, but by the second half his overblown ego and mental instability turn the former <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheChessmaster' title='/pmwiki/pmwiki.php/Main/TheChessmaster'>Chessmaster</a> and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Manipulative Bastard</a> from <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/Thor' title='/pmwiki/pmwiki.php/Film/Thor'>Thor</a></em> into an easy target. He is outsmarted by Black Widow, and then every member of the main cast has a chance to get back on him during his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumiliationConga' title='/pmwiki/pmwiki.php/Main/HumiliationConga'>Humiliation Conga</a> while he experiences a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainousBreakdown' title='/pmwiki/pmwiki.php/Main/VillainousBreakdown'>Villainous Breakdown</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TongueTrauma' title='/pmwiki/pmwiki.php/Main/TongueTrauma'>Tongue Trauma</a>: Although he was interrupted, the Russian general at the beginning was clearly planning to use this <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColdBloodedTorture' title='/pmwiki/pmwiki.php/Main/ColdBloodedTorture'>method of persuasion</a> on Black Widow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TortureAlwaysWorks' title='/pmwiki/pmwiki.php/Main/TortureAlwaysWorks'>Torture Always Works</a>: Never played straight, but played with twice.<ul ><li> Black Widow is introduced as a "helpless" victim about to suffer <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ColdBloodedTorture' title='/pmwiki/pmwiki.php/Main/ColdBloodedTorture'>Cold-Blooded Torture</a>. She is actually drawing information from her would-be torturers, though, and presumably has an escape planned before Agent Coulson intervenes.</li><li> In the second act, while other characters are debating the possibility of beating information out of Loki, Black Widow uses <em>real</em> interrogation to deduce Loki's strategy. Loki has also taken the precaution of being ignorant of the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MacGuffin' title='/pmwiki/pmwiki.php/Main/MacGuffin'>MacGuffin</a>'s whereabouts so that that information can't be tortured out of him; he fully expects Fury to try it.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Touche' title='/pmwiki/pmwiki.php/Main/Touche'>Touché</a>: A non-verbal example. Captain America tells Fury that <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SeenItAll' title='/pmwiki/pmwiki.php/Main/SeenItAll'>nothing in the modern world could surprise him</a>, which Fury bets ten dollars against. Then he's brought aboard an aircraft carrier, which turns into a helicarrier and engages stealth panels to hide itself. Clearly impressed, Cap wordlessly hands Fury ten dollars.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheTower' title='/pmwiki/pmwiki.php/Main/TheTower'>The Tower</a>: The newly-built Stark Tower, aptly-if-<a class='twikilink' href='/pmwiki/pmwiki.php/Main/HypocriticalHumor' title='/pmwiki/pmwiki.php/Main/HypocriticalHumor'>inadvertently</a> described by Tony (albeit talking about Loki) as "a monument built to the skies, with his name plastered on it". <span class="spoiler" title="you can set spoilers visible by default on your profile" >Naturally, it becomes the focus of the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FinalBattle' title='/pmwiki/pmwiki.php/Main/FinalBattle'>Final Battle</a>.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TragicKeepsake' title='/pmwiki/pmwiki.php/Main/TragicKeepsake'>Tragic Keepsake</a>: Fury invoked this by showing Cap and Tony <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson's bloodied Captain America trading cards, which he had <em>taken out of Coulson's locker and added blood to</em></span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrailersAlwaysSpoil' title='/pmwiki/pmwiki.php/Main/TrailersAlwaysSpoil'>Trailers Always Spoil</a>:<ul ><li> Will <span class="spoiler" title="you can set spoilers visible by default on your profile" >Iron Man</span> die from his fall or not? Well, anyone who remembers the trailer will know <span class="spoiler" title="you can set spoilers visible by default on your profile" >he doesn't.</span></li><li> The line <span class="spoiler" title="you can set spoilers visible by default on your profile" >"Barton's been compromised."</span> appears in several trailers hinting at Loki taking control of him. This happens in the opening scenes, however.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TranquilFury' title='/pmwiki/pmwiki.php/Main/TranquilFury'>Tranquil Fury</a>:<ul ><li> Invoked as a prelude to a superlative asskicking.<div class='indent'><strong>Steve:</strong> Doctor Banner? ... Now might be a really good time for you to get angry. <br /><strong>Banner:</strong> That's my secret, Cap.... <span class="spoiler" title="you can set spoilers visible by default on your profile" >I'm always angry.</span></div></li><li> Also the man himself, no pun intended.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TransformingVehicle' title='/pmwiki/pmwiki.php/Main/TransformingVehicle'>Transforming Vehicle</a>: Of a scale rarely seen: what appears at first to be a standard aircraft carrier deploys its turbines and turn into the S.H.I.E.L.D. Helicarrier before taking to the sky.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrickArrow' title='/pmwiki/pmwiki.php/Main/TrickArrow'>Trick Arrow</a>: Though he tends to stick to pointy or exploding arrowheads, Hawkeye has a couple of notable uses of this trope. He fires a <em>computer override</em> arrow at one point, and uses a grappling hook arrow a couple of times. His quiver is the real impressive bit of technology. It stores dozens of specialized arrowheads and automatically attaches new ones to the shafts he's got stored; he can select which arrows he wants at the press of a button. He later takes down a Chitauri hovercraft with a <em>superheating</em> arrow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheTriple' title='/pmwiki/pmwiki.php/Main/TheTriple'>The Triple</a>: Tony Stark asks Bruce Banner how he stays calm.<div class='indent'><strong>Tony:</strong> What's your secret? Relaxing jazz, bongo drums, huge bag of weed?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrueCompanions' title='/pmwiki/pmwiki.php/Main/TrueCompanions'>True Companions</a>: The Avengers are all such big egos (except for the S.H.I.E.L.D. agents) that they can barely be in a room together. They fight and argue, but at the same time, they bring out the best in one another and when they unite with common purpose, they're unstoppable. In short, the Avengers are, as Joss says, "family".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TruthInTelevision' title='/pmwiki/pmwiki.php/Main/TruthInTelevision'>Truth in Television</a>: Hawkeye's techno-quiver screwing headless shafts into <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrickArrow' title='/pmwiki/pmwiki.php/Main/TrickArrow'>custom arrowheads</a> at <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SwissArmyWeapon' title='/pmwiki/pmwiki.php/Main/SwissArmyWeapon'>the push of a button</a> is quality <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TechnologyPorn' title='/pmwiki/pmwiki.php/Main/TechnologyPorn'>Technology Porn</a>, but has basis in reality; medieval archers carried arrows and arrowheads separately for the same reason &#8212; so they could swap arrowheads to suit their target. Well, that and so yanking out the arrow would <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/AnnoyingArrows' title='/pmwiki/pmwiki.php/Main/AnnoyingArrows'>leave the arrowhead inside the wound</a>...</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TurbineBlender' title='/pmwiki/pmwiki.php/Main/TurbineBlender'>Turbine Blender</a>: Iron Man nearly falls victim to a self-inflicted turbine blender when he has to spin up the Helicarrier's malfunctioning engine from the inside.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TwoGirlsToATeam' title='/pmwiki/pmwiki.php/Main/TwoGirlsToATeam'>Two Girls to a Team</a>: Black Widow and Maria Hill. Though the latter is not a member of the superhero team, they're both heroines and agents of S.H.I.E.L.D.</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder3');">&nbsp;&nbsp;&nbsp;&nbsp;U&nbsp;</div><div id="folder3" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UltimateShowdownOfUltimateDestiny' title='/pmwiki/pmwiki.php/Main/UltimateShowdownOfUltimateDestiny'>The Ultimate Showdown of Ultimate Destiny</a>: In a movie like this, it's almost inevitable. We have Iron Man vs. Thor vs. Captain America, Thor vs. Hulk and <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy' title='/pmwiki/pmwiki.php/Main/BrainwashedAndCrazy'>Brainwashed and Crazy</a> Hawkeye</span> vs. Black Widow.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnderestimatingBadassery' title='/pmwiki/pmwiki.php/Main/UnderestimatingBadassery'>Underestimating Badassery</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >Yes, Loki, you <em>are</em> a god, but that <em>doesn't</em> mean you should try to push the Hulk around.</span></li><li> The Chitauri are initially quite dismissive of the ability of the human race to challenge them. Needless to say, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HumansAreWarriors' title='/pmwiki/pmwiki.php/Main/HumansAreWarriors'>lessons are learned</a>.</li><li> The Russians at the beginning say that Natasha doesn't live up to her badass reputation as the Black Widow. Then they discover that not only has <em>she</em> been getting information from <em>them</em>, she was in no danger, and easily frees herself and takes them all out once the time comes.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Understatement' title='/pmwiki/pmwiki.php/Main/Understatement'>Understatement</a>:<ul ><li> When briefing Cap, who yet has to find out about the existence of extraterrestrial life, about the situation, Nick Fury says that Loki is "not from around here".</li><li> The security guard who discovers Banner after his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DestinationDefenestration' title='/pmwiki/pmwiki.php/Main/DestinationDefenestration'>exit from the Hellcarrier</a> sums it up pretty nicely.<div class='indent'><strong>Guard:</strong> Well son... you've got a condition.</div></li><li> As does Captain America when he runs into Loki in Germany.<div class='indent'><strong>Steve Rogers:</strong> You know, the last time I was in Germany, and saw a man standing above everybody else... we ended up disagreeing.</div></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnfazedEveryman' title='/pmwiki/pmwiki.php/Main/UnfazedEveryman'>Unfazed Everyman</a>: A guard coming across Banner post-transformation. "Son, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Understatement' title='/pmwiki/pmwiki.php/Main/Understatement'>you've got a condition.</a>"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnfinishedUntestedUsedAnyway' title='/pmwiki/pmwiki.php/Main/UnfinishedUntestedUsedAnyway'>Unfinished, Untested, Used Anyway</a>: JARVIS complains that the latest Iron Man armor isn't ready, but Tony needs to use it since his current suit is barely functional and an invasion is minutes away.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheUnmasquedWorld' title='/pmwiki/pmwiki.php/Main/TheUnmasquedWorld'>The Unmasqued World</a>: While everybody had already more-or-less known about Cap (although not his return), Iron Man and the Hulk, by the end of the film mankind has become aware of the existence of extraterrestrials, Asgardians and the Avengers themselves, and have even begun to react much like the mainstream <a class='twikilink' href='/pmwiki/pmwiki.php/Franchise/MarvelUniverse' title='/pmwiki/pmwiki.php/Franchise/MarvelUniverse'>Marvel Universe</a> does with most of their heroes.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnstoppableForceMeetsImmovableObject' title='/pmwiki/pmwiki.php/Main/UnstoppableForceMeetsImmovableObject'>Unstoppable Force Meets Immovable Object</a>: What happens when Thor's hammer, the most powerful weapon in the MCU, is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DropTheHammer' title='/pmwiki/pmwiki.php/Main/DropTheHammer'>dropped</a> on Captain America's shield, the most indestructible defense in the MCU? <em><strong><a class='twikilink' href='/pmwiki/pmwiki.php/Main/KungFuSonicBoom' title='/pmwiki/pmwiki.php/Main/KungFuSonicBoom'>BOOM</a></strong></em></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnusualEuphemism' title='/pmwiki/pmwiki.php/Main/UnusualEuphemism'>Unusual Euphemism</a>: Natasha uses the odd phrase "red on my ledger" when discussing her motivation as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheAtoner' title='/pmwiki/pmwiki.php/Main/TheAtoner'>The Atoner</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnusualUserInterface' title='/pmwiki/pmwiki.php/Main/UnusualUserInterface'>Unusual User Interface</a>: The Chitauri gliders are piloted by an elaborate harness that makes it looks like they're steering with their <em>faces</em>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnwittingInstigatorOfDoom' title='/pmwiki/pmwiki.php/Main/UnwittingInstigatorOfDoom'>Unwitting Instigator of Doom</a>: While it's still mostly <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Loki's fault</a> and he had very good reasons to be suspicious, if Stark had kept quiet on what he figured S.H.I.E.L.D. would do with the Tesseract, things could have gone smoother for the heroes. Banner's more of a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnwittingPawn' title='/pmwiki/pmwiki.php/Main/UnwittingPawn'>pawn</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UnwittingPawn' title='/pmwiki/pmwiki.php/Main/UnwittingPawn'>Unwitting Pawn</a>: Loki's plan to foil S.H.I.E.L.D. hinges on Bruce Banner &#8212; not just his condition, but the fact that Banner is smart enough to put half of Loki's clues together before the rest of the Avengers realizes there's a puzzle that needs solving.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UrbanRuins' title='/pmwiki/pmwiki.php/Main/UrbanRuins'>Urban Ruins</a>: <em>The Avengers</em> enters its climax in this environment. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Loki's army of Chitauri have ravaged Manhattan and left most of it in ruins.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UseYourHead' title='/pmwiki/pmwiki.php/Main/UseYourHead'>Use Your Head</a>: Iron Man tries this in his battle against Thor. Key word: "Tries." Fully suited, he blasts Thor with a headbutt, who doesn't even flinch in slight discomfort, before returning the favor, bare forehead vs. gold-titanium alloy. And the former wins handily &#8212; apparently, Asgardian skulls are <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MadeOfIndestructium' title='/pmwiki/pmwiki.php/Main/MadeOfIndestructium'>Made of Indestructium</a>.</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder4');">&nbsp;&nbsp;&nbsp;&nbsp;V&nbsp;</div><div id="folder4" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VerbalBackspace' title='/pmwiki/pmwiki.php/Main/VerbalBackspace'>Verbal Backspace</a>: Thor tends to rush in when he speaks...<div class='indent'><strong>Thor:</strong> Have care how you speak. Loki is beyond reason but he is of Asgard, and he is my brother. <br /><strong>Black Widow:</strong> He killed 80 people in two days. <br /><strong>Thor:</strong> He's adopted...?</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VichyEarth' title='/pmwiki/pmwiki.php/Main/VichyEarth'>Vichy Earth</a>: Loki believes he and his Chitauri army will be the bringers of such a regime. Tony Stark, however, does not agree.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ViewerFriendlyInterface' title='/pmwiki/pmwiki.php/Main/ViewerFriendlyInterface'>Viewer-Friendly Interface</a>: The S.H.I.E.L.D. Helicarrier has a few giant vertically-mounted touchscreens for Fury and Hill to use, which feature giant spinning holograms of the Helicarrier, Earth, or just some moving wiggly lines. Background drones get keyboards and joysticks on their machines. The "Captain's" screens are specifically designed for a person with normal eyesight, which is lampshaded by Tony Stark when he covers one eye and tries to see all the screens around him and then asks how Nick Fury can see them with just one eye. (He turns, according to Maria Hill.)</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainOpeningScene' title='/pmwiki/pmwiki.php/Main/VillainOpeningScene'>Villain Opening Scene</a>: The movie opens with a brief, ominous scene of The Other giving Loki his scepter and musing about how they will <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TakeOverTheWorld' title='/pmwiki/pmwiki.php/Main/TakeOverTheWorld'>Take Over the World</a> and "The humans? What can they do but burn?"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainousBreakdown' title='/pmwiki/pmwiki.php/Main/VillainousBreakdown'>Villainous Breakdown</a>: The only reason why the grand schemer Loki <span class="spoiler" title="you can set spoilers visible by default on your profile" >would taunt and antagonize the Hulk</span> near the end of the film. Also, the only reason why Loki does anything in this film. With the throne of Asgard out of reach, he apparently wants to be ruler of something, <em>no matter what</em>. Hilariously averted when Loki tries <span class="spoiler" title="you can set spoilers visible by default on your profile" >and fails to brainwash Tony.</span> Instead of screaming "This cannot be!" like a typical villain, Loki just mutters his confusion.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainousPlanInertia' title='/pmwiki/pmwiki.php/Main/VillainousPlanInertia'>Villainous Plan Inertia</a>: While The Hulk <em>effortlessly</em> curbstomps Loki during the final battle, his alien invasion still continues without him and nearly wears down The Avengers through sheer attrition. It's only when Iron Man commandeers a nuke and sends it to the alien flagship through the portal that the Chitauri are defeated.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VillainOverForDinner' title='/pmwiki/pmwiki.php/Main/VillainOverForDinner'>Villain Over for Dinner</a>: Upon figuring out that Loki's next step involves trespassing Stark Tower, Tony tries to force this situation onto Loki, by pretending to be completely unfazed by his presence and offering him a drink. <span class="spoiler" title="you can set spoilers visible by default on your profile" >It's actually a ruse so Tony can get access to the bracelets he needs for putting on the Mark VII suit.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VisibleInvisibility' title='/pmwiki/pmwiki.php/Main/VisibleInvisibility'>Visible Invisibility</a>: The S.H.I.E.L.D. carrier has this, flipped on after it lifts off, but it ceases to be a plot point after that (and certainly didn't help when Loki's posse came knocking). Loki's rescue team is explicitly shown to be tracking his scepter.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VisualPun' title='/pmwiki/pmwiki.php/Main/VisualPun'>Visual Pun</a>:<ul ><li> Tony in his <a class='twikilink' href='/pmwiki/pmwiki.php/Music/BlackSabbath' title='/pmwiki/pmwiki.php/Music/BlackSabbath'>Black Sabbath</a> T-shirt; one of Black Sabbath's hits was "Iron Man". The design of the shirt is also a visual pun. The figure on the shirt is a British military pilot with a triangle on his forehead, and the album is called "Never Say Die!" The Iron Man armor started as a flight suit and had a triangular motif (until Whedon changed it) to match the triangular crystal that powered his arc reactor, which is what keeps him alive.</li><li> In Black Widow's opening scene, she beats up her captors with a total of eight limbs &#8212; her own, and four on the chair.</li><li> When Bruce first starts to hulk out, as his shirt tears he's lying next to a sign saying WARNING: CONTENTS UNDER PRESSURE.</li><li> Nick Fury's go-to pistol for the fight on the Helicarrier is a Smith and Wesson M&amp;P pistol. Specifically the 'Shield' model.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/VoxPops' title='/pmwiki/pmwiki.php/Main/VoxPops'>Vox Pops</a>: Occurs at the end, after the Battle of New York, to foreshadow the public opinion of superheroes in Phase One: most people are supportive and thankful, but some are wondering about the damage the city sustained and the fact that the Avengers themselves aren't answering to anyone.</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder5');">&nbsp;&nbsp;&nbsp;&nbsp;W&nbsp;</div><div id="folder5" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WaifFu' title='/pmwiki/pmwiki.php/Main/WaifFu'>Waif-Fu</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SignatureStyle' title='/pmwiki/pmwiki.php/Main/SignatureStyle'>But of course.</a> The movie is directed by <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a>, after all. Mostly performed by <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassNormal' title='/pmwiki/pmwiki.php/Main/BadassNormal'>Black Widow</a>, though not nearly as highly played as usual for Whedon. Loki is a male example.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WallOfWeapons' title='/pmwiki/pmwiki.php/Main/WallOfWeapons'>Wall of Weapons</a>: Seen on board the Helicarrier next to Captain America's shield and new uniform and near a door where Coulson has to do a retina scan to enter. Presumably it's the room <span class="spoiler" title="you can set spoilers visible by default on your profile" >where the BFG he uses on Loki is stored.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WallSlump' title='/pmwiki/pmwiki.php/Main/WallSlump'>Wall Slump</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Agent Coulson</span> immediately collapses against a nearby wall after being stabbed through the back by Loki and dies shortly after speaking to Director Fury.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WarComesHome' title='/pmwiki/pmwiki.php/Main/WarComesHome'>War Comes Home</a>: Has this trope for the climax. Loki summons an army of Chitauri and has it attack New York which is the home of both Iron Man and Captain America. The Avengers team up to fight back the Chitauri and they are ultimately successful in fending off the invasion.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WealthyPhilanthropist' title='/pmwiki/pmwiki.php/Main/WealthyPhilanthropist'>Wealthy Philanthropist</a>: The rich CEO Tony Stark describes himself as "a genius, billionaire, playboy philanthropist".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WeaponizedLandmark' title='/pmwiki/pmwiki.php/Main/WeaponizedLandmark'>Weaponized Landmark</a>: Thor uses the Chrysler Building's spire to concentrate and amplify his lightning.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WeAreStrugglingTogether' title='/pmwiki/pmwiki.php/Main/WeAreStrugglingTogether'>We ARE Struggling Together</a>: The various characters get on each others' nerves when they're off duty, and thus set the stage for Loki's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BatmanGambit' title='/pmwiki/pmwiki.php/Main/BatmanGambit'>Batman Gambit</a>, but even before they become <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrueCompanions' title='/pmwiki/pmwiki.php/Main/TrueCompanions'>True Companions</a>, none of them are stupid enough to let personal quarrels stop them from cooperating when trouble starts. This is clearly demonstrated when Cap and Iron Man are on the point of fighting each other, but as soon as the alarm goes off they immediately drop their argument, suit up and have no problem working together in the ensuing chaos. Summed up in the tagline: "<a class='twikilink' href='/pmwiki/pmwiki.php/Main/JustForPun' title='/pmwiki/pmwiki.php/Main/JustForPun'>Some Assembly Required</a>"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WellDoneSonGuy' title='/pmwiki/pmwiki.php/Main/WellDoneSonGuy'>"Well Done, Son" Guy</a>: Stark's still wrestling with his issues, and apparently Howard Stark spent years talking about how awesome the Captain was. And now the Captain is back, like the big brother you can never live up to. All this is confirmed by Downey.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhamEpisode' title='/pmwiki/pmwiki.php/Main/WhamEpisode'>Wham Episode</a>: One for the entire MCU. Not only is the first major super team formed, the public now knows about aliens, a huge amount of innocents died in the New York attack, and <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos has become interested in Earth.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhamLine' title='/pmwiki/pmwiki.php/Main/WhamLine'>Wham Line</a>:<ul ><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >"So. Banner. That's your play." Spoken by Black Widow after manipulating Loki into gloating and revealing his plan. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OhCrap' title='/pmwiki/pmwiki.php/Main/OhCrap'>Loki's face says it all.</a></span></li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >"I'm always angry."</span></li><li> <span class="spoiler" title="you can set spoilers visible by default on your profile" >"Phase 2 is S.H.I.E.L.D. uses the Cube to make weapons!"</span></li><li> "To challenge [the humans] is to <em><span class="spoiler" title="you can set spoilers visible by default on your profile" >court Death.</span>"</em> Cue <span class="spoiler" title="you can set spoilers visible by default on your profile" ><a class='twikilink' href='/pmwiki/pmwiki.php/ComicBook/Thanos' title='/pmwiki/pmwiki.php/ComicBook/Thanos'>Thanos</a></span> turning around... and <em><a class='twikilink' href='/pmwiki/pmwiki.php/Main/SlasherSmile' title='/pmwiki/pmwiki.php/Main/SlasherSmile'>grinning.</a></em></li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhatHappenedToTheMouse' title='/pmwiki/pmwiki.php/Main/WhatHappenedToTheMouse'>What Happened to the Mouse?</a>:<ul ><li> After the attack on the Helicarrier and the transport of the Tesseract to New York, the remaining rogue scientists and mercs that assisted Loki just up and vanish, leaving him and Selvig to operate and defend the portal device by themselves.</li><li> At the start of the film Loki uses <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MindControl' title='/pmwiki/pmwiki.php/Main/MindControl'>Mind Control</a> on <span class="spoiler" title="you can set spoilers visible by default on your profile" >Barton, Selvig, and</span> an unnamed S.H.I.E.L.D. agent. We see nothing of that S.H.I.E.L.D. agent again after Loki's escape.</li><li> The sick patients Banner had been treating when Natasha recruited him aren't mentioned again, for all that losing their doctor surely reduced their chances of recovery. One would think S.H.I.E.L.D. could at least spare them some antibiotics.</li><li> While Selvig is seen in the movie and Jane is referenced as being in a secure site, no mention is made of Darcy's location. Especially telling since she was one of only 3 friends that Thor made on Earth and he never asks about her.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhatTheHellHero' title='/pmwiki/pmwiki.php/Main/WhatTheHellHero'>What the Hell, Hero?</a>: Captain America calls Nick Fury out after discovering that <span class="spoiler" title="you can set spoilers visible by default on your profile" >he has been secretly reverse-engineering HYDRA armaments and weapons.</span> He also called him out earlier when Nick Fury arrives to assign him to the Avengers shortly after Loki stole the Tesseract in regards to S.H.I.E.L.D. even possessing the tesseract in the first place, simply stating to Fury "You should have left it in the ocean." (referring to Howard Stark finding the Tesseract while searching for Captain America in the previous film).</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WickedCultured' title='/pmwiki/pmwiki.php/Main/WickedCultured'>Wicked Cultured</a>: The beautiful music that plays as Loki attacks Stuttgart is <a class='twikilink' href='/pmwiki/pmwiki.php/Music/FranzSchubert' title='/pmwiki/pmwiki.php/Music/FranzSchubert'>Franz Schubert</a>'s String Quartet No. 13 in A minor, D. 804, Op. 29. Loki choreographs his attack quite neatly with it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WithinParameters' title='/pmwiki/pmwiki.php/Main/WithinParameters'>Within Parameters</a>: Subverted when Dr. Selvig notes the "low levels of gamma radiation" emitting from the Tesseract. Fury expresses concern, but the reference to gamma rays is just a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ContinuityNod' title='/pmwiki/pmwiki.php/Main/ContinuityNod'>Continuity Nod</a> to the Hulk's <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperHeroOrigin' title='/pmwiki/pmwiki.php/Main/SuperHeroOrigin'>Super Hero Origin</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WithMyHandsTied' title='/pmwiki/pmwiki.php/Main/WithMyHandsTied'>With My Hands Tied</a>: The Black Widow can still kick your ass while tied to a chair, shoeless, and on the phone with Coulson.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoobieDestroyerOfWorlds' title='/pmwiki/pmwiki.php/Main/WoobieDestroyerOfWorlds'>Woobie, Destroyer of Worlds</a>:<ul ><li> Loki, who decides to conquer Earth to prove himself better than his <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ManipulativeBastard' title='/pmwiki/pmwiki.php/Main/ManipulativeBastard'>Manipulative Bastard</a> father, Odin.</li><li> Bruce Banner. The look on his face when he says <span class="spoiler" title="you can set spoilers visible by default on your profile" >"I'm always angry,"</span> shows what a burden "the other guy" is on his life. There's also the beautifully subtle moment when he says to Black Widow "I don't every time get what I want," and gently rocks an old baby cradle.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorkoutFanservice' title='/pmwiki/pmwiki.php/Main/WorkoutFanservice'>Workout Fanservice</a>: Captain America is introduced with a loving shot of his body and butt while he is working out his frustrations on a series of punching bags.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorkingOutTheirEmotions' title='/pmwiki/pmwiki.php/Main/WorkingOutTheirEmotions'>Working Out Their Emotions</a>: Steve Rogers' first scene shows him working out on a punching bag in an empty gym, interspersed with <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShellShockedVeteran' title='/pmwiki/pmwiki.php/Main/ShellShockedVeteran'>World War II</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Flashback' title='/pmwiki/pmwiki.php/Main/Flashback'>Flashbacks</a> from <a class='twikilink' href='/pmwiki/pmwiki.php/Film/CaptainAmericaTheFirstAvenger' title='/pmwiki/pmwiki.php/Film/CaptainAmericaTheFirstAvenger'>his first film</a>, until he <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperStrength' title='/pmwiki/pmwiki.php/Main/SuperStrength'>completely destroys the bag</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheWorldIsNotReady' title='/pmwiki/pmwiki.php/Main/TheWorldIsNotReady'>The World Is Not Ready</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >S.H.I.E.L.D. hands the Tesseract over to Asgard at the end, as it makes Earth a target and they clearly aren't ready to possess that kind of power yet.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorldOfBadass' title='/pmwiki/pmwiki.php/Main/WorldOfBadass'>World of Badass</a>: Deconstructed &#8212; the title heroes and their enemies are badass, but the rest of the human race <em>aren't</em>. They need a team like the Avengers to deal with the new universe of unstoppable threats like Loki, the Chitauri, and <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorldOfSnark' title='/pmwiki/pmwiki.php/Main/WorldOfSnark'>World of Snark</a>: Most of the major characters take a level in sarcasm from their previous portrayals. The most prominent are Tony Stark (as you would expect), Bruce Banner, Loki, and to a lesser extent, Nick Fury. Even the <em>Hulk</em> gets one, after being told by Loki that he stands before a God. <span class="spoiler" title="you can set spoilers visible by default on your profile" >His response is to <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MetronomicManMashing' title='/pmwiki/pmwiki.php/Main/MetronomicManMashing'>bash him into the ground repeatedly</a> and mutter "Puny god."</span><div class='indent'><strong><a class='twikilink' href='/pmwiki/pmwiki.php/Creator/JossWhedon' title='/pmwiki/pmwiki.php/Creator/JossWhedon'>Joss Whedon</a>:</strong> Everyone in this movie is a dry wit. It's like a desert of wit.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WorthyOpponent' title='/pmwiki/pmwiki.php/Main/WorthyOpponent'>Worthy Opponent</a>: The smile on Thor's face after being punched by the Hulk says it all.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WouldHarmASenior' title='/pmwiki/pmwiki.php/Main/WouldHarmASenior'>Would Harm a Senior</a>: When an old man refuses to bow down to Loki, Loki is about to kill him before Captain America stops him.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a>: Black Widow's interrogation technique uses an interesting form of this. She pretends to be at a disadvantage, prompting her victim to become overconfident and let slip some vital information. <span class="spoiler" title="you can set spoilers visible by default on your profile" >While she was playing her reactions to Loki up, she later admits to Hawkeye that he did rattle her pretty badly.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WriterOnBoard' title='/pmwiki/pmwiki.php/Main/WriterOnBoard'>Writer on Board</a>: Averted. In the commentary, Joss Whedon mentions how fans were surprised by Cap's line about God before facing off against Loki, since Whedon is an atheist. Whedon said that he's an atheist, but Cap isn't.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WrittenInAbsence' title='/pmwiki/pmwiki.php/Main/WrittenInAbsence'>Written-In Absence</a>:<ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/NataliePortman' title='/pmwiki/pmwiki.php/Creator/NataliePortman'>Natalie Portman</a> was unavailable for the film due to pregnancy. Her absence was explained as Jane Foster being transferred to a secure location in an observatory for her protection after Loki shows up.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/HayleyAtwell' title='/pmwiki/pmwiki.php/Creator/HayleyAtwell'>Hayley Atwell</a> was probably never intended to appear as an elderly Peggy Carter in <em>Avengers</em>, but her character is still referenced on screen by way of a photo (and a deleted scene included on the DVD shows Steve discovering that <span class="spoiler" title="you can set spoilers visible by default on your profile" >she is still alive</span>).</li><li> Despite being a fellow superhero and having the means to assist them, War Machine does not show up, or is even mentioned during this film. His absence is explained in a tie-in comic where he was revealed to have been fighting the Ten Rings on the other side of the world, and arrived back to New York too late to be able to do anything.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WrestlerInAllOfUs' title='/pmwiki/pmwiki.php/Main/WrestlerInAllOfUs'>Wrestler in All of Us</a>: Black Widow takes out a mook via hurricanrana, Hulk body slams several opponents, and Thor even gets in on the action when he gorilla presses Loki. During the battle in New York, Hawkeye finds himself on the wrong end of a spear.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WrongGenreSavvy' title='/pmwiki/pmwiki.php/Main/WrongGenreSavvy'>Wrong Genre Savvy</a>:<ul ><li> When Black Widow tells Captain America and Bruce Banner to enter the interior of the aircraft carrier, Captain America deduced from her comment of it "soon becoming hard to breathe" that the aircraft carrier doubled as a submarine. Turns out it was actually a literal aircraft as well.</li><li> Loki, thrice. First he mistakenly assumes that Romanoff is going to try to pretend to take his side while he's in captivity. Later, he thinks Tony is going to try to appeal to his humanity. Finally, he assumes that ruling is a simple matter of forcing weaker beings to do exactly what you want, despite the fact that the old man in Germany, the New York cops and Dr. Selvig all fought back against him or his forces in some way. Thor <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LampshadeHanging' title='/pmwiki/pmwiki.php/Main/LampshadeHanging'>points out</a> that Loki doesn't seem to understand what being a king <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReasonableAuthorityFigure' title='/pmwiki/pmwiki.php/Main/ReasonableAuthorityFigure'>actually is</a>, and that asking <span class="spoiler" title="you can set spoilers visible by default on your profile" >an insane tyrant alien</span> for help probably wasn't the best idea.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WronskiFeint' title='/pmwiki/pmwiki.php/Main/WronskiFeint'>Wronski Feint</a>: Hawkeye advises Iron Man that this is the way to get rid of the Chitauri bogeys on his six, because "they can't bank worth a damn."</li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder6');">&nbsp;&nbsp;&nbsp;&nbsp;X&nbsp;</div><div id="folder6" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/XanatosGambit' title='/pmwiki/pmwiki.php/Main/XanatosGambit'>Xanatos Gambit</a>: Natasha thinks she's playing Loki with her <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a>, but in fact Loki is getting her to discover his plan, <span class="spoiler" title="you can set spoilers visible by default on your profile" > that he intends to unleash the Hulk,</span> precisely when he needs the team to learn it so they will <span class="spoiler" title="you can set spoilers visible by default on your profile" >stress out Banner by scrutinizing him, making him more susceptible to hulking out just as brainwashed Clint is launching his attack.</span></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder7');">&nbsp;&nbsp;&nbsp;&nbsp;Y&nbsp;</div><div id="folder7" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YeOldeButcheredeEnglishe' title='/pmwiki/pmwiki.php/Main/YeOldeButcheredeEnglishe'>Ye Olde Butcherede Englishe</a>: Invoked. Tony Stark taunts Thor by speaking in mock-Shakespearean English (although, in the <em>Thor</em> movie, Asgardians didn't speak like that). Doubles up as a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MythologyGag' title='/pmwiki/pmwiki.php/Main/MythologyGag'>Mythology Gag</a>.<div class='indent'><strong>Thor:</strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouHaveNoIdeaWhoYoureDealingWith' title='/pmwiki/pmwiki.php/Main/YouHaveNoIdeaWhoYoureDealingWith'>You have no idea what you're dealing with</a>. <br /><strong>Tony:</strong> Uh... <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YourCostumeNeedsWork' title='/pmwiki/pmwiki.php/Main/YourCostumeNeedsWork'>Shakespeare in the park?</a> <em>[strikes a Shakespearean pose]</em> "Doth mother know <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperheroesWearCapes' title='/pmwiki/pmwiki.php/Main/SuperheroesWearCapes'>you weareth her drapes</a>?"<span class="notelabel" onclick="togglenote('note0zbdx');"><sup>note&nbsp;</sup></span><span id="note0zbdx" class="inlinefolder" isnote="true" onclick="togglenote('note0zbdx');" style="cursor:pointer;font-size:smaller;display:none;">The grammatically correct question for that period would be, "Doth mother know thou wearest her drapes?" But cut him some slack, this was a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ThrowItIn' title='/pmwiki/pmwiki.php/Main/ThrowItIn'>Throw It In</a> line.</span></div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouAreBetterThanYouThinkYouAre' title='/pmwiki/pmwiki.php/Main/YouAreBetterThanYouThinkYouAre'>You Are Better Than You Think You Are</a>: Bruce rebuffs all suggestions that the Hulk could be channeled to benevolent purposes: Tony draws parallels between their situations and insists that Banner/Hulk can be a hero.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouAreTheNewTrend' title='/pmwiki/pmwiki.php/Main/YouAreTheNewTrend'>You Are the New Trend</a>: The end features the citizens of New York (and the world in general) showing their admiration of the titular group by doing things like getting their beards cut in the style of Tony Stark and images of The Mighty Shield appearing on t-shirts and graffiti.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouExclamation' title='/pmwiki/pmwiki.php/Main/YouExclamation'>"You!" Exclamation</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Downplayed' title='/pmwiki/pmwiki.php/Main/Downplayed'>Downplayed</a>. Black Widow says "Oh. You." when Loki starts to fire at her while they are riding the Chitauri chariots, but Black Widow's delivery is deadpan and Loki is too far away to hear her.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouHaveFailedMe' title='/pmwiki/pmwiki.php/Main/YouHaveFailedMe'>You Have Failed Me</a>: Not actually done, but promised by The Other should Loki fail to acquire the Tesseract for <span class="spoiler" title="you can set spoilers visible by default on your profile" >Thanos</span>, though he was also talking about the possibility of Loki attempting to withhold the Tesseract as well. To wit:<div class='indent'><strong>The Other:</strong> If you fail &#8212; if the Tesseract is kept from us... there will be no realm, no barren moon, no <em>crevice</em> where he cannot find you. You think you know pain? He will make you long for something sweet as pain.</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouHaveNoIdeaWhoYoureDealingWith' title='/pmwiki/pmwiki.php/Main/YouHaveNoIdeaWhoYoureDealingWith'>You Have No Idea Who You're Dealing With</a>: Said almost word for word by Thor to Tony Stark about Loki on meeting.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouHaveOutlivedYourUsefulness' title='/pmwiki/pmwiki.php/Main/YouHaveOutlivedYourUsefulness'>You Have Outlived Your Usefulness</a>: Our heroes are quite worried that Loki plans on doing this to his mind-controlled minions. Thor worries after Selvig's fate, and Black Widow approaches Loki under the guise of finding out what his plans are for Barton after. His response is not reassuring.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouJustToldMe' title='/pmwiki/pmwiki.php/Main/YouJustToldMe'>You Just Told Me</a>: This is how Natasha Romanoff manages to deduce what Loki is planning as his escape. It's also implied earlier that this is how she gets intel, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CapturedOnPurpose' title='/pmwiki/pmwiki.php/Main/CapturedOnPurpose'>among</a> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ObfuscatingStupidity' title='/pmwiki/pmwiki.php/Main/ObfuscatingStupidity'>other things.</a></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouMonster' title='/pmwiki/pmwiki.php/Main/YouMonster'>You Monster!</a>: Natasha levels this one at Loki after he tells her what he has in mind for Barton. <span class="spoiler" title="you can set spoilers visible by default on your profile" >It's just part of her very effective <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit' title='/pmwiki/pmwiki.php/Main/WoundedGazelleGambit'>Wounded Gazelle Gambit</a>, though.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YoureNothingWithoutYourPhlebotinum' title='/pmwiki/pmwiki.php/Main/YoureNothingWithoutYourPhlebotinum'>You're Nothing Without Your Phlebotinum</a>: Iron Man and Captain America trade these:<ul ><li> Steve Rogers sneers at Stark, "Big man in a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoweredArmour' title='/pmwiki/pmwiki.php/Main/PoweredArmour'>suit of armor</a>. Take that away and what are you?" Stark immediately responds, "A genius, billionaire, playboy, philanthropist." Rogers then immediately shoots down Stark's smug reply by pointing out he knew plenty of better men who had none of that. However, the question of whether Stark has the heart of a hero is not concluded until the finale.</li><li> Stark eventually returns the favor by telling Captain America, "Everything special about you came <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SuperSerum' title='/pmwiki/pmwiki.php/Main/SuperSerum'>from a bottle</a>," implying that Captain America hasn't really earned his spot among the team like the rest have.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YouWouldntLikeMeWhenImAngry' title='/pmwiki/pmwiki.php/Main/YouWouldntLikeMeWhenImAngry'>You Wouldn't Like Me When I'm Angry!</a>: The Hulk, as expected considering he is the <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TropeCodifier' title='/pmwiki/pmwiki.php/Main/TropeCodifier'>Trope Codifier</a> but subverted in this case.<span class="spoiler" title="you can set spoilers visible by default on your profile" >He's <em>always</em> angry and you won't like him when he loses control but you <em>definitely</em> won't like him when he decides to <em>voluntarily</em> unleash the Hulk. Notice how fast and comparatively painless the transformation is before the final battle now that he's accepted the Hulk as part of himself?</span><ul ><li> Also referenced after the S.H.I.E.L.D. pilot opens fire on the Hulk:<div class='indent'><strong>Pilot:</strong> Target angry! <em>Target angry!</em></div></li></ul></li></ul></div></p><p><div class="folderlabel" onclick="togglefolder('folder8');">&nbsp;&nbsp;&nbsp;&nbsp;Z&nbsp;</div><div id="folder8" class="folder" isfolder="true" style="display:block;"><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ZergRush' title='/pmwiki/pmwiki.php/Main/ZergRush'>Zerg Rush</a>: The Chitauri, given the kind of opposition they face, rely on sheer numbers to whittle down the heroes. Of particular note is when a good dozen or so of them <em>simultaneously</em> focus fire on The Hulk, effectively pinning him in place under the combined fire.</li></ul></div><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/TheAvengers/TropesMToP">Tropes M to P</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Film/TheAvengers2012">Film/The Avengers (2012)</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/TheAvengers/TieIns">Tie Ins</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=3249201cca6b7eeca1de118d08d4474b20e5ab7e';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -247,6 +247,26 @@ func (scraper *ServiceScraper) CheckSubpageUri(URI, title string) bool {
 	return match
 }
 
+// ScrapeTvTropes tries to scrape all pages and its subpages that are TvTropesPages by making HTTP requests to TvTropes
+// It only returns an error if it can't write or read the dataset, if the page can't be scraped it skips to the next
+func (scraper *ServiceScraper) ScrapeTvTropes(tvtropespages *tropestogo.TvTropesPages) error {
+	for page, tvtropessubpages := range tvtropespages.Pages {
+		var subPages []tropestogo.Page
+		for subPage := range tvtropessubpages.Subpages {
+			subPages = append(subPages, subPage)
+		}
+
+		scraper.ScrapeTvTropesPage(page, subPages)
+	}
+
+	errPersist := scraper.Persist()
+	if errPersist != nil {
+		return errPersist
+	}
+
+	return nil
+}
+
 // ScrapeTvTropesPage makes an HTTP request to a TvTropes page and its subpages and fully scrapes its contents
 // calling all sub functions and returning a valid Media object
 // If the url of the page isn't found, it returns an ErrNotFound error

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -341,7 +341,7 @@ func (scraper *ServiceScraper) ScrapeTropes(doc *goquery.Document) (map[tropesto
 	doc.Find(selector).EachWithBreak(func(_ int, selection *goquery.Selection) bool {
 		tropeUri, tropeUriExists := selection.Attr("href")
 		if tropeUriExists {
-			newTrope, newTropeError = tropestogo.NewTrope(strings.Split(tropeUri, "/")[4], tropestogo.TropeIndex(0))
+			newTrope, newTropeError = tropestogo.NewTrope(strings.Split(tropeUri, "/")[4], tropestogo.TropeIndex(0), "")
 			if newTropeError != nil {
 				return false
 			}

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -121,17 +121,12 @@ func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, checkUrl *ur
 		return false, ErrNotTvTropes
 	}
 
-	validWorkPage, errWorkPage := scraper.CheckIsWorkPage(checkUrl)
+	validWorkPage, errWorkPage := scraper.CheckIsWorkPage(doc, checkUrl)
 	if !validWorkPage {
 		return false, errWorkPage
 	}
 
-	validMainArticle, errMainArticle := scraper.CheckMainArticle(doc, checkUrl)
-	if !validMainArticle {
-		return false, errMainArticle
-	}
-
-	validTropeSection, errTropeSection := scraper.CheckTropeSection(doc, checkUrl)
+	validTropeSection, errTropeSection := scraper.CheckTropeSection(doc)
 	if !validTropeSection {
 		return false, errTropeSection
 	}
@@ -139,10 +134,15 @@ func (scraper *ServiceScraper) CheckValidWorkPage(reader io.Reader, checkUrl *ur
 	return true, nil
 }
 
-// CheckIsWorkPage checks if the received url belongs to a tvtropes.org Work Page
-// It returns an ErrNotTvTropes error if it doesn't belong to TvTropes or a ErrNotWorkPage if it's from TvTropes but of any other type
-// It returns true if all checks passes
-func (scraper *ServiceScraper) CheckIsWorkPage(url *url.URL) (bool, error) {
+// CheckIsWorkPage checks if the received url belongs to a correct tvtropes.org Work Page
+// It returns an ErrNotTvTropes error if it doesn't belong to TvTropes, an ErrNotWorkPage if it's from TvTropes but of any other type
+// or an ErrUnknownPageStructure if there are strange elements on it
+// Returns true if all checks passes
+func (scraper *ServiceScraper) CheckIsWorkPage(doc *goquery.Document, url *url.URL) (bool, error) {
+	if doc == nil || url == nil {
+		return false, ErrInvalidField
+	}
+
 	if url.Hostname() != TvTropesHostname {
 		return false, fmt.Errorf("%w: "+url.String(), ErrNotTvTropes)
 	}
@@ -152,22 +152,16 @@ func (scraper *ServiceScraper) CheckIsWorkPage(url *url.URL) (bool, error) {
 		return false, fmt.Errorf("%w: "+url.String(), ErrNotWorkPage)
 	}
 
-	return true, nil
-}
-
-// CheckMainArticle checks the received goquery Document DOM Tree
-// and validates if the work main article page has a known structure which can be extracted later
-// If it doesn't recognize something in it, it returns an ErrUnknownPageStructure or an ErrNotWorkPage, so it can't be scraped
-// It returns true if all checks passes
-func (scraper *ServiceScraper) CheckMainArticle(doc *goquery.Document, checkUrl *url.URL) (bool, error) {
 	if doc.Find(MainArticleSelector).Length() == 0 ||
-		doc.Find(SubPagesNavSelector).Find(SubPageListSelector).Find(SubPageLinkSelector).Length() == 0 {
+		doc.Find(SubPagesNavSelector).Find(SubPageListSelector).Find(SubPageLinkSelector).Length() == 0 ||
+		doc.Find(TropeListSelector).Length() == 0 ||
+		doc.Find(TropeLinkSelector).Length() == 0 {
 		return false, ErrUnknownPageStructure
 	}
 
-	tropeIndex := doc.Find(WorkIndexSelector)
-	if strings.Trim(tropeIndex.Text(), " /") != media.Film.String() {
-		return false, fmt.Errorf("%w: "+checkUrl.String(), ErrNotWorkPage)
+	tropeIndex := strings.Trim(doc.Find(WorkIndexSelector).Text(), " /")
+	if tropeIndex != media.Film.String() {
+		return false, fmt.Errorf("%w: the index is"+tropeIndex, ErrNotWorkPage)
 	}
 
 	return true, nil
@@ -178,32 +172,19 @@ func (scraper *ServiceScraper) CheckMainArticle(doc *goquery.Document, checkUrl 
 // First it checks if there are folders, then if the list redirects to trope subpages and last if there's a list with only tropes
 // If the trope section isn't of the recognized types, it returns an ErrUnknownPageStructure, so it can't be scraped
 // It returns true if all checks passes
-func (scraper *ServiceScraper) CheckTropeSection(doc *goquery.Document, checkUrl *url.URL) (bool, error) {
-	// Look for the tropes section
-	if doc.Find(TropeListSelector).Length() != 0 {
-		// Check if tropes are on folders
-		if scraper.CheckTropesOnFolders(doc) {
-			return true, nil
-		}
+func (scraper *ServiceScraper) CheckTropeSection(doc *goquery.Document) (bool, error) {
+	if scraper.CheckTropesOnFolders(doc) {
+		return true, nil
+	}
 
-		// Check if the list is a simple trope list or a list of subpages with tropes
-		if doc.Find(TropeLinkSelector).Length() != 0 {
-			// Get the title of the work from the URI and remove its year for checking subpages
-			splitPath := strings.Split(checkUrl.Path, "/")
-			re := regexp.MustCompile(`\d`)
-			title := re.ReplaceAllString(splitPath[4], "")
+	title, _, _, _ := scraper.ScrapeWorkTitleAndYear(doc)
+	if scraper.CheckTropesOnSubpages(doc, title) {
+		return true, nil
+	}
 
-			if scraper.CheckTropesOnSubpages(doc, title) {
-				return true, nil
-			}
-
-			// If not, then tropes must be on a simple list because the links refer to a trope page
-			// Get the first word of the first element of the list and check if is an anchor to a trope page
-			tropeHref, exists := doc.Find(TropeLinkSelector).First().Attr("href")
-			if exists && strings.HasPrefix(tropeHref, TvTropesMainPath) {
-				return true, nil
-			}
-		}
+	tropeHref, exists := doc.Find(TropeLinkSelector).First().Attr("href")
+	if exists && strings.HasPrefix(tropeHref, TvTropesMainPath) {
+		return true, nil
 	}
 
 	// Tropes are presented in an unknown form, so data can't be extracted
@@ -245,6 +226,15 @@ func (scraper *ServiceScraper) CheckSubpageUri(URI, title string) bool {
 	match := r.MatchString(strings.ToLower(URI))
 
 	return match
+}
+
+// CheckIsSubpage checks both the URI and the title for validating if the given subpage is a correct subpage that holds main tropes within a Work
+// It extracts the whole title + namespace of the title from the Goquery document and checks if its valid
+// Returns a true boolean if it's a subpage, a false if it's not
+func (scraper *ServiceScraper) CheckIsSubpage(title string, subDoc *goquery.Document) bool {
+	subPageTitle := "/" + strings.ReplaceAll(strings.ReplaceAll(subDoc.Find(WorkTitleSelector).Text(), "\n", ""), " ", "")
+
+	return scraper.CheckSubpageUri(subPageTitle, title)
 }
 
 // ScrapeTvTropes tries to scrape all pages and its subpages that are TvTropesPages by making HTTP requests to TvTropes
@@ -410,23 +400,23 @@ func (scraper *ServiceScraper) ScrapeMainSubpageTropes(doc *goquery.Document, su
 
 	doc.Find(MainTropesSelector).EachWithBreak(func(i int, selection *goquery.Selection) bool {
 		subpageUri, subpageUriExists := selection.Attr("href")
+		if i >= len(subDocs) {
+			return false
+		}
 
-		if subpageUriExists && scraper.CheckSubpageUri(subpageUri, title) {
-			subPageTitle := "/" + strings.ReplaceAll(strings.ReplaceAll(subDocs[i].Find(WorkTitleSelector).Text(), "\n", ""), " ", "")
-			if !scraper.CheckSubpageUri(subPageTitle, title) {
-				errSubpage = fmt.Errorf("%w: "+subPageTitle, ErrInvalidSubpage)
-				return false
-			}
-
+		if subpageUriExists && scraper.CheckSubpageUri(subpageUri, title) && scraper.CheckIsSubpage(title, subDocs[i]) {
 			subpageTropes, err := scraper.ScrapeTropes(subDocs[i])
 			if err == nil {
 				for subpageTrope := range subpageTropes {
 					tropes[subpageTrope] = struct{}{}
 				}
+
+				return true
 			}
 		}
 
-		return true
+		errSubpage = fmt.Errorf("%w: "+subpageUri, ErrInvalidSubpage)
+		return false
 	})
 
 	if errSubpage != nil {

--- a/tropestogo/service/scraper/scraper_test.go
+++ b/tropestogo/service/scraper/scraper_test.go
@@ -162,9 +162,11 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				notWorkUrl, _ := url.Parse(mediaUrl)
+				pageReaderJson, _ = os.Open("resources/empty.html")
+				pageReaderCsv, _ = os.Open("resources/empty.html")
 
-				validNotWorkPageJson, errNotWorkPageJson = serviceScraperJson.CheckIsWorkPage(notWorkUrl)
-				validNotWorkPageCsv, errNotWorkPageCsv = serviceScraperCsv.CheckIsWorkPage(notWorkUrl)
+				validNotWorkPageJson, errNotWorkPageJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, notWorkUrl)
+				validNotWorkPageCsv, errNotWorkPageCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, notWorkUrl)
 			})
 
 			It("Should mark the page as invalid", func() {
@@ -184,8 +186,11 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				differentUrl, _ := url.Parse(googleUrl)
-				validDifferentPageJson, errDifferentJson = serviceScraperJson.CheckIsWorkPage(differentUrl)
-				validDifferentPageCsv, errDifferentCsv = serviceScraperCsv.CheckIsWorkPage(differentUrl)
+				pageReaderJson, _ = os.Open("resources/empty.html")
+				pageReaderCsv, _ = os.Open("resources/empty.html")
+
+				validDifferentPageJson, errDifferentJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, differentUrl)
+				validDifferentPageCsv, errDifferentCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, differentUrl)
 			})
 
 			It("Should mark the page as invalid", func() {

--- a/tropestogo/service/scraper/scraper_test.go
+++ b/tropestogo/service/scraper/scraper_test.go
@@ -54,6 +54,11 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("Scraper", func() {
+	AfterEach(func() {
+		pageReaderCsv.Close()
+		pageReaderJson.Close()
+	})
+
 	Describe("Create the scraper services", func() {
 		Context("The services are created correctly", func() {
 			It("Shouldn't return an error", func() {
@@ -92,11 +97,6 @@ var _ = Describe("Scraper", func() {
 				validTvTropesPageCsv, errTvTropesCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl)
 			})
 
-			AfterEach(func() {
-				pageReaderCsv.Close()
-				pageReaderJson.Close()
-			})
-
 			It("Should mark the page as valid", func() {
 				Expect(validTvTropesPageJson).To(BeTrue())
 				Expect(validTvTropesPageCsv).To(BeTrue())
@@ -121,11 +121,6 @@ var _ = Describe("Scraper", func() {
 				validTvTropesPage2Csv, errTvTropes2Csv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl2)
 			})
 
-			AfterEach(func() {
-				pageReaderJson.Close()
-				pageReaderCsv.Close()
-			})
-
 			It("Should mark the page as valid", func() {
 				Expect(validTvTropesPage2Json).To(BeTrue())
 				Expect(validTvTropesPage2Csv).To(BeTrue())
@@ -148,11 +143,6 @@ var _ = Describe("Scraper", func() {
 
 				validTvTropesPage3Json, errTvTropes3Json = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl3)
 				validTvTropesPage3Csv, errTvTropes3Json = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl3)
-			})
-
-			AfterEach(func() {
-				pageReaderCsv.Close()
-				pageReaderJson.Close()
 			})
 
 			It("Should mark the page as valid", func() {
@@ -224,11 +214,6 @@ var _ = Describe("Scraper", func() {
 				validfilm1Csv, errorfilm1Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrl)
 				errPersistJson = serviceScraperJson.Persist()
 				errPersistCsv = serviceScraperCsv.Persist()
-			})
-
-			AfterEach(func() {
-				pageReaderCsv.Close()
-				pageReaderJson.Close()
 			})
 
 			It("Shouldn't return an error", func() {
@@ -327,11 +312,6 @@ var _ = Describe("Scraper", func() {
 				errPersistCsv = serviceScraperCsv.Persist()
 			})
 
-			AfterEach(func() {
-				pageReaderCsv.Close()
-				pageReaderJson.Close()
-			})
-
 			It("Shouldn't return an error", func() {
 				Expect(errorfilm3Csv).To(BeNil())
 				Expect(errorfilm3Json).To(BeNil())
@@ -374,11 +354,6 @@ var _ = Describe("Scraper", func() {
 				filminvalidtypeCsv, errorfilminvalidtypeCsv = serviceScraperCsv.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrlUnknown)
 				errPersistCsv = serviceScraperCsv.Persist()
 				errPersistJson = serviceScraperJson.Persist()
-			})
-
-			AfterEach(func() {
-				pageReaderCsv.Close()
-				pageReaderJson.Close()
 			})
 
 			It("Should return an empty media object", func() {

--- a/tropestogo/service/scraper/scraper_test.go
+++ b/tropestogo/service/scraper/scraper_test.go
@@ -4,28 +4,32 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	tropestogo "github.com/jlgallego99/TropesToGo"
 	"github.com/jlgallego99/TropesToGo/media"
 	"github.com/jlgallego99/TropesToGo/media/csv_dataset"
 	"github.com/jlgallego99/TropesToGo/media/json_dataset"
+	"github.com/jlgallego99/TropesToGo/service/scraper"
 	"io"
 	"net/url"
 	"os"
 	"strings"
-
-	tropestogo "github.com/jlgallego99/TropesToGo"
-	"github.com/jlgallego99/TropesToGo/service/scraper"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 const (
-	oldboyUrl        = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
-	anewhopeUrl      = "https://tvtropes.org/pmwiki/pmwiki.php/Film/ANewHope"
-	avengersUrl      = "https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012"
-	mediaUrl         = "https://tvtropes.org/pmwiki/pmwiki.php/Main/Media"
-	googleUrl        = "https://www.google.com/"
-	attackontitanUrl = "https://tvtropes.org/pmwiki/pmwiki.php/Manga/AttackOnTitan"
+	oldboyUrl             = "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003"
+	oldboyResource        = "resources/oldboy2003.html"
+	anewhopeUrl           = "https://tvtropes.org/pmwiki/pmwiki.php/Film/ANewHope"
+	anewhopeResource      = "resources/anewhope.html"
+	avengersUrl           = "https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012"
+	avengersResource      = "resources/theavengers2012.html"
+	mediaUrl              = "https://tvtropes.org/pmwiki/pmwiki.php/Main/Media"
+	googleUrl             = "https://www.google.com/"
+	attackontitanUrl      = "https://tvtropes.org/pmwiki/pmwiki.php/Manga/AttackOnTitan"
+	attackontitanResource = "resources/attackontitan.html"
+	emptyResource         = "resources/empty.html"
 )
 
 var (
@@ -90,8 +94,8 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				tvTropesUrl, _ := url.Parse(oldboyUrl)
-				pageReaderJson, _ = os.Open("resources/oldboy2003.html")
-				pageReaderCsv, _ = os.Open("resources/oldboy2003.html")
+				pageReaderJson, _ = os.Open(oldboyResource)
+				pageReaderCsv, _ = os.Open(oldboyResource)
 
 				validTvTropesPageJson, errTvTropesJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl)
 				validTvTropesPageCsv, errTvTropesCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl)
@@ -114,8 +118,8 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				tvTropesUrl2, _ := url.Parse(avengersUrl)
-				pageReaderJson, _ = os.Open("resources/theavengers2012.html")
-				pageReaderCsv, _ = os.Open("resources/theavengers2012.html")
+				pageReaderJson, _ = os.Open(avengersResource)
+				pageReaderCsv, _ = os.Open(avengersResource)
 
 				validTvTropesPage2Json, errTvTropes2Json = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl2)
 				validTvTropesPage2Csv, errTvTropes2Csv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl2)
@@ -138,8 +142,8 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				tvTropesUrl3, _ := url.Parse(anewhopeUrl)
-				pageReaderCsv, _ = os.Open("resources/anewhope.html")
-				pageReaderJson, _ = os.Open("resources/anewhope.html")
+				pageReaderCsv, _ = os.Open(anewhopeResource)
+				pageReaderJson, _ = os.Open(anewhopeResource)
 
 				validTvTropesPage3Json, errTvTropes3Json = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl3)
 				validTvTropesPage3Csv, errTvTropes3Json = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl3)
@@ -162,8 +166,8 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				notWorkUrl, _ := url.Parse(mediaUrl)
-				pageReaderJson, _ = os.Open("resources/empty.html")
-				pageReaderCsv, _ = os.Open("resources/empty.html")
+				pageReaderJson, _ = os.Open(emptyResource)
+				pageReaderCsv, _ = os.Open(emptyResource)
 
 				validNotWorkPageJson, errNotWorkPageJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, notWorkUrl)
 				validNotWorkPageCsv, errNotWorkPageCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, notWorkUrl)
@@ -186,8 +190,8 @@ var _ = Describe("Scraper", func() {
 
 			BeforeEach(func() {
 				differentUrl, _ := url.Parse(googleUrl)
-				pageReaderJson, _ = os.Open("resources/empty.html")
-				pageReaderCsv, _ = os.Open("resources/empty.html")
+				pageReaderJson, _ = os.Open(emptyResource)
+				pageReaderCsv, _ = os.Open(emptyResource)
 
 				validDifferentPageJson, errDifferentJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, differentUrl)
 				validDifferentPageCsv, errDifferentCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, differentUrl)
@@ -205,219 +209,192 @@ var _ = Describe("Scraper", func() {
 		})
 	})
 
-	Describe("Scrape Film Page", func() {
-		Context("Valid Film Page with tropes on a simple list", func() {
-			var validfilm1Csv, validfilm1Json media.Media
-			var errorfilm1Csv, errorfilm1Json error
+	Describe("Scrape and persist an invalid Film because the media type isn't supported", func() {
+		var filminvalidtypeJson, filminvalidtypeCsv media.Media
+		var errorfilminvalidtypeJson, errorfilminvalidtypeCsv error
 
-			BeforeEach(func() {
-				tvTropesUrl, _ := url.Parse(oldboyUrl)
-				pageReaderCsv, _ = os.Open("resources/oldboy2003.html")
-				pageReaderJson, _ = os.Open("resources/oldboy2003.html")
+		BeforeEach(func() {
+			tvTropesUrlUnknown, _ := url.Parse(attackontitanUrl)
+			pageReaderCsv, _ = os.Open(attackontitanResource)
+			pageReaderJson, _ = os.Open(attackontitanResource)
 
-				validfilm1Json, errorfilm1Json = serviceScraperJson.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrl)
-				validfilm1Csv, errorfilm1Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrl)
-				errPersistJson = serviceScraperJson.Persist()
-				errPersistCsv = serviceScraperCsv.Persist()
-			})
-
-			It("Shouldn't return an error", func() {
-				Expect(errorfilm1Json).To(BeNil())
-				Expect(errorfilm1Csv).To(BeNil())
-				Expect(errPersistJson).To(BeNil())
-				Expect(errPersistCsv).To(BeNil())
-			})
-
-			It("Should have correct fields", func() {
-				testValidScrapedMedia(validfilm1Csv, "Oldboy", "2003", media.Film)
-				testValidScrapedMedia(validfilm1Json, "Oldboy", "2003", media.Film)
-			})
-
-			It("Shouldn't have repeated tropes", func() {
-				uniqueCsv := areTropesUnique(validfilm1Csv.GetWork().Tropes)
-				uniqueJson := areTropesUnique(validfilm1Json.GetWork().Tropes)
-
-				Expect(uniqueCsv).To(BeTrue())
-				Expect(uniqueJson).To(BeTrue())
-			})
-
-			It("Should have added a correct record on the JSON repository", func() {
-				testJsonRepository("Oldboy", "2003", "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003", "Film")
-			})
-
-			It("Should have added a correct record on the CSV repository", func() {
-				testCsvRepository("Oldboy", "2003", "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003", "Film")
-			})
+			filminvalidtypeJson, errorfilminvalidtypeJson = serviceScraperJson.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrlUnknown)
+			filminvalidtypeCsv, errorfilminvalidtypeCsv = serviceScraperCsv.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrlUnknown)
+			errPersistCsv = serviceScraperCsv.Persist()
+			errPersistJson = serviceScraperJson.Persist()
 		})
 
-		Context("Valid Film Page with tropes distributed on main sub pages", func() {
-			var validfilm2Csv, validfilm2Json media.Media
-			var errorfilm2Csv, errorfilm2Json error
+		It("Should return an empty media object", func() {
+			Expect(filminvalidtypeJson.GetWork()).To(BeNil())
+			Expect(filminvalidtypeJson.GetPage().GetUrl()).To(BeNil())
+			Expect(filminvalidtypeJson.GetPage().GetPageType()).To(BeZero())
+			Expect(filminvalidtypeJson.GetMediaType()).To(Equal(media.UnknownMediaType))
 
-			BeforeEach(func() {
-				tvTropesUrl2, _ := url.Parse("https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012")
-				pageReaderCsv, _ = os.Open("resources/theavengers2012.html")
-				pageReaderJson, _ = os.Open("resources/theavengers2012.html")
+			Expect(filminvalidtypeCsv.GetWork()).To(BeNil())
+			Expect(filminvalidtypeCsv.GetPage().GetUrl()).To(BeNil())
+			Expect(filminvalidtypeCsv.GetPage().GetPageType()).To(BeZero())
+			Expect(filminvalidtypeCsv.GetMediaType()).To(Equal(media.UnknownMediaType))
+		})
 
-				var subpageReadersCsv []io.Reader
-				var subpageReadersJson []io.Reader
-				for _, subpageFile := range avengersSubpageFiles {
-					subpageReaderCsv, _ := os.Open(subpageFile)
-					subpageReaderJson, _ := os.Open(subpageFile)
+		It("Should return an appropriate error", func() {
+			Expect(errors.Unwrap(errorfilminvalidtypeJson)).To(Equal(media.ErrUnknownMediaType))
+			Expect(errors.Unwrap(errorfilminvalidtypeCsv)).To(Equal(media.ErrUnknownMediaType))
+			Expect(errors.Unwrap(errPersistCsv)).To(Equal(csv_dataset.ErrPersist))
+			Expect(errors.Unwrap(errPersistJson)).To(Equal(json_dataset.ErrPersist))
+		})
 
-					subpageReadersCsv = append(subpageReadersCsv, subpageReaderCsv)
-					subpageReadersJson = append(subpageReadersJson, subpageReaderJson)
+		It("Should have empty datasets", func() {
+			// Check empty JSON dataset
+			var dataset json_dataset.JSONDataset
+			fileContents, _ := os.ReadFile("dataset.json")
+			err := json.Unmarshal(fileContents, &dataset)
+
+			Expect(err).To(BeNil())
+			Expect(dataset.Tropestogo).To(BeEmpty())
+
+			// Check empty CSV dataset
+			datasetFile, errReader := os.Open("dataset.csv")
+			Expect(errReader).To(BeNil())
+			reader := csv.NewReader(datasetFile)
+			records, errReadAll := reader.ReadAll()
+			Expect(errReadAll).To(BeNil())
+
+			Expect(err).To(BeNil())
+			Expect(len(records)).To(Equal(1))
+			Expect(records[0]).To(Equal([]string{"title", "year", "lastupdated", "url", "mediatype", "tropes", "tropes_index"}))
+		})
+	})
+
+	Describe("Scrape different Film Pages and persist on the dataset", func() {
+		var validfilm1Csv, validfilm2Csv, validfilm3Csv, validfilm1Json, validfilm2Json, validfilm3Json media.Media
+		var errorfilm1Csv, errorfilm2Csv, errorfilm3Csv, errorfilm1Json, errorfilm2Json, errorfilm3Json error
+
+		BeforeEach(func() {
+			tvTropesUrl, _ := url.Parse(oldboyUrl)
+			tvTropesUrl2, _ := url.Parse(avengersUrl)
+			tvTropesUrl3, _ := url.Parse(anewhopeUrl)
+
+			var subpageReadersCsv []io.Reader
+			var subpageReadersJson []io.Reader
+			for _, subpageFile := range avengersSubpageFiles {
+				subpageReaderCsv, _ := os.Open(subpageFile)
+				subpageReaderJson, _ := os.Open(subpageFile)
+
+				subpageReadersCsv = append(subpageReadersCsv, subpageReaderCsv)
+				subpageReadersJson = append(subpageReadersJson, subpageReaderJson)
+			}
+
+			// Scrape Oldboy
+			pageReaderCsv, _ = os.Open(oldboyResource)
+			pageReaderJson, _ = os.Open(oldboyResource)
+			validfilm1Json, errorfilm1Json = serviceScraperJson.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrl)
+			validfilm1Csv, errorfilm1Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrl)
+
+			// Scrape The Avengers
+			pageReaderCsv, _ = os.Open(avengersResource)
+			pageReaderJson, _ = os.Open(avengersResource)
+			validfilm2Csv, errorfilm2Json = serviceScraperJson.ScrapeWorkPage(pageReaderJson, subpageReadersCsv, tvTropesUrl2)
+			validfilm2Json, errorfilm2Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, subpageReadersJson, tvTropesUrl2)
+
+			// Scrape A New Hope
+			pageReaderCsv, _ = os.Open(anewhopeResource)
+			pageReaderJson, _ = os.Open(anewhopeResource)
+			validfilm3Json, errorfilm3Json = serviceScraperJson.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrl3)
+			validfilm3Csv, errorfilm3Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrl3)
+
+			// Persist all data
+			errPersistJson = serviceScraperJson.Persist()
+			errPersistCsv = serviceScraperCsv.Persist()
+		})
+
+		It("Shouldn't return any errors on scraping the Film", func() {
+			Expect(errorfilm1Json).To(BeNil())
+			Expect(errorfilm1Csv).To(BeNil())
+
+			Expect(errorfilm2Json).To(BeNil())
+			Expect(errorfilm2Csv).To(BeNil())
+
+			Expect(errorfilm3Json).To(BeNil())
+			Expect(errorfilm3Csv).To(BeNil())
+		})
+
+		It("Shouldn't return any persisting errors", func() {
+			Expect(errPersistJson).To(BeNil())
+			Expect(errPersistCsv).To(BeNil())
+		})
+
+		It("Should have no empty or null fields", func() {
+			testValidScrapedMedia(validfilm1Csv)
+			testValidScrapedMedia(validfilm1Json)
+
+			testValidScrapedMedia(validfilm2Csv)
+			testValidScrapedMedia(validfilm2Json)
+
+			testValidScrapedMedia(validfilm3Csv)
+			testValidScrapedMedia(validfilm3Json)
+		})
+
+		It("Shouldn't have repeated tropes", func() {
+			Expect(areTropesUnique(validfilm1Csv.GetWork().Tropes)).To(BeTrue())
+			Expect(areTropesUnique(validfilm1Json.GetWork().Tropes)).To(BeTrue())
+
+			Expect(areTropesUnique(validfilm2Csv.GetWork().Tropes)).To(BeTrue())
+			Expect(areTropesUnique(validfilm2Json.GetWork().Tropes)).To(BeTrue())
+
+			Expect(areTropesUnique(validfilm3Csv.GetWork().Tropes)).To(BeTrue())
+			Expect(areTropesUnique(validfilm3Json.GetWork().Tropes)).To(BeTrue())
+		})
+
+		It("Each record on the repository should have the correct columns/keys and they mustn't be empty", func() {
+			// Check JSON dataset
+			var dataset json_dataset.JSONDataset
+			fileContents, _ := os.ReadFile("dataset.json")
+			err := json.Unmarshal(fileContents, &dataset)
+
+			Expect(err).To(BeNil())
+			Expect(dataset.Tropestogo).To(Not(BeEmpty()))
+			for _, record := range dataset.Tropestogo {
+				jsonStringTropes := make([]string, 0)
+				for _, datasetTrope := range record.Tropes {
+					jsonStringTropes = append(jsonStringTropes, datasetTrope.Title)
 				}
 
-				validfilm2Csv, errorfilm2Json = serviceScraperJson.ScrapeWorkPage(pageReaderJson, subpageReadersCsv, tvTropesUrl2)
-				validfilm2Json, errorfilm2Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, subpageReadersJson, tvTropesUrl2)
-				errPersistJson = serviceScraperJson.Persist()
-				errPersistCsv = serviceScraperCsv.Persist()
-			})
+				Expect(record.Title).To(Not(BeEmpty()))
+				Expect(record.URL).To(Not(BeEmpty()))
+				Expect(record.LastUpdated).To(Not(BeEmpty()))
+				Expect(record.MediaType).To(Equal(media.Film.String()))
 
-			It("Shouldn't return an error", func() {
-				Expect(errorfilm2Csv).To(BeNil())
-				Expect(errorfilm2Json).To(BeNil())
-			})
+				areRepositoryTropesUnique(jsonStringTropes)
+			}
 
-			It("Should have correct fields", func() {
-				testValidScrapedMedia(validfilm2Csv, "The Avengers", "2012", media.Film)
-				testValidScrapedMedia(validfilm2Json, "The Avengers", "2012", media.Film)
-			})
+			// Check CSV dataset
+			datasetFile, errReader := os.Open("dataset.csv")
+			Expect(errReader).To(BeNil())
+			reader := csv.NewReader(datasetFile)
+			records, errReadAll := reader.ReadAll()
+			Expect(errReadAll).To(BeNil())
 
-			It("Shouldn't have repeated tropes", func() {
-				uniqueCsv := areTropesUnique(validfilm2Csv.GetWork().Tropes)
-				uniqueJson := areTropesUnique(validfilm2Json.GetWork().Tropes)
+			Expect(err).To(BeNil())
+			Expect(records[0]).To(Equal([]string{"title", "year", "lastupdated", "url", "mediatype", "tropes", "tropes_index"}))
+			Expect(len(records) > 1).To(BeTrue())
+			for _, record := range records {
+				for j, column := range record {
+					// The Year can be empty
+					if j != 1 {
+						Expect(column).To(Not(BeEmpty()))
+					}
+				}
 
-				Expect(uniqueCsv).To(BeTrue())
-				Expect(uniqueJson).To(BeTrue())
-			})
-
-			It("Should have added a correct record on the JSON repository", func() {
-				testJsonRepository("Oldboy", "2003", "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003", "Film")
-			})
-
-			It("Should have added a correct record on the CSV repository", func() {
-				testCsvRepository("Oldboy", "2003", "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003", "Film")
-			})
-		})
-
-		Context("Valid Film Page with tropes on folders", func() {
-			var validfilm3Csv, validfilm3Json media.Media
-			var errorfilm3Csv, errorfilm3Json error
-
-			BeforeEach(func() {
-				tvTropesUrl3, _ := url.Parse(anewhopeUrl)
-				pageReaderCsv, _ = os.Open("resources/anewhope.html")
-				pageReaderJson, _ = os.Open("resources/anewhope.html")
-
-				validfilm3Json, errorfilm3Json = serviceScraperJson.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrl3)
-				validfilm3Csv, errorfilm3Csv = serviceScraperCsv.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrl3)
-				errPersistJson = serviceScraperJson.Persist()
-				errPersistCsv = serviceScraperCsv.Persist()
-			})
-
-			It("Shouldn't return an error", func() {
-				Expect(errorfilm3Csv).To(BeNil())
-				Expect(errorfilm3Json).To(BeNil())
-				Expect(errPersistCsv).To(BeNil())
-				Expect(errPersistJson).To(BeNil())
-			})
-
-			It("Should have correct fields", func() {
-				testValidScrapedMedia(validfilm3Csv, "A New Hope", "", media.Film)
-				testValidScrapedMedia(validfilm3Json, "A New Hope", "", media.Film)
-			})
-
-			It("Shouldn't have repeated tropes", func() {
-				uniqueCsv := areTropesUnique(validfilm3Csv.GetWork().Tropes)
-				uniqueJson := areTropesUnique(validfilm3Json.GetWork().Tropes)
-
-				Expect(uniqueCsv).To(BeTrue())
-				Expect(uniqueJson).To(BeTrue())
-			})
-
-			It("Should have added a correct record on the JSON repository", func() {
-				testJsonRepository("Oldboy", "2003", "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003", "Film")
-			})
-
-			It("Should have added a correct record on the CSV repository", func() {
-				testCsvRepository("Oldboy", "2003", "https://tvtropes.org/pmwiki/pmwiki.php/Film/Oldboy2003", "Film")
-			})
-		})
-
-		Context("Invalid Film because the media type isn't supported", func() {
-			var filminvalidtypeJson, filminvalidtypeCsv media.Media
-			var errorfilminvalidtypeJson, errorfilminvalidtypeCsv error
-
-			BeforeEach(func() {
-				tvTropesUrlUnknown, _ := url.Parse(attackontitanUrl)
-				pageReaderCsv, _ = os.Open("resources/attackontitan.html")
-				pageReaderJson, _ = os.Open("resources/attackontitan.html")
-
-				filminvalidtypeJson, errorfilminvalidtypeJson = serviceScraperJson.ScrapeWorkPage(pageReaderCsv, []io.Reader{}, tvTropesUrlUnknown)
-				filminvalidtypeCsv, errorfilminvalidtypeCsv = serviceScraperCsv.ScrapeWorkPage(pageReaderJson, []io.Reader{}, tvTropesUrlUnknown)
-				errPersistCsv = serviceScraperCsv.Persist()
-				errPersistJson = serviceScraperJson.Persist()
-			})
-
-			It("Should return an empty media object", func() {
-				Expect(filminvalidtypeJson.GetWork()).To(BeNil())
-				Expect(filminvalidtypeJson.GetPage().GetUrl()).To(BeNil())
-				Expect(filminvalidtypeJson.GetPage().GetPageType()).To(BeZero())
-				Expect(filminvalidtypeJson.GetMediaType()).To(Equal(media.UnknownMediaType))
-
-				Expect(filminvalidtypeCsv.GetWork()).To(BeNil())
-				Expect(filminvalidtypeCsv.GetPage().GetUrl()).To(BeNil())
-				Expect(filminvalidtypeCsv.GetPage().GetPageType()).To(BeZero())
-				Expect(filminvalidtypeCsv.GetMediaType()).To(Equal(media.UnknownMediaType))
-			})
-
-			It("Should return an appropriate error", func() {
-				Expect(errors.Unwrap(errorfilminvalidtypeJson)).To(Equal(media.ErrUnknownMediaType))
-				Expect(errors.Unwrap(errorfilminvalidtypeCsv)).To(Equal(media.ErrUnknownMediaType))
-				Expect(errors.Unwrap(errPersistCsv)).To(Equal(csv_dataset.ErrPersist))
-				Expect(errors.Unwrap(errPersistJson)).To(Equal(json_dataset.ErrPersist))
-			})
+				areRepositoryTropesUnique(strings.Split(record[5], ";"))
+			}
 		})
 	})
 })
 
-func testValidScrapedMedia(validMedia media.Media, title, year string, mediaType media.MediaType) {
-	Expect(validMedia.GetWork().Title).To(Equal(title))
-	Expect(validMedia.GetWork().Year).To(Equal(year))
-	Expect(validMedia.GetMediaType()).To(Equal(mediaType))
+func testValidScrapedMedia(validMedia media.Media) {
+	Expect(validMedia.GetWork().Title).To(Not(BeEmpty()))
+	Expect(validMedia.GetMediaType()).To(Equal(media.Film))
 	Expect(validMedia.GetWork().Tropes).To(Not(BeEmpty()))
-}
-
-func testCsvRepository(title, year, URL, mediaType string) {
-	f, errOpen := os.Open("dataset.csv")
-	reader := csv.NewReader(f)
-	records, errReadCSV := reader.ReadAll()
-
-	Expect(errOpen).To(BeNil())
-	Expect(errReadCSV).To(BeNil())
-
-	Expect(len(records[0])).To(Equal(7))
-	Expect(len(records[1])).To(Equal(7))
-	Expect(records[1][0]).To(Equal(title))
-	Expect(records[1][1]).To(Equal(year))
-	Expect(records[1][3]).To(Equal(URL))
-	Expect(records[1][4]).To(Equal(mediaType))
-	Expect(len(strings.Split(records[1][5], ";")) > 0).To(BeTrue())
-}
-
-func testJsonRepository(title, year, URL, mediaType string) {
-	var dataset json_dataset.JSONDataset
-	fileContents, _ := os.ReadFile("dataset.json")
-	err := json.Unmarshal(fileContents, &dataset)
-
-	Expect(err).To(BeNil())
-	Expect(dataset.Tropestogo[0].Title).To(Equal(title))
-	Expect(dataset.Tropestogo[0].Year).To(Equal(year))
-	Expect(dataset.Tropestogo[0].URL).To(Equal(URL))
-	Expect(dataset.Tropestogo[0].MediaType).To(Equal(mediaType))
-	Expect(len(dataset.Tropestogo[0].Tropes) > 0).To(BeTrue())
 }
 
 func areTropesUnique(tropes map[tropestogo.Trope]struct{}) bool {
@@ -427,6 +404,19 @@ func areTropesUnique(tropes map[tropestogo.Trope]struct{}) bool {
 			return false
 		} else {
 			visited[trope.GetTitle()] = true
+		}
+	}
+
+	return true
+}
+
+func areRepositoryTropesUnique(tropes []string) bool {
+	visited := make(map[string]bool, 0)
+	for _, trope := range tropes {
+		if visited[trope] == true {
+			return false
+		} else {
+			visited[trope] = true
 		}
 	}
 

--- a/tropestogo/trope.go
+++ b/tropestogo/trope.go
@@ -56,15 +56,19 @@ func (index TropeIndex) String() string {
 
 // Trope represents a reiterative resource that is collected in TvTropes
 type Trope struct {
-	// A trope has an immutable name and is recognised by it
+	// title is the trope immutable name and is recognised by it
 	title string
 	// index is the conceptual group of tropes to which this trope belongs
 	index TropeIndex
+	// isMain represents if the trope is on the main Work page
+	isMain bool
+	// subpage refers to the subpage within a Work this trope belongs
+	subpage string
 }
 
 // NewTrope is a factory that creates a valid Trope value object by receiving its name and the index to which it belongs
 // It checks if the index is valid and returns an ErrUnknownIndex if it's not
-func NewTrope(title string, index TropeIndex) (Trope, error) {
+func NewTrope(title string, index TropeIndex, subpage string) (Trope, error) {
 	if len(title) == 0 {
 		return Trope{}, ErrMissingValues
 	}
@@ -74,8 +78,10 @@ func NewTrope(title string, index TropeIndex) (Trope, error) {
 	}
 
 	return Trope{
-		title: title,
-		index: index,
+		title:   title,
+		index:   index,
+		isMain:  subpage == "",
+		subpage: subpage,
 	}, nil
 }
 
@@ -87,4 +93,14 @@ func (trope Trope) GetTitle() string {
 // GetIndex returns the main category this trope belongs to in narratives
 func (trope Trope) GetIndex() TropeIndex {
 	return trope.index
+}
+
+// GetIsMain returns a boolean indicating whether it's a trope on the main Work page
+func (trope Trope) GetIsMain() bool {
+	return trope.isMain
+}
+
+// GetSubpage returns the Work subpage this trope belongs to
+func (trope Trope) GetSubpage() string {
+	return trope.subpage
 }

--- a/tropestogo/trope_test.go
+++ b/tropestogo/trope_test.go
@@ -11,9 +11,9 @@ var _ = Describe("Trope", func() {
 	var errValidTrope, errNoTitle, errNoIndex error
 
 	BeforeEach(func() {
-		validTrope, errValidTrope = tropestogo.NewTrope("ChekhovsGun", tropestogo.NarrativeTrope)
-		tropeNoTitle, errNoTitle = tropestogo.NewTrope("", tropestogo.TopicalTrope)
-		tropeNoIndex, errNoIndex = tropestogo.NewTrope("ChekhovsGun", tropestogo.TropeIndex(100))
+		validTrope, errValidTrope = tropestogo.NewTrope("ChekhovsGun", tropestogo.NarrativeTrope, "")
+		tropeNoTitle, errNoTitle = tropestogo.NewTrope("", tropestogo.TopicalTrope, "")
+		tropeNoIndex, errNoIndex = tropestogo.NewTrope("ChekhovsGun", tropestogo.TropeIndex(100), "")
 	})
 
 	Describe("Create a Trope", func() {
@@ -21,6 +21,8 @@ var _ = Describe("Trope", func() {
 			It("Shouldn't return an empty object", func() {
 				Expect(validTrope.GetTitle()).To(Equal("ChekhovsGun"))
 				Expect(validTrope.GetIndex()).To(Equal(tropestogo.NarrativeTrope))
+				Expect(validTrope.GetSubpage()).To(BeEmpty())
+				Expect(validTrope.GetIsMain()).To(BeTrue())
 			})
 
 			It("Shouldn't raise an error", func() {

--- a/tropestogo/tvtropespages.go
+++ b/tropestogo/tvtropespages.go
@@ -12,14 +12,25 @@ var (
 
 // TvTropesPages is an entity that manages all relevant pages in TvTropes for its extraction
 // Each Page has a last updated date, for checking future TvTropes updates on its Pages
+// and a list of its subpages, each with their own last updated time
 type TvTropesPages struct {
-	Pages map[Page]time.Time
+	Pages map[Page]*TvTropesSubpages
+}
+
+// TvTropesSubpages is an entity that manages all subpages of a TvTropes page for its extraction
+// It has the main page last updated time and also each Page has its own last updated date
+type TvTropesSubpages struct {
+	// LastUpdated is the last time the main page was updated
+	LastUpdated time.Time
+
+	// Subpages are pages that are inside the main page, and each has a last time when they were updated
+	Subpages map[Page]time.Time
 }
 
 // NewTvTropesPages creates an empty object to which we can add valid Pages
 func NewTvTropesPages() *TvTropesPages {
 	return &TvTropesPages{
-		Pages: make(map[Page]time.Time, 0),
+		Pages: make(map[Page]*TvTropesSubpages, 0),
 	}
 }
 
@@ -27,7 +38,7 @@ func NewTvTropesPages() *TvTropesPages {
 // except if the page has already been added before, then it will return an ErrDuplicatedPage error
 // If the url is empty or has an invalid format, it will return either an ErrEmptyUrl or ErrBadUrl error
 // If the url does not belong to a TvTropes page, it will return an ErrNotTvTropes error
-func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string) error {
+func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string, subpageUrls []string) error {
 	newPage, errNewPage := NewPage(pageUrl)
 	if errNewPage != nil {
 		return errNewPage
@@ -39,6 +50,19 @@ func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string) error {
 		}
 	}
 
-	tvtropespages.Pages[newPage] = time.Now()
+	subPages := &TvTropesSubpages{
+		LastUpdated: time.Now(),
+		Subpages:    make(map[Page]time.Time, 0),
+	}
+	for _, subpageUrl := range subpageUrls {
+		newSubpage, errSubpage := NewPage(subpageUrl)
+		if errSubpage != nil {
+			return errSubpage
+		}
+
+		subPages.Subpages[newSubpage] = time.Now()
+	}
+
+	tvtropespages.Pages[newPage] = subPages
 	return nil
 }


### PR DESCRIPTION
En este PR se implementa parte del scraping de los tropos en subpáginas #69, concretamente en aquellas páginas como https://tvtropes.org/pmwiki/pmwiki.php/Film/TheAvengers2012 donde los tropos principales están divididos en sub páginas por orden alfabético, dejando los de las sub páginas temáticas para otro PR futuro

El scraper se ocupa de lanzar la función general de scraping de tropos para cada sub página en caso de detectar que los tropos están divididos de esta manera. Estas sub páginas tienen los tropos o en listas o en carpetas, al igual que cuando los tropos están únicamente en el artículo principal, por lo que se puede utilizar la misma función

Se modifica el objeto valor tropo para que ahora incluya además información sobre si es un tropo principal en esa obra (que son, en este PR, los unicos que se extraen actualmente) o secundario y a qué sub página temática pertenece (que se terminará de implementar en el proximo PR). #84 Un tropo, al ser un objeto valor, se creará de forma independiente para cada obra, y por eso contiene información de cual es su categoría concreta en esa obra (también para satisfacer la HU #57)

Se han adaptado todas las funciones de scraping para funcionar de forma genérica con readers, permitiendo scrapear tanto de páginas web reales como de ficheros HTML locales (para el testing, principalmente)

Además, se ha realizado una pequeña remodelación de la entidad TvTropesPages para tener una mejor división entre scraper y crawler. TvTropesPages relaciona ahora páginas con sus sub páginas, teniendo ahora en la entidad todo lo necesario para que el scraper simplemente haga parsing de ellas. El crawler se ocupará en el futuro de rellenar esta entidad con todas las páginas y sus sub páginas relevantes. Ahora el scraper no realiza ninguna tarea de crawling buscando enlaces, simplemente extrae la información de las páginas que se le dan, que vendrán de esta entidad (closes #85)