### PR TITLE
Primera versión del crawler sin almacenado ni caché de las páginas extraídas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,8 +311,7 @@ typings/
 
 # Ignore all HTMLs (textodite reports) except the TvTropes resources
 *.html
-!tropestogo/service/scraper/resources/*.html
-!tropestogo/service/crawler/resources/*.html
+!tropestogo/service/**/*.html
 
 # ignore .idea folder
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -312,6 +312,7 @@ typings/
 # Ignore all HTMLs (textodite reports) except the TvTropes resources
 *.html
 !tropestogo/service/scraper/resources/*.html
+!tropestogo/service/crawler/resources/*.html
 
 # ignore .idea folder
 .idea/

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -1,12 +1,45 @@
 package crawler
 
-import "net/url"
+import (
+	"errors"
+	"fmt"
+	tropestogo "github.com/jlgallego99/TropesToGo"
+	"github.com/jlgallego99/TropesToGo/media"
+	"net/url"
+)
+
+const Pagelist = "https://tvtropes.org/pmwiki/pagelist_having_pagetype_in_namespace.php?t=work"
+
+var (
+	ErrNotFound = errors.New("couldn't request the URL")
+	ErrBadUrl   = errors.New("invalid URL")
+)
 
 type ServiceCrawler struct {
-	// Seeds are the base URLs of the crawler
-	seeds []url.URL
+	// The seed is the starting URL of the crawler
+	seed tropestogo.Page
 }
 
 func NewCrawler() (*ServiceCrawler, error) {
 	return nil, nil
+}
+
+func (crawler *ServiceCrawler) SetMediaSeed(mediaType media.MediaType) error {
+	seedUrl, errParse := url.Parse(Pagelist)
+	if errParse != nil {
+		return fmt.Errorf("%w: "+Pagelist+"\n%w", ErrBadUrl, errParse)
+	}
+
+	values := seedUrl.Query()
+	values.Add("n", mediaType.String())
+	seedUrl.RawQuery = values.Encode()
+
+	seedPage, errNewPage := tropestogo.NewPage(seedUrl.String())
+	if errNewPage != nil {
+		return errNewPage
+	}
+
+	crawler.seed = seedPage
+
+	return nil
 }

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/PuerkitoBio/goquery"
 	tropestogo "github.com/jlgallego99/TropesToGo"
-	"github.com/jlgallego99/TropesToGo/media"
 	"io"
 	"net/http"
 	"net/url"
@@ -38,16 +37,14 @@ type ServiceCrawler struct {
 	seed *url.URL
 }
 
-func NewCrawler(mediaTypeString string) (*ServiceCrawler, error) {
-	crawler := &ServiceCrawler{}
-	mediaType, errMediaType := media.ToMediaType(mediaTypeString)
-	if errMediaType != nil {
-		return nil, errMediaType
+func NewCrawler() *ServiceCrawler {
+	seedUrl, _ := url.Parse(Pagelist)
+
+	crawler := &ServiceCrawler{
+		seed: seedUrl,
 	}
 
-	crawler.SetMediaSeed(mediaType)
-
-	return crawler, nil
+	return crawler
 }
 
 // CrawlWorkPages searches crawlLimit number of Work pages from the defined seed starting page; if it's 0 or less, then it crawls all Work pages
@@ -157,28 +154,6 @@ func (crawler *ServiceCrawler) CrawlWorkSubpages(doc *goquery.Document) []string
 	})
 
 	return subPagesUrls
-}
-
-// SetMediaSeed sets a mediaType for the crawler seed (starting page) for crawling all pages of that medium
-// It returns an error if the page URL or the mediaType isn't valid/doesn't exist on TvTropes
-func (crawler *ServiceCrawler) SetMediaSeed(mediaType media.MediaType) error {
-	seedUrl, errParse := url.Parse(Pagelist)
-	if errParse != nil {
-		return fmt.Errorf("%w: "+Pagelist, ErrBadUrl)
-	}
-
-	values := seedUrl.Query()
-	values.Add("n", mediaType.String())
-	seedUrl.RawQuery = values.Encode()
-
-	seedPage, errNewPage := tropestogo.NewPage(seedUrl.String())
-	if errNewPage != nil {
-		return errNewPage
-	}
-
-	crawler.seed = seedPage
-
-	return nil
 }
 
 // CrawlWorkPagesFromReaders crawls all Work Pages and its subpages from an index reader and its pages readers. Only for test purposes

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -81,6 +81,10 @@ func (crawler *ServiceCrawler) CrawlWorkPages() (*tropestogo.TvTropesPages, erro
 		pageSelector.EachWithBreak(func(i int, selection *goquery.Selection) bool {
 			workUrl, urlExists := selection.Attr("href")
 			pageReader, errAddPage = http.Get(workUrl)
+			if pageReader.StatusCode == 403 {
+				time.Sleep(time.Minute)
+			}
+
 			if errAddPage != nil || !urlExists {
 				return false
 			}
@@ -89,6 +93,7 @@ func (crawler *ServiceCrawler) CrawlWorkPages() (*tropestogo.TvTropesPages, erro
 			subPagesUrls := crawler.CrawlWorkSubpages(pageDoc)
 
 			errAddPage = crawledPages.AddTvTropesPage(workUrl, subPagesUrls)
+			time.Sleep(time.Second / 2)
 
 			return true
 		})
@@ -98,7 +103,6 @@ func (crawler *ServiceCrawler) CrawlWorkPages() (*tropestogo.TvTropesPages, erro
 		}
 
 		pageNumber += 1
-		time.Sleep(time.Second / 2)
 	}
 
 	return crawledPages, nil

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -8,11 +8,14 @@ import (
 	"net/url"
 )
 
-const Pagelist = "https://tvtropes.org/pmwiki/pagelist_having_pagetype_in_namespace.php?t=work"
+const (
+	Pagelist = "https://tvtropes.org/pmwiki/pagelist_having_pagetype_in_namespace.php?t=work"
+)
 
 var (
-	ErrNotFound = errors.New("couldn't request the URL")
-	ErrBadUrl   = errors.New("invalid URL")
+	ErrNotFound    = errors.New("couldn't request the URL")
+	ErrBadUrl      = errors.New("invalid URL")
+	ErrInvalidPage = errors.New("couldn't crawl in page")
 )
 
 type ServiceCrawler struct {
@@ -20,10 +23,20 @@ type ServiceCrawler struct {
 	seed tropestogo.Page
 }
 
-func NewCrawler() (*ServiceCrawler, error) {
-	return nil, nil
+func NewCrawler(mediaTypeString string) (*ServiceCrawler, error) {
+	crawler := &ServiceCrawler{}
+	mediaType, errMediaType := media.ToMediaType(mediaTypeString)
+	if errMediaType != nil {
+		return nil, errMediaType
+	}
+
+	crawler.SetMediaSeed(mediaType)
+
+	return crawler, nil
 }
 
+// SetMediaSeed sets a mediaType for the crawler seed (starting page) for crawling all pages of that medium
+// It returns an error if the page URL or the mediaType isn't valid/doesn't exist on TvTropes
 func (crawler *ServiceCrawler) SetMediaSeed(mediaType media.MediaType) error {
 	seedUrl, errParse := url.Parse(Pagelist)
 	if errParse != nil {

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -98,7 +98,7 @@ func (crawler *ServiceCrawler) CrawlWorkPages(crawlLimit int) (*tropestogo.TvTro
 		}
 
 		if errAddPage != nil {
-			return nil, fmt.Errorf("%w: %w", ErrCrawling, errAddPage)
+			return nil, fmt.Errorf("error crawling: %w", errAddPage)
 		}
 
 		pageNumber += 1
@@ -165,7 +165,7 @@ func (crawler *ServiceCrawler) CrawlWorkSubpages(doc *goquery.Document) []string
 func (crawler *ServiceCrawler) SetMediaSeed(mediaType media.MediaType) error {
 	seedUrl, errParse := url.Parse(Pagelist)
 	if errParse != nil {
-		return fmt.Errorf("%w: "+Pagelist+"\n%w", ErrBadUrl, errParse)
+		return fmt.Errorf("%w: "+Pagelist, ErrBadUrl)
 	}
 
 	values := seedUrl.Query()
@@ -231,7 +231,7 @@ func (crawler *ServiceCrawler) CrawlWorkPagesFromReaders(indexReader io.Reader, 
 		}
 
 		if errAddPage != nil {
-			return nil, fmt.Errorf("%w: %w", ErrCrawling, errAddPage)
+			return nil, fmt.Errorf("error crawling: %w", errAddPage)
 		}
 
 		pageNumber += 1

--- a/tropestogo/service/crawler/crawler_suite_test.go
+++ b/tropestogo/service/crawler/crawler_suite_test.go
@@ -1,0 +1,13 @@
+package crawler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCrawler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Crawler Suite")
+}

--- a/tropestogo/service/crawler/crawler_test.go
+++ b/tropestogo/service/crawler/crawler_test.go
@@ -10,7 +10,7 @@ import (
 // A crawler service for test purposes
 var serviceCrawler *crawler.ServiceCrawler
 var errNewCrawler, errCrawling error
-var crawledPages []tropestogo.Page
+var crawledPages *tropestogo.TvTropesPages
 
 var _ = BeforeSuite(func() {
 	serviceCrawler, errNewCrawler = crawler.NewCrawler("Film")
@@ -25,11 +25,16 @@ var _ = Describe("Crawler", func() {
 		})
 
 		It("Should have crawled web pages", func() {
-			Expect(len(crawledPages) > 0).To(BeTrue())
+			Expect(len(crawledPages.Pages) > 0).To(BeTrue())
 
-			for _, crawledPage := range crawledPages {
+			for crawledPage, crawledSubpages := range crawledPages.Pages {
 				Expect(crawledPage.GetUrl()).To(Not(BeNil()))
 				Expect(crawledPage.GetPageType()).To(Equal(tropestogo.WorkPage))
+				Expect(len(crawledSubpages.Subpages) > 0).To(BeTrue())
+
+				for crawledSubpage := range crawledSubpages.Subpages {
+					Expect(crawledSubpage.GetUrl()).To(Not(BeNil()))
+				}
 			}
 		})
 	})

--- a/tropestogo/service/crawler/crawler_test.go
+++ b/tropestogo/service/crawler/crawler_test.go
@@ -1,0 +1,36 @@
+package crawler_test
+
+import (
+	tropestogo "github.com/jlgallego99/TropesToGo"
+	crawler "github.com/jlgallego99/TropesToGo/service/crawler"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// A crawler service for test purposes
+var serviceCrawler *crawler.ServiceCrawler
+var errNewCrawler, errCrawling error
+var crawledPages []tropestogo.Page
+
+var _ = BeforeSuite(func() {
+	serviceCrawler, errNewCrawler = crawler.NewCrawler("Film")
+	Expect(errNewCrawler).To(BeNil())
+	crawledPages, errCrawling = serviceCrawler.CrawlWorkPages()
+})
+
+var _ = Describe("Crawler", func() {
+	Context("The Crawler gets all Films", func() {
+		It("Shouldn't return an error", func() {
+			Expect(errCrawling).To(BeNil())
+		})
+
+		It("Should have crawled web pages", func() {
+			Expect(len(crawledPages) > 0).To(BeTrue())
+
+			for _, crawledPage := range crawledPages {
+				Expect(crawledPage.GetUrl()).To(Not(BeNil()))
+				Expect(crawledPage.GetPageType()).To(Equal(tropestogo.WorkPage))
+			}
+		})
+	})
+})

--- a/tropestogo/service/crawler/crawler_test.go
+++ b/tropestogo/service/crawler/crawler_test.go
@@ -15,7 +15,7 @@ var crawledPages *tropestogo.TvTropesPages
 var _ = BeforeSuite(func() {
 	serviceCrawler, errNewCrawler = crawler.NewCrawler("Film")
 	Expect(errNewCrawler).To(BeNil())
-	crawledPages, errCrawling = serviceCrawler.CrawlWorkPages()
+	crawledPages, errCrawling = serviceCrawler.CrawlWorkPages(10)
 })
 
 var _ = Describe("Crawler", func() {
@@ -30,7 +30,7 @@ var _ = Describe("Crawler", func() {
 			for crawledPage, crawledSubpages := range crawledPages.Pages {
 				Expect(crawledPage.GetUrl()).To(Not(BeNil()))
 				Expect(crawledPage.GetPageType()).To(Equal(tropestogo.WorkPage))
-				Expect(len(crawledSubpages.Subpages) > 0).To(BeTrue())
+				Expect(len(crawledSubpages.Subpages) >= 0).To(BeTrue())
 
 				for crawledSubpage := range crawledSubpages.Subpages {
 					Expect(crawledSubpage.GetUrl()).To(Not(BeNil()))

--- a/tropestogo/service/crawler/crawler_test.go
+++ b/tropestogo/service/crawler/crawler_test.go
@@ -22,7 +22,7 @@ var errNewCrawler, errCrawling error
 var crawledPages *tropestogo.TvTropesPages
 
 var _ = BeforeSuite(func() {
-	serviceCrawler, errNewCrawler = crawler.NewCrawler("Film")
+	serviceCrawler = crawler.NewCrawler()
 	Expect(errNewCrawler).To(BeNil())
 
 	indexReader, _ := os.Open(indexResource)

--- a/tropestogo/service/crawler/crawler_test.go
+++ b/tropestogo/service/crawler/crawler_test.go
@@ -5,7 +5,16 @@ import (
 	crawler "github.com/jlgallego99/TropesToGo/service/crawler"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"io"
+	"os"
 )
+
+const (
+	indexResource = "resources/film_index_page1.html"
+)
+
+var filmResources = []string{"resources/film1.html", "resources/film2.html", "resources/film3.html",
+	"resources/film4.html", "resources/film5.html"}
 
 // A crawler service for test purposes
 var serviceCrawler *crawler.ServiceCrawler
@@ -15,16 +24,24 @@ var crawledPages *tropestogo.TvTropesPages
 var _ = BeforeSuite(func() {
 	serviceCrawler, errNewCrawler = crawler.NewCrawler("Film")
 	Expect(errNewCrawler).To(BeNil())
-	crawledPages, errCrawling = serviceCrawler.CrawlWorkPages(10)
+
+	indexReader, _ := os.Open(indexResource)
+	workReaders := make([]io.Reader, 0)
+	for _, filmResource := range filmResources {
+		workResource, _ := os.Open(filmResource)
+		workReaders = append(workReaders, workResource)
+	}
+
+	crawledPages, errCrawling = serviceCrawler.CrawlWorkPagesFromReaders(indexReader, workReaders, 5)
 })
 
 var _ = Describe("Crawler", func() {
-	Context("The Crawler gets all Films", func() {
+	Context("Crawling a limited number of Work Pages from the Index", func() {
 		It("Shouldn't return an error", func() {
 			Expect(errCrawling).To(BeNil())
 		})
 
-		It("Should have crawled web pages", func() {
+		It("Should have crawled Work Pages and its subpages", func() {
 			Expect(len(crawledPages.Pages) > 0).To(BeTrue())
 
 			for crawledPage, crawledSubpages := range crawledPages.Pages {

--- a/tropestogo/service/crawler/resources/film1.html
+++ b/tropestogo/service/crawler/resources/film1.html
@@ -1,0 +1,1798 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "Film", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Aadai (Film) - TV Tropes</title>
+            <meta name="description" content="Aadai (transl. Dress) is an Indian-Tamil thriller directed by Rathna Kumar of Meyaadha Maan fame and produced by Viji under the banner of V Studios. It was &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/Film/Aadai" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Aadai (Film) - TV Tropes" />
+            <meta name="twitter:description" content="Aadai (transl. Dress) is an Indian-Tamil thriller directed by Rathna Kumar of Meyaadha Maan fame and produced by Viji under the banner of V Studios. It was &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Aadai" />
+			<meta property="og:type" content="video.movie" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/Film/Aadai" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="Aadai (transl. Dress) is an Indian-Tamil thriller directed by Rathna Kumar of Meyaadha Maan fame and produced by Viji under the banner of V Studios. It was released July 19th 2019 and starred Amala Paul in the lead role. Kamini is a free-spirited &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=d77d98b7671da37d9a794abba2c9266166e994c0" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "d77d98b7671da37d9a794abba2c9266166e994c0",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/SummonEverymanHero" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/VideoGame/FateExtellaLink" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/Film/Aadai?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=Film/Aadai">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=Film.Aadai">
+                <i class="fa fa-history"></i> History</a></li><li class="link-reviews"><a href="/pmwiki/review_add.php?tt=Aadai&g=Film">
+                      <i class="fa fa-star-half-o"></i> Add Review</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-discussion more_list_item"><a href="/pmwiki/remarks.php?trope=Film.Aadai">
+                  <i class="fa fa-comment"></i> Discussion</a></li><li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/Film/Aadai?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="Film"/>
+<input type="hidden" id="title-hidden" value="Aadai"/>
+<input type="hidden" id="article_id" value="735014" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/Film/Aadai</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>Film / </strong>
+        
+        Aadai
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Film",
+                "item": "https://tvtropes.org/pmwiki/pmwiki.php/Main/Film"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Aadai"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+                                        <li>
+                    <a href="/pmwiki/pmwiki.php/Film/Aadai" class="subpage-link curr-subpage" title="The Film page">
+                    <span class="wrapper"><span class="spi film"></span>Film</span></a>
+                </li>
+                            
+                
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/Aadai?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/Aadai?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/Aadai?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/Aadai?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/Aadai?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/Aadai?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/Aadai?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/Aadai?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/Aadai?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/Aadai?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/Aadai?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/Aadai?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/Aadai?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/Aadai?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/Aadai?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/Aadai?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/Aadai?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/Aadai?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><div class="quoteright" style="width:350px;" ><div class="lazy_load_img_box" style="padding-top:45.43%"><img src='https://static.tvtropes.org/pmwiki/pub/images/amala_pauls_second_look_poster_aadai.jpg' class='embeddedimage' border='0' alt='https://static.tvtropes.org/pmwiki/pub/images/amala_pauls_second_look_poster_aadai.jpg' / width=350 height=159></div></div><div class="acaptionright" style="width:350px;" ></div><em>Aadai</em> (transl. <em>Dress</em>) is an Indian-Tamil thriller directed by Rathna Kumar of <a class='urllink' href='https://en.wikipedia.org/wiki/Meyaadha_Maan'>Meyaadha Maan<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> fame and produced by Viji under the banner of V Studios. It was released July 19th 2019 and starred <a class='urllink' href='https://en.wikipedia.org/wiki/Amala_Paul'>Amala Paul<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> in the lead role.</p><p>Kamini is a free-spirited young woman who works at the media company #Hashtag along with her team on the prank show <em>Gotcha! Gotcha!</em>. On her birthday, the company finishes moving to a new building across town, so she and her friends decided to use the now empty building to celebrate.</p><p>After a night of drinking, Kamini awakens the next morning to the shock of her life: her friends are gone and so are her clothes! Now Kamini must find a way out while trying to piece together the mystery of what happened the night before...<hr /><h2>Shows examples of:</h2><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AbandonedWarehouse' title='/pmwiki/pmwiki.php/Main/AbandonedWarehouse'>Abandoned Office Building</a>: The office building where Kamini is stuck was the space the company #Hashtag had previously occupied.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AllMenArePerverts' title='/pmwiki/pmwiki.php/Main/AllMenArePerverts'>All Men Are Perverts</a>: Implied as the reason Kamini asks for a <em>female</em> delivery girl instead of a man due to her state of undress.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BystanderSyndrome' title='/pmwiki/pmwiki.php/Main/BystanderSyndrome'>Bystander Syndrome</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" > A year after Nangeli's prank was featured on <em>Gotcha! Gotcha!</em> and a year before the events of film, Nangeli's mother was visiting her mother in the city when she fainted. The first person to try and help stopped when she recognized the young woman and thought it was part of the show. Not to mention the men who stopped and took selfies thinking the same thing not knowing what was happening...</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CandidCameraPrank' title='/pmwiki/pmwiki.php/Main/CandidCameraPrank'>Candid Camera Prank</a>: <em>Gotcha! Gotcha!</em> is a tv show created by Kamini and her friends where they pull pranks on people mainly by scaring them or faking medical emergencies.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Catchphrase' title='/pmwiki/pmwiki.php/Main/Catchphrase'>Catchphrase</a>: "Wanna Bet?" said by Kamini whenever someone says she can't do something; it even includes a sassy finger-snap. It's so compulsive that she does it to her boss at one point before backpedaling.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CensorShadow' title='/pmwiki/pmwiki.php/Main/CensorShadow'>Censor Shadow</a>: The only things that Kamini has to conceal herself with are <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HandOrObjectUnderwear' title='/pmwiki/pmwiki.php/Main/HandOrObjectUnderwear'>her hands</a>, <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShouldersUpNudity' title='/pmwiki/pmwiki.php/Main/ShouldersUpNudity'>creative camera angles</a> and the darkness of the office building.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ClosedCircle' title='/pmwiki/pmwiki.php/Main/ClosedCircle'>Closed Circle</a>: The film primarily takes place within the now abandoned office building where Kamini worked.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DisappointedByTheMotive' title='/pmwiki/pmwiki.php/Main/DisappointedByTheMotive'>Disappointed by the Motive</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" > Kamini is not happy to find out that everything she went through was because the woman responsible, Nangeli, wanted payback for a prank her friends did for their show that caused her to miss an important exam. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PlayedWith' title='/pmwiki/pmwiki.php/Main/PlayedWith'>Played With</a> when Nangeli revealed that she <em>did</em> move on from it until the next year when her visiting mother collapsed and no one helped, believing it to be a prank.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheDogWasTheMastermind' title='/pmwiki/pmwiki.php/Main/TheDogWasTheMastermind'>The Dog Was the Mastermind</a>: That delivery girl who Kamini tried to steal clothes from? <span class="spoiler" title="you can set spoilers visible by default on your profile" > She was the one who stole Kamini's clothes as payback for being a previous subject of her team's pranks.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DramaPreservingHandicap' title='/pmwiki/pmwiki.php/Main/DramaPreservingHandicap'>Drama-Preserving Handicap</a>: When Kamini finds her phone, the only reason she can't call for help is because its call balance is empty. She also can't get it refilled because the call service won't refill it over the phone and Kamini is aware they're recording the phone calls so she can't just explain the situation.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Foreshadowing' title='/pmwiki/pmwiki.php/Main/Foreshadowing'>Foreshadowing</a>: It's mentioned at one point early in the film that some people don't react well to being the subjects of pranks.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreezeFrameBonus' title='/pmwiki/pmwiki.php/Main/FreezeFrameBonus'>Freeze-Frame Bonus</a>: If one pays attention to the delivery girl's shirt, it's a different company name from the one Kamini calls. <span class="spoiler" title="you can set spoilers visible by default on your profile" > It's because she paid off the <strong>actual</strong> delivery boy to take the food and pose as him.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheGambler' title='/pmwiki/pmwiki.php/Main/TheGambler'>The Gambler</a>: Kamini lacks the ability to not take a bet or challenge.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HandOrObjectUnderwear' title='/pmwiki/pmwiki.php/Main/HandOrObjectUnderwear'>Hand-or-Object Underwear</a>: Kamini only has her hands to preserve her modesty as there's nothing left in the now-abandoned office to cover herself with. She finds a large mirror at one point but drops and shatters it <a class='twikilink' href='/pmwiki/pmwiki.php/Main/JumpScare' title='/pmwiki/pmwiki.php/Main/JumpScare'>when a pigeon frightens her.</a></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Hypocrite' title='/pmwiki/pmwiki.php/Main/Hypocrite'>Hypocrite</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" > Nangeli's motive for stealing Kamini's clothes was to get back at the latter for a prank the "<em>Gotcha! Gotcha!</em>" crew did two years ago. Except that the crew would have likely planned said pranks so no one would get hurt and they only scared people for a couple minutes at most. Nangeli's actions left Kamini terrified and alone for an entire day and she got hurt from broken glass.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Irony' title='/pmwiki/pmwiki.php/Main/Irony'>Irony</a>: The reason that Kamini doesn't call the police is fear of the media finding out and reporting it, which would leave her humiliated. The two local men who find the unconscious delivery girl call the police specifically because doing so will draw the attention of reporters and they'll become famous. In hindsight, a naked girl stuck in an abandoned office building wouldn't have been as newsworthy as a <span class="spoiler" title="you can set spoilers visible by default on your profile" > supposed</span> murder.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/LaserGuidedKarma' title='/pmwiki/pmwiki.php/Main/LaserGuidedKarma'>Laser-Guided Karma</a>: Kamini and her team's show is about them pulling pranks on people by faking emergencies or masquerading as crazed killers and scaring the daylights out of them. <span class="spoiler" title="you can set spoilers visible by default on your profile" > When Kamini finds herself naked and alone in the abandoned office building, she is left scared and humiliated. Meanwhile every attempt to contact someone is brushed off as a prank call and no one takes her seriously.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MushroomSamba' title='/pmwiki/pmwiki.php/Main/MushroomSamba'>Mushroom Samba</a>: Getting take-out, one of the crew puts fried magic mushrooms in the dish and doesn't tell the rest until <em>after</em> they start feeling the effect. Strangely the men all have vivid hallucinations, while at most Kamini sees the flames from her lighter taking different shapes and Jeni gets a bad reaction before both pass out.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NakedFreakOut' title='/pmwiki/pmwiki.php/Main/NakedFreakOut'>Naked Freak-Out</a>: Kamini is pretty out of it when she wakes up from being hung-over so it takes her a minute to realize she's not wearing any clothes. Once she does though, she immediately wraps herself in a fetal position, scared and confused.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NakedPeopleTrappedOutside' title='/pmwiki/pmwiki.php/Main/NakedPeopleTrappedOutside'>Naked People Trapped Outside</a>: Not <strong>outside</strong> but still applies as Kamini is left trapped miles from home with nothing to cover herself at an abandoned office building.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NotQuiteDead' title='/pmwiki/pmwiki.php/Main/NotQuiteDead'>Not Quite Dead</a>: The delivery girl that Kamini knocked out with the pipe is initially thought to be dead only for a paramedic to realize the police were mistaken.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PoliceAreUseless' title='/pmwiki/pmwiki.php/Main/PoliceAreUseless'>Police Are Useless</a>: To the point it's sort of funny if a little sad. To wit, the officers who arrive at the office building think the woman found is dead without even checking for a pulse and are berated by their superior for waiting for permission to search the building when the "killer" could still be there. <span class="spoiler" title="you can set spoilers visible by default on your profile" > Less funny is when Kamini's mother comes to the police station to report her daughter's disappearance, and the officer she reports it to tells the mother she should have done a better job raising her daughter and is left to simply wait to file a report.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RearWindowInvestigation' title='/pmwiki/pmwiki.php/Main/RearWindowInvestigation'>Rear Window Investigation</a>: While Kamini is on the roof, a worker from a neighboring building sees her (or at least spots movement on the roof) and goes over on his lunch break to investigate. Kamini manages to lock the doors before he finds her and the worker is called away by his boss.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShamelessFanserviceGirl' title='/pmwiki/pmwiki.php/Main/ShamelessFanserviceGirl'>Shameless Fanservice Girl</a>: Kamini gets accused of this, first by her boyfriend then <span class="spoiler" title="you can set spoilers visible by default on your profile" > Nangeli</span>, but ironically it's shown she's actually a <strong><a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReluctantFanserviceGirl' title='/pmwiki/pmwiki.php/Main/ReluctantFanserviceGirl'>Reluctant</a></strong> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReluctantFanserviceGirl' title='/pmwiki/pmwiki.php/Main/ReluctantFanserviceGirl'>Fanservice Girl</a>. The closest we come to this trope is when Kamini does a mock striptease <strong>but</strong> she and her friends were pretty drunk and starting to feel the effects of the magic mushrooms.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ShoutOut' title='/pmwiki/pmwiki.php/Main/ShoutOut'>Shout-Out</a>: When talking with Jeni about anchoring, she jokes to Kamini that the latter could do a Naked News-style report fitting more with her style of television.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/Streaking' title='/pmwiki/pmwiki.php/Main/Streaking'>Streaking</a>: When first taking stock of her situation, Kamini figures that worse case she'll resort to this after sunset if she hasn't escaped by then. <span class="spoiler" title="you can set spoilers visible by default on your profile" > Thankfully she gets her clothes back before having to.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TrailersAlwaysLie' title='/pmwiki/pmwiki.php/Main/TrailersAlwaysLie'>Trailers Always Lie</a>: The promotions including the posters seemed to make the movie out to be a crime thriller about Kamini's disappearance.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/UndressingTheUnconscious' title='/pmwiki/pmwiki.php/Main/UndressingTheUnconscious'>Undressing the Unconscious</a>: After passing out while fully dressed, Kamini wakes up with her clothes gone, implying this; a flashback to that night confirms it.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhatTheHellHero' title='/pmwiki/pmwiki.php/Main/WhatTheHellHero'>What the Hell, Hero?</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" > Nangeli the delivery girl calls out Kamini for planning to steal her clothes instead of helping her when Nangeli passed out. Granted Nangeli was the reason for everything that happened but that doesn't make her any less right…</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WhyCouldntYouBeDifferent' title='/pmwiki/pmwiki.php/Main/WhyCouldntYouBeDifferent'>Why Couldn't You Be Different?</a>: The main issue between Kamini and her mother is the former is a free-spirited woman while the latter is very conservative to the point she's disappointed her 20-something daughter isn't a stay-at-home mom rather than a producer of a very popular tv show.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/WithFriendsLikeThese' title='/pmwiki/pmwiki.php/Main/WithFriendsLikeThese'>With Friends Like These...</a>: Kamini locks her friend Jeni in the bathroom and takes her place as the anchor for the last live broadcast from their current building. This isn't so bad except for when she was later berated by their boss leaving Jeni in tears. Kamini doesn't reveal her actions and doesn't seem all that remorseful [[note] She <em>was</em> pretty drunk at that point[[/note]. All because Jeni jokingly stated Kamini didn't have the disposition to be an anchor...</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/YankTheDogsChain' title='/pmwiki/pmwiki.php/Main/YankTheDogsChain'>Yank the Dog's Chain</a>: After spending the entire day trapped in the building with no clothes, Kamini finds a roll of toilet paper to use for covering. Then she gets outside and it's pouring rain. Luckily she also finds some police tape to use before <span class="spoiler" title="you can set spoilers visible by default on your profile" > the person who took her clothes in the first place just hands them back.</span></li></ul><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/War2019">War (2019)</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/BollywoodMovies">Bollywood Movies</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/Housefull4">Housefull 4</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=d77d98b7671da37d9a794abba2c9266166e994c0';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/crawler/resources/film2.html
+++ b/tropestogo/service/crawler/resources/film2.html
@@ -1,0 +1,1868 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "Film", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Aaron Loves Angela (Film) - TV Tropes</title>
+            <meta name="description" content="Aaron Loves Angela is a 1975 coming-of-age romantic drama film written by Gerald Sanford and directed by Gordon Parks Jr. Aaron James (Kevin Hooks) is a &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/Film/AaronLovesAngela" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Aaron Loves Angela (Film) - TV Tropes" />
+            <meta name="twitter:description" content="Aaron Loves Angela is a 1975 coming-of-age romantic drama film written by Gerald Sanford and directed by Gordon Parks Jr. Aaron James (Kevin Hooks) is a &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/pmwiki/pub/images/aaron_loves_angela.jpg" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Aaron Loves Angela" />
+			<meta property="og:type" content="video.movie" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/Film/AaronLovesAngela" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/pmwiki/pub/images/aaron_loves_angela.jpg" />
+			<meta property="og:description" content="Aaron Loves Angela is a 1975 coming-of-age romantic drama film written by Gerald Sanford and directed by Gordon Parks Jr. Aaron James (Kevin Hooks) is a sixteen-year-old black basketball player living in Harlem with his father Ike (Moses Gunn), a &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=d77d98b7671da37d9a794abba2c9266166e994c0" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "d77d98b7671da37d9a794abba2c9266166e994c0",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/CryLaughing" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/VideoGame/WorldWarZ2019" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/Film/AaronLovesAngela?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=Film/AaronLovesAngela">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=Film.AaronLovesAngela">
+                <i class="fa fa-history"></i> History</a></li><li class="link-reviews"><a href="/pmwiki/review_add.php?tt=AaronLovesAngela&g=Film">
+                      <i class="fa fa-star-half-o"></i> Add Review</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-discussion more_list_item"><a href="/pmwiki/remarks.php?trope=Film.AaronLovesAngela">
+                  <i class="fa fa-comment"></i> Discussion</a></li><li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/Film/AaronLovesAngela?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="Film"/>
+<input type="hidden" id="title-hidden" value="AaronLovesAngela"/>
+<input type="hidden" id="article_id" value="826280" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/Film/AaronLovesAngela</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>Film / </strong>
+        
+        Aaron Loves Angela
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Film",
+                "item": "https://tvtropes.org/pmwiki/pmwiki.php/Main/Film"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Aaron Loves Angela"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+                                        <li>
+                    <a href="/pmwiki/pmwiki.php/Film/AaronLovesAngela" class="subpage-link curr-subpage" title="The Film page">
+                    <span class="wrapper"><span class="spi film"></span>Film</span></a>
+                </li>
+                            
+                
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/AaronLovesAngela?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/AaronLovesAngela?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/AaronLovesAngela?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/AaronLovesAngela?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/AaronLovesAngela?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/AaronLovesAngela?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/AaronLovesAngela?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/AaronLovesAngela?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/AaronLovesAngela?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/AaronLovesAngela?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/AaronLovesAngela?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/AaronLovesAngela?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/AaronLovesAngela?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/AaronLovesAngela?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/AaronLovesAngela?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/AaronLovesAngela?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/AaronLovesAngela?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/AaronLovesAngela?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><div class="quoteright" style="width:310px;" ><div class="lazy_load_img_box" style="padding-top:148.57%"><img src='https://static.tvtropes.org/pmwiki/pub/images/aaron_loves_angela.jpg' class='embeddedimage' border='0' alt='https://static.tvtropes.org/pmwiki/pub/images/aaron_loves_angela.jpg' / width=350 height=520></div></div></p><p><em>Aaron Loves Angela</em> is a 1975 <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ComingOfAgeStory' title='/pmwiki/pmwiki.php/Main/ComingOfAgeStory'>coming-of-age</a> romantic drama film written by Gerald Sanford and directed by Gordon Parks Jr.</p><p>Aaron James (Kevin Hooks) is a sixteen-year-old black basketball player living in Harlem with his father Ike (<a class='twikilink' href='/pmwiki/pmwiki.php/Creator/MosesGunn' title='/pmwiki/pmwiki.php/Creator/MosesGunn'>Moses Gunn</a>), a former college football player. Aaron falls in love with Angela Sanchez (<a class='twikilink' href='/pmwiki/pmwiki.php/Creator/IreneCara' title='/pmwiki/pmwiki.php/Creator/IreneCara'>Irene Cara</a>), a fifteen-year-old Puerto Rican girl living with her mother. As the two meet in secret, they witness a crime involving Aaron's drug dealing neighbor Beau Lincoln (Robert Hooks), which endangers their lives.</p><p><hr /><h2><em>Aaron Loves Angela</em> contains examples of:</h2><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AbandonedArea' title='/pmwiki/pmwiki.php/Main/AbandonedArea'>Abandoned Area</a>: Aaron asks his best friend Willie Russell (Leon Pinkney) to find him a place where he and Angela can have their trysts. Willie shows him a condemned apartment building with a room with a mattress where he sometimes takes girls. Aaron and Angela are both uncomfortable going into a condemned building at first, but they soon get used to the place and start fixing up the room to make it more romantic.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BriefcaseFullOfMoney' title='/pmwiki/pmwiki.php/Main/BriefcaseFullOfMoney'>Briefcase Full of Money</a>: Beau carries a briefcase with stacks of money sorted by denomination, from fives to fifties. <span class="spoiler" title="you can set spoilers visible by default on your profile" >After he's shot, he begs Aaron with his dying breaths to take it. Aaron does, attracting the ire of the two goons who killed him.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BringingRunningShoesToACarChase' title='/pmwiki/pmwiki.php/Main/BringingRunningShoesToACarChase'>Bringing Running Shoes to a Car Chase</a>: The two goons find Aaron and Angela at Grant's Tomb and start driving towards them. Aaron and Angela flee down the street until they reach a park where the goons can't drive and have to get out and run.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheCameo' title='/pmwiki/pmwiki.php/Main/TheCameo'>The Cameo</a>: <a class='twikilink' href='/pmwiki/pmwiki.php/Music/JoseFeliciano' title='/pmwiki/pmwiki.php/Music/JoseFeliciano'>José Feliciano</a>, who composed the soundtrack, appears as a musician in a club. Basketball star Walt Frazier also appears; Ike follows him and asks him to give Aaron advice.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CardiovascularLove' title='/pmwiki/pmwiki.php/Main/CardiovascularLove'>Cardiovascular Love</a>: The hearts in the movie poster, and this is a story about a romantic couple.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DisappearedDad' title='/pmwiki/pmwiki.php/Main/DisappearedDad'>Disappeared Dad</a>: Angela's dad is a trumpet player in Los Angeles. He visits her on Christmas.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FingertipDrugAnalysis' title='/pmwiki/pmwiki.php/Main/FingertipDrugAnalysis'>Fingertip Drug Analysis</a>: One of Beau's buyers dabs some cocaine on his tongue and gums, then yells, "The stuff is shit!"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FiveFingerDiscount' title='/pmwiki/pmwiki.php/Main/FiveFingerDiscount'>Five-Finger Discount</a>: Aaron and his friends shoplift porn magazines from an adult bookstore.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreezeFrameEnding' title='/pmwiki/pmwiki.php/Main/FreezeFrameEnding'>Freeze-Frame Ending</a>: The credits play over a shot of Aaron and Angela running hand in hand.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ICouldaBeenAContender' title='/pmwiki/pmwiki.php/Main/ICouldaBeenAContender'>I Coulda Been a Contender!</a>: Ike spends much of his time drunkenly looking at slides of his football days. He's sad and bitter that his career didn't work out, and his biggest wish for Aaron is that he'll have a successful basketball career, even though Aaron doesn't think he'll ever be tall enough.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight' title='/pmwiki/pmwiki.php/Main/TheLoinsSleepTonight'>The Loins Sleep Tonight</a>: Implied. Aaron tries to have sex with Beau's girlfriend Cleo (Ernestine Jackson) as practice before Angela. Cut to Aaron glumly getting dressed while Cleo says, "Now Aaron honey, don't be upset. It happens that way sometimes."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MaliciousMisnaming' title='/pmwiki/pmwiki.php/Main/MaliciousMisnaming'>Malicious Misnaming</a>: Willie accuses Aaron of losing a basketball game because he was distracted by "Angel Sandwich."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MalignedMixedMarriage' title='/pmwiki/pmwiki.php/Main/MalignedMixedMarriage'>Maligned Mixed Marriage</a>: Surprisingly, the racial differences between Aaron and Angela barely factor into the plot, except for one scene. When Angela kisses Aaron outside of her building, two of her neighbors chase him and try to beat him up, because "We don't like no outsiders fuckin' with our women, man!"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MissingMom' title='/pmwiki/pmwiki.php/Main/MissingMom'>Missing Mom</a>: Aaron's mother is a dancer who got bored of her family and moved to Paris. She didn't take Aaron along because he was too much like his dad.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ModestyBedsheet' title='/pmwiki/pmwiki.php/Main/ModestyBedsheet'>Modesty Bedsheet</a>: After Aaron and Angela have sex, they lie on the mattress with a blanket wrapped around his waist and her chest.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ReallyMovesAround' title='/pmwiki/pmwiki.php/Main/ReallyMovesAround'>Really Moves Around</a>: Angela's mother moves whenever she gets bored. The two of them have lived in New Orleans, Miami, and Atlanta.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ResentfulGuardian' title='/pmwiki/pmwiki.php/Main/ResentfulGuardian'>Resentful Guardian</a>: In a moment of drunken rage, Ike tells Aaron, "I don't know why I should ruin my own life for someone whose own mama didn't want him.… Stop fucking up my life! You know what I could've done without you? How many times I wanted to split? Just get the hell out of here!" and <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TantrumThrowing' title='/pmwiki/pmwiki.php/Main/TantrumThrowing'>smashes his glass against the wall</a>. After he calms down, he says, "Aaron, I didn't mean what I said. I just have to have someone to hurt sometimes, and you're all I got."</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheirFirstTime' title='/pmwiki/pmwiki.php/Main/TheirFirstTime'>Their First Time</a>: Aaron takes Angela to the room Willie showed him, puts on some music, and pours her a drink. When she realizes what he's after, she starts crying and runs away, thinking Aaron doesn't love her and thinks she's cheap, but later she comes back, and they have sex in the room.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TitleDrop' title='/pmwiki/pmwiki.php/Main/TitleDrop'>Title Drop</a>: Aaron writes "Aaron likes Angela" as <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SweetieGraffiti' title='/pmwiki/pmwiki.php/Main/SweetieGraffiti'>Sweetie Graffiti</a> in the stairwell of his apartment building, then "Aaron likes Angela very much" on a piece of metal, and finally "Aaron loves Angela!" on a napkin he tells Willie to give to Angela.</li></ul><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/WesternAnimation/Vivo">Vivo</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/LatinoAmericanMedia">Latino-American Media</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AfterlifeOfTheParty">Afterlife of the Party</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/Da5Bloods">Da 5 Bloods</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/AfricanAmericanMedia">African-American Media</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AboutLastNight">About Last Night...</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/Zardoz">Zardoz</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/FilmsOfThe1970s">Films of the 1970s</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/TheAbductionOfSaintAnne">The Abduction of Saint Anne</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/The5000FingersOfDrT">The 5,000 Fingers Of Dr. T</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Creator/ColumbiaPictures">Creator/Columbia Pictures</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AbsenceOfMalice">Absence of Malice</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/NineSevenSixEvil">976-EVIL</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/UsefulNotes/RestrictedRating">UsefulNotes/Restricted Rating</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AboutLastNight">About Last Night...</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/NineToFive">9 to 5</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/AmericanFilms/AToC">AmericanFilms/A to C</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AbandonedMine">Abandoned Mine</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=d77d98b7671da37d9a794abba2c9266166e994c0';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/crawler/resources/film3.html
+++ b/tropestogo/service/crawler/resources/film3.html
@@ -1,0 +1,1826 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "Film", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Abacus: Small Enough to Jail (Film) - TV Tropes</title>
+            <meta name="description" content="Abacus: Small Enough to Jail is a 2016 documentary feature by Steve James of Hoop Dreams fame. It tells the story of the federal prosecution of Abacus &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Abacus: Small Enough to Jail (Film) - TV Tropes" />
+            <meta name="twitter:description" content="Abacus: Small Enough to Jail is a 2016 documentary feature by Steve James of Hoop Dreams fame. It tells the story of the federal prosecution of Abacus &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Abacus: Small Enough to Jail" />
+			<meta property="og:type" content="video.movie" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="Abacus: Small Enough to Jail is a 2016 documentary feature by Steve James of Hoop Dreams fame. It tells the story of the federal prosecution of Abacus Federal Savings Bank. Abacus was and is a bank located in the Chinatown neighborhood of New &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=d77d98b7671da37d9a794abba2c9266166e994c0" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "d77d98b7671da37d9a794abba2c9266166e994c0",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/TheMainCharactersDoEverything" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Film/LuckyStar" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=Film/AbacusSmallEnoughToJail">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=Film.AbacusSmallEnoughToJail">
+                <i class="fa fa-history"></i> History</a></li><li class="link-reviews"><a href="/pmwiki/review_add.php?tt=AbacusSmallEnoughToJail&g=Film">
+                      <i class="fa fa-star-half-o"></i> Add Review</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-discussion more_list_item"><a href="/pmwiki/remarks.php?trope=Film.AbacusSmallEnoughToJail">
+                  <i class="fa fa-comment"></i> Discussion</a></li><li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="Film"/>
+<input type="hidden" id="title-hidden" value="AbacusSmallEnoughToJail"/>
+<input type="hidden" id="article_id" value="630091" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>Film / </strong>
+        
+        Abacus: Small Enough to Jail
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Film",
+                "item": "https://tvtropes.org/pmwiki/pmwiki.php/Main/Film"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Abacus: Small Enough to Jail"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+                                        <li>
+                    <a href="/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail" class="subpage-link curr-subpage" title="The Film page">
+                    <span class="wrapper"><span class="spi film"></span>Film</span></a>
+                </li>
+                            
+                
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/AbacusSmallEnoughToJail?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/AbacusSmallEnoughToJail?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/AbacusSmallEnoughToJail?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/AbacusSmallEnoughToJail?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/AbacusSmallEnoughToJail?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/AbacusSmallEnoughToJail?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/AbacusSmallEnoughToJail?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/AbacusSmallEnoughToJail?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/AbacusSmallEnoughToJail?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/AbacusSmallEnoughToJail?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/AbacusSmallEnoughToJail?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/AbacusSmallEnoughToJail?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/AbacusSmallEnoughToJail?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/AbacusSmallEnoughToJail?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/AbacusSmallEnoughToJail?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/AbacusSmallEnoughToJail?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/AbacusSmallEnoughToJail?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/AbacusSmallEnoughToJail?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><div class="quoteright" style="width:350px;" ><div class="lazy_load_img_box" style="padding-top:52.29%"><img src='https://static.tvtropes.org/pmwiki/pub/images/screen_shot_2016_09_09_at_113653_am.png' class='embeddedimage' border='0' alt='https://static.tvtropes.org/pmwiki/pub/images/screen_shot_2016_09_09_at_113653_am.png' / width=350 height=183></div></div></p><p><em>Abacus: Small Enough to Jail</em> is a 2016 documentary feature by Steve James of <em><a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Film/HoopDreams' title='https://tvtropes.org/pmwiki/pmwiki.php/Film/HoopDreams'>Hoop Dreams</a></em> fame.</p><p>It tells the story of the federal prosecution of Abacus Federal Savings Bank. Abacus was and is a bank located in the Chinatown neighborhood of New York City. It was founded by lawyer Tom Sung in 1984 specifically to serve the Chinese-American community of New York, and continued to be run as a family business by his daughters Jill and Vera Sung. In December 2009 widespread mortgage fraud (kickbacks, money laundering, income and document falsification) was discovered to be taking place among loan officers at the bank. The Sungs promptly fired the culpable employees but are horrified when they realize that they themselves and their bank are being prosecuted for larceny and conspiracy. The film chronicles the efforts of the Sung family to clear its name.</p><p><hr /><h2>Tropes:</h2></p><p><ul ><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/BlatantLies' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/BlatantLies'>Blatant Lies</a>: Ken Yu is caught out as a perjurer when he denies ever asking borrowers for a cash kickback, followed by an audio recording of Yu asking a borrower for a cash kickback.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/Documentary' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/Documentary'>Documentary</a>: Portraying the criminal prosecution of a bank in Manhattan's Chinatown.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/Dramatization' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/Dramatization'>Dramatization</a>: Since cameras aren't allowed in federal courtrooms, testimony from the trial is recreated with actor voiceovers that play over courtroom sketches. (Margaret Colin of <em><a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Film/IndependenceDay' title='https://tvtropes.org/pmwiki/pmwiki.php/Film/IndependenceDay'>Independence Day</a></em> fame provides the voice of the prosecuting attorney.)</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/EarnYourHappyEnding' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/EarnYourHappyEnding'>Earn Your Happy Ending</a>: After five years of investigation, two months of trial, and a very long jury deliberation, Abacus and the Sungs are acquitted of all charges.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/FriendlyLocalChinatown' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/FriendlyLocalChinatown'>Friendly Local Chinatown</a>: The bank was founded to serve the local Chinese community and several scenes show Tom Sung interacting with his fellow Chinese-Americans. Interviewees suggest that the unique nature of the local Chinese community, with many new arrivals to America and many people working cash jobs with unreported income, helped facilitate the fraud.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/HorribleJudgeOfCharacter' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/HorribleJudgeOfCharacter'>Horrible Judge of Character</a>: While the film takes the position that the Sungs were innocent of fraud and unaware of the crimes of their underlings at the bank, they <em>did</em> hire eight people who later pleaded guilty to mortgage fraud. The film also notes that another Abacus executive absconded with a million dollars of the bank's money in 2003.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/KarmaHoudini' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/KarmaHoudini'>Karma Houdini</a>: Carol Lim, who stole a million dollars of Abacus money in 2003, precipitating a Depression-style run on the bank, was never caught.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/TheKenBurnsEffect' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/TheKenBurnsEffect'>The Ken Burns Effect</a>: Used many times, like when there's a slow zoom into a picture of loan officer Ken Yu when others explain the crimes Yu committed at Abacus.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/PerpWalk' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/PerpWalk'>Perp Walk</a>: A major point of contention is the decision by authorities to take indicted Abacus employees out of the courthouse in a literal chain gang, where they were all handcuffed together. The Sungs charge that this was a deliberate humiliation.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/TheScapegoat' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/TheScapegoat'>The Scapegoat</a>: A theme of the movie. The central question is why Abacus Savings, a small local bank, was the only bank to be prosecuted for crimes related to the 2008 financial crisis and the <a class='urllink' href='https://en.wikipedia.org/wiki/Great_Recession'>Great Recession<img src="https://static.tvtropes.org/pmwiki/pub/external_link.gif" height="12" width="12" style="border:none;" /></a> when major international banking conglomerates like Chase Manhattan only had to pay relatively trivial fines.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/ShoutOut' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/ShoutOut'>Shout-Out</a>: The movie opens with the Sungs watching <em><a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Film/ItsAWonderfulLife' title='https://tvtropes.org/pmwiki/pmwiki.php/Film/ItsAWonderfulLife'>It's a Wonderful Life</a></em>, which Tom Sung describes as an inspiration that led him to get into the banking business. This also sets up a <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/CallBack' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/CallBack'>Call-Back</a> later when the story of the run on Abacus is illustrated with the run-on-the-bank scene from <em>It's a Wonderful Life</em>.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/StealingFromTheTill' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/StealingFromTheTill'>Stealing from the Till</a>: The film notes that a bank officer named Carol Lim ran away with a million dollars of Abacus money in 2003.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/TalkingHeads' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/TalkingHeads'>Talking Heads</a>: In classic documentary style. Surprisingly, the film includes interviews from district attorney Cyrus Vance and prosecuting attorney Polly Greenberg, both of whom come off badly.</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/TitleDrop' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/TitleDrop'>Title Drop</a>: From author Matt Taibbi, who says "Abacus is small enough to jail."</li><li> <a class='twikilink' href='https://tvtropes.org/pmwiki/pmwiki.php/Main/WhereAreTheyNowEpilogue' title='https://tvtropes.org/pmwiki/pmwiki.php/Main/WhereAreTheyNowEpilogue'>"Where Are They Now?" Epilogue</a>: A brief one that notes that Ken Yu's plea deal was revoked and he went to jail, while Abacus continues to operate with stricter federal oversight.</li></ul></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/Icarus">Icarus</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/UsefulNotes/AcademyAwardForBestDocumentaryFeature">UsefulNotes/Academy Award for Best Documentary Feature</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/FacesPlaces">Faces Places</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/AbductedInPlainSight">Abducted in Plain Sight</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/Documentary">Documentary</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/TheActOfKilling">The Act of Killing</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/ThirtyOne">31</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/FilmsOf20152019">Films of 2015–2019</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AbsurdAccident">Absurd Accident</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=d77d98b7671da37d9a794abba2c9266166e994c0';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/crawler/resources/film4.html
+++ b/tropestogo/service/crawler/resources/film4.html
@@ -1,0 +1,1854 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "Film", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>A Bad Moms Christmas (Film) - TV Tropes</title>
+            <meta name="description" content="A Bad Moms Christmas is a 2017 Christmas comedy film and a sequel to Bad Moms. The holidays are getting stressful for overwhelmed moms Amy, Carla and Kiki &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/Film/ABadMomsChristmas" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="A Bad Moms Christmas (Film) - TV Tropes" />
+            <meta name="twitter:description" content="A Bad Moms Christmas is a 2017 Christmas comedy film and a sequel to Bad Moms. The holidays are getting stressful for overwhelmed moms Amy, Carla and Kiki &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/pmwiki/pub/images/mv5bmtuwnta4mdmxnl5bml5banbnxkftztgwmje4njq0mzi_v1.jpg" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="A Bad Moms Christmas" />
+			<meta property="og:type" content="video.movie" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/Film/ABadMomsChristmas" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/pmwiki/pub/images/mv5bmtuwnta4mdmxnl5bml5banbnxkftztgwmje4njq0mzi_v1.jpg" />
+			<meta property="og:description" content="A Bad Moms Christmas is a 2017 Christmas comedy film and a sequel to Bad Moms. The holidays are getting stressful for overwhelmed moms Amy, Carla and Kiki when their mothers visit for the holidays, Amy celebrates a simple Christmas with Jesse and &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=d77d98b7671da37d9a794abba2c9266166e994c0" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "d77d98b7671da37d9a794abba2c9266166e994c0",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/ThirdPartyDealBreaker" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Fanfic/MonsterInTheMountain" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/Film/ABadMomsChristmas?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=Film/ABadMomsChristmas">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=Film.ABadMomsChristmas">
+                <i class="fa fa-history"></i> History</a></li><li class="link-reviews"><a href="/pmwiki/review_add.php?tt=ABadMomsChristmas&g=Film">
+                      <i class="fa fa-star-half-o"></i> Add Review</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-discussion more_list_item"><a href="/pmwiki/remarks.php?trope=Film.ABadMomsChristmas">
+                  <i class="fa fa-comment"></i> Discussion</a></li><li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/Film/ABadMomsChristmas?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="Film"/>
+<input type="hidden" id="title-hidden" value="ABadMomsChristmas"/>
+<input type="hidden" id="article_id" value="721510" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/Film/ABadMomsChristmas</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>Film / </strong>
+        
+        A Bad Moms Christmas
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Film",
+                "item": "https://tvtropes.org/pmwiki/pmwiki.php/Main/Film"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "A Bad Moms Christmas"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+        
+                                        <li>
+                    <a href="/pmwiki/pmwiki.php/Film/ABadMomsChristmas" class="subpage-link curr-subpage" title="The Film page">
+                    <span class="wrapper"><span class="spi film"></span>Film</span></a>
+                </li>
+                            
+                
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/ABadMomsChristmas?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/ABadMomsChristmas?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/ABadMomsChristmas?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/ABadMomsChristmas?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/ABadMomsChristmas?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/ABadMomsChristmas?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/ABadMomsChristmas?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/ABadMomsChristmas?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/Laconic/ABadMomsChristmas?action=edit">Laconic</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/ABadMomsChristmas?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Quotes/ABadMomsChristmas?action=edit">Quotes</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/ABadMomsChristmas?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/ABadMomsChristmas?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/ABadMomsChristmas?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/ABadMomsChristmas?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/Trivia/ABadMomsChristmas?action=edit">Trivia</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/ABadMomsChristmas?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/ABadMomsChristmas?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><div class="quoteright" style="width:350px;" ><div class="lazy_load_img_box" style="padding-top:148.29%"><img src='https://static.tvtropes.org/pmwiki/pub/images/mv5bmtuwnta4mdmxnl5bml5banbnxkftztgwmje4njq0mzi_v1.jpg' class='embeddedimage' border='0' alt='https://static.tvtropes.org/pmwiki/pub/images/mv5bmtuwnta4mdmxnl5bml5banbnxkftztgwmje4njq0mzi_v1.jpg' / width=350 height=519></div></div><div class="acaptionright" style="width:350px;" > Celebrate the holidays like a mother.</div></p><p><em>A Bad Moms Christmas</em> is a 2017 Christmas comedy film and a sequel to <em><a class='twikilink' href='/pmwiki/pmwiki.php/Film/BadMoms' title='/pmwiki/pmwiki.php/Film/BadMoms'>Bad Moms</a></em>.</p><p>The holidays are getting stressful for overwhelmed moms <a class='twikilink' href='/pmwiki/pmwiki.php/Film/BadMoms' title='/pmwiki/pmwiki.php/Film/BadMoms'>Amy, Carla and Kiki</a> when their mothers visit for the holidays, Amy celebrates a simple Christmas with Jesse and their kids until her mom Ruth (<a class='twikilink' href='/pmwiki/pmwiki.php/Creator/ChristineBaranski' title='/pmwiki/pmwiki.php/Creator/ChristineBaranski'>Christine Baranski</a>) controls every aspect and takes over Christmas, Kiki's mom Sandy (<a class='twikilink' href='/pmwiki/pmwiki.php/Creator/CherylHines' title='/pmwiki/pmwiki.php/Creator/CherylHines'>Cheryl Hines</a>) is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MyBelovedSmother' title='/pmwiki/pmwiki.php/Main/MyBelovedSmother'>clingy and oversteps her boundaries</a> and Carla's mom Isis (<a class='twikilink' href='/pmwiki/pmwiki.php/Creator/SusanSarandon' title='/pmwiki/pmwiki.php/Creator/SusanSarandon'>Susan Sarandon</a>), whom she hasn't seen in years, is between jobs but wants to spend time with her nonetheless.</p><p>Amy, Kiki and Carla vow to take Christmas back for themselves.</p><p><hr /><h2>This movie contains these tropes</h2></p><p><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AmazinglyEmbarrassingParents' title='/pmwiki/pmwiki.php/Main/AmazinglyEmbarrassingParents'>Amazingly Embarrassing Parents</a>: The moms of the main trio. Ruth annoys Amy by being a critical and perfectionist show-off, Kiki gets downright irked at Sandy being <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MyBelovedSmother' title='/pmwiki/pmwiki.php/Main/MyBelovedSmother'>overwhelming and smothering</a>, and Carla... well, she doesn't care that mom Isis is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/GenerationXerox' title='/pmwiki/pmwiki.php/Main/GenerationXerox'>a hedonist like herself</a>, but only that she never comes unless it's to get money for gambling.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BadassCreed' title='/pmwiki/pmwiki.php/Main/BadassCreed'>Badass Creed</a>: "Take Christmas back!"</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CastingGag' title='/pmwiki/pmwiki.php/Main/CastingGag'>Casting Gag</a>: Amy's family loudly complains at her mom dragging all of them to the Russian <em><a class='twikilink' href='/pmwiki/pmwiki.php/Theatre/TheNutcracker' title='/pmwiki/pmwiki.php/Theatre/TheNutcracker'>The Nutcracker</a></em>, which is entirely in Russian, as no one speaks it. Her mom also later remarks "What are we, Jewish?" about their Christmas tradition. <a class='twikilink' href='/pmwiki/pmwiki.php/Creator/MilaKunis' title='/pmwiki/pmwiki.php/Creator/MilaKunis'>Mila Kunis</a>, who plays Amy, is a Russian-speaking Jew.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChippendalesDancers' title='/pmwiki/pmwiki.php/Main/ChippendalesDancers'>Chippendales Dancers</a>: Ty, who falls in love with Carla.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ChristmasEpisode' title='/pmwiki/pmwiki.php/Main/ChristmasEpisode'>Christmas Episode</a>: The sequel's entire plot focuses on Christmas and the three friend's with their families struggling with chaos during the holidays. <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HilarityEnsues' title='/pmwiki/pmwiki.php/Main/HilarityEnsues'>Hilarity Ensues</a>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DemotedToExtra' title='/pmwiki/pmwiki.php/Main/DemotedToExtra'>Demoted to Extra</a>: Gwendolyn, Stacy and Vicki only appear in one scene where Amy is forced by her mother to go caroling... dressed as Scrooge!</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DisappearedDad' title='/pmwiki/pmwiki.php/Main/DisappearedDad'>Disappeared Dad</a>: Kiki's dad died when she was a child.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheDitz' title='/pmwiki/pmwiki.php/Main/TheDitz'>The Ditz</a>: Jaxon, who is <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DumbassTeenageSon' title='/pmwiki/pmwiki.php/Main/DumbassTeenageSon'>an teen that is not-so-bright</a> and isn't given much screen time like some characters.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/DuelingMovies' title='/pmwiki/pmwiki.php/Main/DuelingMovies'>Dueling Movies</a>: Along with <em>Daddy's Home 2</em>, both films being sequels set during Christmas.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FanDisservice' title='/pmwiki/pmwiki.php/Main/FanDisservice'>Fan Disservice</a>: One of the Santa strippers is overweight and exposes his belly, leading to several groans in the audience watching.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FreudianExcuse' title='/pmwiki/pmwiki.php/Main/FreudianExcuse'>Freudian Excuse</a>: This movie introduces the three mothers of the main trio, and it's clear why they started the original like that: Amy tried too hard for growing up with a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/ControlFreak' title='/pmwiki/pmwiki.php/Main/ControlFreak'>Control Freak</a> (who in turn, was also treated like that by her mother), Kiki only cared for her children because her mother was overbearing, and Carla is a neglectful hedonist because mom <em>is</em> the same way.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/FromTheMouthsOfBabes' title='/pmwiki/pmwiki.php/Main/FromTheMouthsOfBabes'>From the Mouths of Babes</a>:<ul ><li> Jane has grown quite the potty mouth.</li><li> Lori drops some F-bombs when she talks about <a class='twikilink' href='/pmwiki/pmwiki.php/Main/PrimalScene' title='/pmwiki/pmwiki.php/Main/PrimalScene'>Jesse and Amy having sex</a>.</li></ul><div class='indent'><strong>Lori:</strong> You came over to the house last week I heard you and Daddy in the bedroom and then you punched the wall and said the "F"-word. You were like, "Oh my fucking God, oh my fucking God!"</div></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HenpeckedHusband' title='/pmwiki/pmwiki.php/Main/HenpeckedHusband'>Henpecked Husband</a>: Amy's dad Hank is often pushed around by Ruth and feels powerless to stand up for himself.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HowWeGotHere' title='/pmwiki/pmwiki.php/Main/HowWeGotHere'>How We Got Here</a>: The movie starts with Amy stating in a voice-over that she feels responsible for turning Christmas into a disaster and flashing back to the last week before Christmas with a dejected Amy amidst destroyed decorations, claiming to have ruined Christmas. Eventually it gets there, a lavish party thrown by Amy's mom behind her back which leads Amy to fight her, expel her <span class="spoiler" title="you can set spoilers visible by default on your profile" >and make her kids sad that after driving daddy away, Amy is now doing the same with grandma</span>.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/InferioritySuperiorityComplex' title='/pmwiki/pmwiki.php/Main/InferioritySuperiorityComplex'>Inferiority Superiority Complex</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Amy's mother turns out to have this. Her own mom never really loved her; she goes for a perfect Christmas and wants to look the best because it makes her feel, even for a second, that she's good enough. Amy's dad tells Amy all this, and that his wife is actually the most insecure woman he's ever met.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MrFanservice' title='/pmwiki/pmwiki.php/Main/MrFanservice'>Mr. Fanservice</a>:<ul ><li> The male Santa stripteases in the bar.</li><li> Justin Hartley as Ty, as one of the Santa male entertainers who Carla falls for.</li><li> Also, Ty's suggestive dance for Carla at the end.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/MyBelovedSmother' title='/pmwiki/pmwiki.php/Main/MyBelovedSmother'>My Beloved Smother</a>:<ul ><li> Sandy literally babies Kiki and meddles in Kiki's marriage.</li><li> Amy's mom Ruth insults her Christmas decorations, overindulges her grandkids and acts rudely towards her daughter's boyfriend Jesse.</li></ul></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/RealPersonCameo' title='/pmwiki/pmwiki.php/Main/RealPersonCameo'>Real Person Cameo</a>: Kenny G appears as himself.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheShrink' title='/pmwiki/pmwiki.php/Main/TheShrink'>The Shrink</a>: Kiki goes to one with her mother Sandy, complaining that her attempts at being close to her daughter are downright invasive.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TeenPregnancy' title='/pmwiki/pmwiki.php/Main/TeenPregnancy'>Teen Pregnancy</a>: Sandy claims that she was 18 when Kiki was born.</li></ul></p><p><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/BadMoms">Bad Moms</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Creator/STXEntertainment">Creator/STX Entertainment</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/TheBoy">The Boy</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/BachelorMother">Bachelor Mother</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/ChristmasMoviesIndex">Christmas Movies Index</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/BadSanta">Bad Santa</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/BadGenius">Bad Genius</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/FilmsOf20152019">Films of 2015–2019</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/BalangigaHowlingWilderness">Balangiga: Howling Wilderness</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/BadMoms">Bad Moms</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/UsefulNotes/RestrictedRating">UsefulNotes/Restricted Rating</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/BadSanta">Bad Santa</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/BadMoms">Bad Moms</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/AmericanFilms/AToC">AmericanFilms/A to C</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/BadMoon">Bad Moon</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=d77d98b7671da37d9a794abba2c9266166e994c0';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/crawler/resources/film5.html
+++ b/tropestogo/service/crawler/resources/film5.html
@@ -1,0 +1,1845 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "Film", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>Abandoned Mine (Film) - TV Tropes</title>
+            <meta name="description" content="Abandoned Mine (alternate title: The Mine) is a Horror Movie by Jeff Chamberlain. Brad (Reilly McClendon) is a teenager in a small town who's invited his &hellip;" />
+                        <link rel="canonical" href="https://tvtropes.org/pmwiki/pmwiki.php/Film/AbandonedMine" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="Abandoned Mine (Film) - TV Tropes" />
+            <meta name="twitter:description" content="Abandoned Mine (alternate title: The Mine) is a Horror Movie by Jeff Chamberlain. Brad (Reilly McClendon) is a teenager in a small town who's invited his &hellip;" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/pmwiki/pub/images/abandoned_mine.jpg" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="Abandoned Mine" />
+			<meta property="og:type" content="video.movie" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pmwiki.php/Film/AbandonedMine" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/pmwiki/pub/images/abandoned_mine.jpg" />
+			<meta property="og:description" content="Abandoned Mine (alternate title: The Mine) is a Horror Movie by Jeff Chamberlain. Brad (Reilly McClendon) is a teenager in a small town who's invited his friends Jimmy (Adam Hendershott), Laurie (Saige Thompson), and Sharon (Alexa PenaVega) to &hellip;" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=d77d98b7671da37d9a794abba2c9266166e994c0" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "d77d98b7671da37d9a794abba2c9266166e994c0",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/SignatureLine" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/Manga/NozomuNozomi" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-edit">
+                    <a rel = "nofollow" class = "article-edit-button"data-modal-target= "login"href = "/pmwiki/pmwiki.php/Film/AbandonedMine?action=edit">
+                         <i class="fa fa-pencil"></i> Edit Page</a></li><li class="link-related"><a href="/pmwiki/relatedsearch.php?term=Film/AbandonedMine">
+                <i class="fa fa-share-alt"></i> Related</a></li><li class="link-history"><a href="/pmwiki/article_history.php?article=Film.AbandonedMine">
+                <i class="fa fa-history"></i> History</a></li><li class="link-reviews"><a href="/pmwiki/review_add.php?tt=AbandonedMine&g=Film">
+                      <i class="fa fa-star-half-o"></i> Add Review</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-discussion more_list_item"><a href="/pmwiki/remarks.php?trope=Film.AbandonedMine">
+                  <i class="fa fa-comment"></i> Discussion</a></li><li class="link-todo tuck-always more_list_item"><a href="#todo" data-modal-target="login"><i class="fa fa-check-circle"></i> To Do</a></li><li class="link-pageSource tuck-always more_list_item"><a href="/pmwiki/pmwiki.php/Film/AbandonedMine?action=source" target="_blank" rel="nofollow"data-modal-target= "login"><i class="fa fa-code"></i> Page Source</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Article"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Article ">
+
+        
+                <article id="main-entry" class="with-sidebar">
+        
+        
+
+
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value="Film"/>
+<input type="hidden" id="title-hidden" value="AbandonedMine"/>
+<input type="hidden" id="article_id" value="850011" />
+<input type="hidden" id="logged_in" value="false" />
+<p id="current_url" class="hidden">http://tvtropes.org/pmwiki/pmwiki.php/Film/AbandonedMine</p>
+
+    <meta itemprop="datePublished" content=""/>
+    <meta itemprop="articleSection" content="" />
+    <meta itemprop="image" content="">
+
+
+
+
+
+
+
+
+
+<a href="#watch" class="watch-button " data-modal-target="login" >Follow<span>ing</span></a>
+
+
+<h1 itemprop="headline" class="entry-title">
+
+    
+                <strong>Film / </strong>
+        
+        Abandoned Mine
+    
+        
+</h1>
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "name": "tvtropes.org",
+                "item": "https://tvtropes.org"
+            },{
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Film",
+                "item": "https://tvtropes.org/pmwiki/pmwiki.php/Main/Film"
+            },{
+                "@type": "ListItem",
+                "position": 3,
+                "name": "Abandoned Mine"            }]
+        }
+    </script>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+
+
+<div id="editLockModal" class="modal fade hidden-until-active" >
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Edit Locked</h4>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="body">
+                        <div class="danger troper_locked_message"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<nav class="body-options" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    <ul class="subpage-links">
+
+                    <li>
+                <a href="/pmwiki/pmwiki.php/Main/AbandonedMine" class="subpage-link " title="The Main page">
+                <span class="wrapper"><span class="spi main-page"></span>Main</span></a>
+            </li>
+        
+                                        <li>
+                    <a href="/pmwiki/pmwiki.php/Film/AbandonedMine" class="subpage-link curr-subpage" title="The Film page">
+                    <span class="wrapper"><span class="spi film"></span>Film</span></a>
+                </li>
+                                                            <li>
+                    <a href="/pmwiki/pmwiki.php/Laconic/AbandonedMine" class="subpage-link " title="The Laconic page">
+                    <span class="wrapper"><span class="spi laconic-icon"></span>Laconic</span></a>
+                </li>
+                                                                                        <li>
+                    <a href="/pmwiki/pmwiki.php/Quotes/AbandonedMine" class="subpage-link " title="The Quotes page">
+                    <span class="wrapper"><span class="spi quotes"></span>Quotes</span></a>
+                </li>
+                                                            <li>
+                    <a href="/pmwiki/pmwiki.php/Trivia/AbandonedMine" class="subpage-link " title="The Trivia page">
+                    <span class="wrapper"><span class="spi trivia"></span>Trivia</span></a>
+                </li>
+                            
+                            <li>
+                <a href="/pmwiki/pmwiki.php/VideoExamples/AbandonedMine" class="subpage-link video-examples-tab  " title="Video Examples">
+                    <img src="/images/play-button-logo.png" alt="play" class="">
+                    <span class="wrapper">VideoExamples</span>
+                </a>
+            </li>
+        
+
+        
+                    <li class="create-subpage dropdown">
+                                    <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
+                    <span class="wrapper">Create New <i class="fa fa-plus-circle"></i></span>
+                    </a>
+
+
+                    <select onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                        <option value="">- Create New -</option>
+
+                                                <option value="/pmwiki/pmwiki.php/Analysis/AbandonedMine?action=edit">Analysis</option>
+                                                <option value="/pmwiki/pmwiki.php/Characters/AbandonedMine?action=edit">Characters</option>
+                                                <option value="/pmwiki/pmwiki.php/FanficRecs/AbandonedMine?action=edit">FanficRecs</option>
+                                                <option value="/pmwiki/pmwiki.php/FanWorks/AbandonedMine?action=edit">FanWorks</option>
+                                                <option value="/pmwiki/pmwiki.php/Fridge/AbandonedMine?action=edit">Fridge</option>
+                                                <option value="/pmwiki/pmwiki.php/Haiku/AbandonedMine?action=edit">Haiku</option>
+                                                <option value="/pmwiki/pmwiki.php/Headscratchers/AbandonedMine?action=edit">Headscratchers</option>
+                                                <option value="/pmwiki/pmwiki.php/ImageLinks/AbandonedMine?action=edit">ImageLinks</option>
+                                                <option value="/pmwiki/pmwiki.php/PlayingWith/AbandonedMine?action=edit">PlayingWith</option>
+                                                <option value="/pmwiki/pmwiki.php/Recap/AbandonedMine?action=edit">Recap</option>
+                                                <option value="/pmwiki/pmwiki.php/ReferencedBy/AbandonedMine?action=edit">ReferencedBy</option>
+                                                <option value="/pmwiki/pmwiki.php/Synopsis/AbandonedMine?action=edit">Synopsis</option>
+                                                <option value="/pmwiki/pmwiki.php/Timeline/AbandonedMine?action=edit">Timeline</option>
+                                                <option value="/pmwiki/pmwiki.php/WMG/AbandonedMine?action=edit">WMG</option>
+                                                <option value="/pmwiki/pmwiki.php/YMMV/AbandonedMine?action=edit">YMMV</option>
+                        
+                    </select>
+
+                    
+                            </li>
+            </ul>
+
+
+</nav>
+
+
+
+
+<div id="main-article" class="article-content retro-folders">
+    <p><div class="quoteright" style="width:350px;" ><div class="lazy_load_img_box" style="padding-top:147.71%"><img src='https://static.tvtropes.org/pmwiki/pub/images/abandoned_mine.jpg' class='embeddedimage' border='0' alt='https://static.tvtropes.org/pmwiki/pub/images/abandoned_mine.jpg' / width=350 height=517></div></div></p><p><em>Abandoned Mine</em> (alternate title: <em>The Mine</em>) is a <a class='twikilink' href='/pmwiki/pmwiki.php/Main/HorrorFilms' title='/pmwiki/pmwiki.php/Main/HorrorFilms'>Horror Movie</a> by Jeff Chamberlain.</p><p>Brad (Reilly McClendon) is a teenager in a small town who's invited his friends Jimmy (Adam Hendershott), Laurie (Saige Thompson), and Sharon (Alexa PenaVega) to spend Halloween Night with him on a special trip. One of them also invites along an Indian boy who just has them call him "Ethan" (Charan Prabhakar), and the three head over to what they find out is the Jarvis Mine, an old mine where, a century ago, the workers had the owner and his daughters <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BuriedAlive' title='/pmwiki/pmwiki.php/Main/BuriedAlive'>Buried Alive</a> in the mine so his business partners could get the huge gold vein found there.</p><p>Supposedly, the mine is haunted by the ghosts of Jarvis and his two daughters, who want freedom from their prison. None of them believe the haunting is true though, but are reluctant to actually go inside the mine... until it starts raining.</p><p>Now inside the mine, the gang must find a way out before the Jarvises find them.</p><p>The movie was released on September 13th, 2012.</p><p><hr /><h2><em>Abandoned Mine</em> contains examples of:</h2><ul ><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AbandonedMine' title='/pmwiki/pmwiki.php/Main/AbandonedMine'>Abandoned Mine</a>: The main setting of the movie is the Jarvis Mine.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AccidentalMurder' title='/pmwiki/pmwiki.php/Main/AccidentalMurder'>Accidental Murder</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >Laurie, while out of her mind from her experience in the mine, hears Brad carrying Sharon. She mistakes it for Jarvis, grabs a long thin object, and then attacks him with it when he comes around the corner.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/AnkleDrag' title='/pmwiki/pmwiki.php/Main/AnkleDrag'>Ankle Drag</a>: When the group's been whittled down to Laurie, Sharon, and Ethan, Sharon starts stating that there's something in the mine with them. Then she starts getting dragged off by some unseen force. <span class="spoiler" title="you can set spoilers visible by default on your profile" >Said "unseen force" was a rope that Brad tied around her ankle.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/BatScare' title='/pmwiki/pmwiki.php/Main/BatScare'>Bat Scare</a>: At one point, while the group (sans Jimmy) are crawling through a small tunnel, they end up disturbing a horde of bats, sending them flying right through them.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/CostumeTestMontage' title='/pmwiki/pmwiki.php/Main/CostumeTestMontage'>Costume-Test Montage</a>: Laurie and Sharon are shown in a montage near the start of the movie trying on different costumes to "Crazy Over You" by XOCH.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/NoodleIncident' title='/pmwiki/pmwiki.php/Main/NoodleIncident'>Noodle Incident</a>: Near the beginning of the movie, Laurie pranks Sharon to get back at her for "the dead skunk thing".</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/OffWithHisHead' title='/pmwiki/pmwiki.php/Main/OffWithHisHead'>Off with His Head!</a>: When she and Ethan get to the bottom of the mine, Laurie bites the head off a rat.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TheReveal' title='/pmwiki/pmwiki.php/Main/TheReveal'>The Reveal</a>: <span class="spoiler" title="you can set spoilers visible by default on your profile" >All the scary stuff and death that the group's been encountering in the mine is all one great big prank set up by Brad.</span></li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/SanitySlippage' title='/pmwiki/pmwiki.php/Main/SanitySlippage'>Sanity Slippage</a>: Laurie seems to suffer from this late in the movie, saying the mine is actually a giant monster, and they're in its digestive system, likening the various caverns they've been in to its organs.</li><li> <a class='twikilink' href='/pmwiki/pmwiki.php/Main/TokenMinority' title='/pmwiki/pmwiki.php/Main/TokenMinority'>Token Minority</a>: Ethan is the sole non-white character in the whole movie.</li></ul><hr /></p></div>
+
+
+
+        
+
+
+
+    
+        <div class="section-links" itemscope itemtype="http://schema.org/SiteNavigationElement">
+
+    
+    <div class="titles">
+        <div><h3 class="text-center text-uppercase">Previous</h3></div>
+        <div><h3 class="text-center text-uppercase">Index</h3></div>
+        <div><h3 class="text-center text-uppercase">Next</h3></div>
+    </div>
+
+
+    <div class="links">
+                    
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/NineSevenSixEvil2TheAstralFactor">976-EVIL 2: The Astral Factor</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/HorrorFilms">Horror Films</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/TheABCsOfDeath">The ABCs of Death</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/TwentyEightHotelRooms">28 Hotel Rooms</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/Main/FilmsOf20102014">Films of 2010–2014</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Film/AbductionOfEden">Abduction of Eden</a> 
+                                            </li>
+                </ul>
+
+            
+                <ul>
+                    <li>
+                                                    <a href="/pmwiki/pmwiki.php/Film/AaronLovesAngela">Aaron Loves Angela</a>
+                                            </li>
+                    <li>
+                        <a href="/pmwiki/pmwiki.php/AmericanFilms/AToC">AmericanFilms/A to C</a>
+                    </li>
+                    <li>
+                         
+                            <a href="/pmwiki/pmwiki.php/Creator/AbbottAndCostello">Abbott and Costello</a> 
+                                            </li>
+                </ul>
+
+                    
+        
+            </div>
+</div>
+
+
+
+
+    <div id="proper_player_insert_div" class="outer_ads_by_salon_wrapper">
+    </div>
+
+
+<script>
+    if( document.getElementById('user-prefs').classList.contains('folders-open') ){
+        console.log('open all folders');
+        var elements = document.querySelectorAll('.folderlabel, .toggle-all-folders-button');
+        elements.forEach((element) => {
+          element.classList.add('is-open');
+        });
+    }
+</script>
+
+
+<script>
+function insert_ad(adCount, paragraph, adName){
+        var ad_count = adCount < 10 ? "0"+adCount : adCount;
+
+        // Create element for ad unit
+        var adUnit = document.createElement('div');
+        adUnit.setAttribute("class", `htlad-${adName}`);
+        adUnit.setAttribute("id", `${adName}_${adCount}`);
+        adUnit.setAttribute("data-targeting", `{"slot_number": "${ad_count}"}`);
+
+        // Add Advertisement label
+        var adLabel = document.createElement("span");
+        adLabel.innerHTML = "Advertisement:"
+        adLabel.setAttribute("class","ad-caption");
+
+        var adWrapper = document.createElement("div");
+        adWrapper.setAttribute("class","tvtropes-ad-unit mobile-fad square_fad mobile_unit_scroll");
+        adWrapper.setAttribute("id","mobile_"+adCount);
+
+        // Merge all pieces
+        adWrapper.appendChild(adLabel);
+        adWrapper.appendChild(adUnit);
+
+        // Insert into DOM
+        paragraph.parentNode.insertBefore(adWrapper, paragraph.nextSibling);
+}
+
+var node = document.getElementById("main-article").firstElementChild;
+var pHeight = 0;
+var pCount = 0;
+var adCount = 1;
+var nodeCount = 0;
+var nodeLevel = 0;
+var x = 0;
+
+if(1 && (document.body.clientWidth && document.body.clientWidth<=768) ) {
+
+        //loop through elements of content
+        while(x<300) {
+            x++; nodeCount++;
+
+            //traverse to the next element (if exists)
+            if(nodeCount>1) {
+                if(!node.nextElementSibling) {
+                    console.log('adparser: no next element');
+
+                    if(nodeLevel>0) {
+                        nodeLevel--;
+                        node = node.parentElement;
+                        console.log('adparser: we were down a level, go back up ('+nodeLevel+')');
+                        continue;
+                    }
+                    else {
+                       break; 
+                    }
+                }
+
+                node = node.nextElementSibling;
+            }
+
+
+            //skip inserted ads or empty nodes
+            if(!node || node==="null" || typeof node !== "object") continue;
+            if(!node.offsetHeight || node.offsetHeight==0) continue;
+            if(node.className && node.className.includes('tvtropes-ad-unit')) continue;
+
+            //skip if image block that has a caption after it
+            if(node.className && node.className.includes('quoteright')) {
+                if(node.nextElementSibling && node.nextElementSibling.className && node.nextElementSibling.className.includes('acaptionright')) {
+                    pHeight += node.offsetHeight;
+                    continue;
+                }
+            } 
+
+            //if very large element, loop through elements inside
+            if(node.offsetHeight>700 && node.firstElementChild) {
+                nodeLevel++;
+                console.log('adparser: traverse through large element='+node.nodeName+', height='+node.offsetHeight+' level='+nodeLevel);
+                node = node.firstElementChild;
+                nodeCount = 0;
+                continue;
+            }
+
+            //paragraph counter
+            if(node.nodeName=="P") pCount++;
+
+            //add height of node to counter
+            pHeight += node.offsetHeight;
+
+            //add margin of node to counter if available
+            try {
+                var nodeStyle = getComputedStyle(node);
+                if(nodeStyle.marginTop && parseInt(nodeStyle.marginTop)>0) pHeight+=parseInt(nodeStyle.marginTop);
+                if(nodeStyle.marginBottom && parseInt(nodeStyle.marginBottom)>0) pHeight+=parseInt(nodeStyle.marginBottom);
+                //console.log(nodeStyle.marginTop+','+nodeStyle.marginBottom);
+            } catch(e) { }
+
+            //debug logging
+            console.log('adparser: name='+node.nodeName+', height='+node.offsetHeight+' =>'+pHeight);
+            //console.log(node.className);
+
+            //only inserts an ad if the total height and paragraph count conditions are met
+            if( (adCount==1 && pCount>1 && pHeight >= 550) || pHeight >= 750 ) {
+
+                    //if we are about to insert after a folder, use the next sibling so it's under the contents
+                    if(node.className && node.className.includes("folderlabel") && node.nextElementSibling) node = node.nextElementSibling;
+
+                    console.log('adparser: insert ad '+adCount);
+                    insert_ad(adCount, node, "tvtropes_m_incontent_dynamic");
+                    adCount++;
+                    pHeight = 0;
+                    pCount = 0;
+
+                    if(adCount>5) break;
+            }
+        }
+
+
+        //insert one at end if room
+        if(adCount<=5 && pHeight>=550) {
+            console.log('adparser: insert ad');
+            insert_ad(adCount, document.getElementById("main-article").lastElementChild, "tvtropes_m_incontent_dynamic");
+        }
+
+}
+
+</script>
+
+
+                
+
+                
+            </article>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=d77d98b7671da37d9a794abba2c9266166e994c0';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/crawler/resources/film_index_page1.html
+++ b/tropestogo/service/crawler/resources/film_index_page1.html
@@ -1,0 +1,1565 @@
+<!DOCTYPE html>
+	<html>
+		<head lang="en">
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-XPPLXMRF6Z"></script>
+            <script>
+                // Used for Video players on Tropes
+                var tropes_videos_commands = tropes_videos_commands || [];
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', 'G-XPPLXMRF6Z');
+
+                window.googletag = window.googletag || {cmd: []};
+            </script>
+			
+						<script type="text/javascript">
+					var site_htl_settings = {
+							"adx"              : "yes", // yes/no if we should include adx on page
+							"groupname"        : "Unknown", // track groupname in htl/gam
+							"user_type"        : "guest", // track member/guest in htl/gam
+							"is_testing"       : "no", // yes/no if in testing mode
+							"split_testing"    : "1", // 0/1, 0=control, 1=test, for a/b testing
+							"send_reports"     : "1", // true/false if reports should be sent for logging in DataBricks
+							"report_url"       : "https://analytics.tvtropes.org/analytics-data/tvtropes/", // Endpoint for logging (data stream)
+							"logging_turned_on": "1", // true/false if console logging should be turned on
+							"site_name"        : "tvtropes", // Site name for display in logging
+							"sticky_slot_names": ["tvtropes_dt_sticky", "tvtropes_m_sticky"], // Possible slot names for the sticky slot
+					}
+			</script>
+			
+											<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+
+								<script>
+					// Create the ad project
+var ads_project = (function(sent_in_settings){
+    var is_mobile = (document.innerWidth <= 768) ? true : false;
+
+    //default settings
+    var setting_defaults = {
+        "adx"              : "yes",
+        "groupname"        : "",
+        "user_type"        : "guest",
+        "is_testing"       : "no",
+        "split_testing"    : "0",
+        "send_reports"     : "0",
+        "logging_turned_on": "false",
+        "site_name"        : "site_name",
+        "report_url"       : "",
+        "page_template"    : "",
+        "sticky_slot_names": []
+    }
+
+    // Combine defaults with sent in parameters
+    var project_settings = {...setting_defaults, ...sent_in_settings};
+    
+    /***************************************
+    --------------- AD CODE ---------------
+    ***************************************/
+    
+    // Variables for refresh logic (sticky)
+    var refresh = true;
+    var sticky_refresh_counter = 1;
+    var refresh_timer;
+    var global_ad_slot_name = "";
+    var global_bidder_name = "";
+    var last_refresh_time = "";
+    var unfilled_count = 0;
+    
+    window.htlbid = window.htlbid || {};
+    htlbid.cmd = htlbid.cmd || [];
+    htlbid.cmd.push(function() {
+        htlbid.layout('universal');
+        
+        // Only set these if given in settings
+        if(project_settings.groupname != "") htlbid.setTargeting("groupname", project_settings.groupname);
+        if(project_settings.page_template != "") htlbid.setTargeting("page_template", project_settings.page_template);
+
+        htlbid.setTargeting("adx", project_settings.adx);
+        //htlbid.setTargeting('is_testing', project_settings.is_testing);
+        //htlbid.setTargeting('split_testing', project_settings.split_testing);
+        htlbid.setTargeting('website', project_settings.site_name);
+        htlbid.setTargeting('user_type', project_settings.user_type);
+
+        // On slot rendering (or unfilled)
+        googletag.pubads().addEventListener('slotRenderEnded', function(event){
+            var slot_targeting = event.slot.getTargetingMap();
+            
+            var bidder_name, size = 0;
+            
+            // If it's empty, no bids?
+            var cpm = (slot_targeting["hb_pb"]) ? slot_targeting["hb_pb"][0] : 0;
+            
+            // In case there is no size from anywhere
+            if(event.size && event.size.length > 0) size = event.size[0]+"x"+event.size[1];
+            
+            // Either Amazon/ADX or Unfilled
+            if(event.advertiserId != 5280547887){
+                if(event.advertiserId == 4467125037){
+                    bidder_name = "adx";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5279698200){
+                    bidder_name = "amazon";
+                    
+                    if(cpm == 0) cpm = 0.11;
+                }
+                else if(event.advertiserId == 5291323376) bidder_name = "house";
+                else if(!event.advertiserId || event.isEmpty) bidder_name = "unfilled";
+                else bidder_name = "unknown";
+                
+                if(bidder_name != "unknown" && bidder_name != "unfilled") output_logging("ADX/Amazon bid report");
+                else output_logging("unknown/unfilled bid report");
+            }
+            // Bidder won the auction
+            else{
+                output_logging("Bidders bid report");
+                
+                bidder_name = (slot_targeting["hb_bidder"]) ? slot_targeting["hb_bidder"][0] : "unknown";
+            }
+            
+            var slot = {
+                "slotName"  : validate_value(event.slot.getAdUnitPath().replace("/1026302/", ""), "string", 50),
+                "cpm"       : validate_value(parseFloat(cpm), "number"),
+                "bidder"    : validate_value(bidder_name, "string", 50),
+                "size"      : validate_value(size, "string", 50),
+                "adUnitCode": validate_value(event.slot.getSlotId().getDomId(), "string", 50),
+                "empty"     : validate_value(event.isEmpty, "boolean")
+            };
+
+            var slot_tracking = Object.assign({}, page_tracking_data);
+            
+            // Override ad-unit with this ad unit to send reporting data
+            slot_tracking.ad_unit = slot;
+            
+            // Loggin out bid report
+            output_logging(slot_tracking);
+            output_logging(slot_tracking.ad_unit.slotName + " "+ slot_tracking.ad_unit.bidder + ", "+ slot_tracking.ad_unit.cpm);
+            
+            if(project_settings.send_reports == "1"){
+                try{
+                    // Send actual bid report
+                    send_bid_report(slot_tracking);
+                }
+                catch(e){
+                    output_logging("Bid report error");
+                }
+            }
+            
+            // Sticky changes
+            if(project_settings.sticky_slot_names.includes(slot_tracking.ad_unit.slotName)){
+                // Check if the bidder is one of these bidders, if so, hide the sticky container
+                if(["gumgum", "kargo", "unknown", "unfilled"].includes(bidder_name)){
+                    document.getElementById("outer_sticky").style.display = "none";
+                }
+                // All other bidders use our sticky container, show it
+                else{
+                    document.getElementById("outer_sticky").style.display = "";
+                }
+
+                // Unfilled slot
+                if(bidder_name == "unfilled"){
+                    unfilled_count++;
+                    
+                    // Stop refreshing after 3 unfilled impressions
+                    if(unfilled_count >= 3){
+                        refresh = false;
+                        
+                        console.log("Refreshed turned off after 3 unfilled impressions");
+                    }
+                }
+                // Reset unfilled count if it's not in a row
+                else if(bidder_name != "house") unfilled_count = 0;
+                
+                // Start refresh check after every sticky ad has been filled (refreshed)
+                start_refresh(slot_tracking.ad_unit.adUnitCode, bidder_name);
+            }
+        });
+    });
+    
+    // Functions for Refresh
+    function start_refresh(ad_slot_name, bidder_name){
+        // Remove old listener before adding a new one
+        document.removeEventListener("visibilitychange", visibility_change_logic);
+        
+        // Stop here if we don't need to refresh the sticky (or max number of refreshes has been reached)
+        if(!refresh || sticky_refresh_counter > 10){
+            output_logging("no timer needed");
+            refresh = false;
+            return;
+        }
+        
+        global_ad_slot_name = ad_slot_name;
+        global_bidder_name = bidder_name;
+        
+        document.addEventListener("visibilitychange", visibility_change_logic);
+        
+        output_logging('refresh timer started');
+
+        // Use 35 second tracker on mobile, 40 on desktop
+        if(is_mobile) refresh_timer = refresh_timer_tracker(35, refresh_sticky);
+        else refresh_timer = refresh_timer_tracker(40, refresh_sticky);
+    }
+    // Logic for visibility change
+    function visibility_change_logic(){
+        // Pause refresh timer
+        if(document.hidden){
+            refresh_timer.pause()
+        }
+        // Start refresh timer
+        else if(refresh){
+            refresh_timer.resume();
+        }
+    }
+    // Timer ended, do refresh
+    function refresh_sticky(){
+        // If you aren't supposed to refresh
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+        
+        // Kargo
+        if(global_bidder_name == "kargo"){
+            //close if Kargo container exists, otherwise don't refresh (must have been manually closed)
+            if(window.Kargo) Kargo.CreativeRegister.getCreativesOfType('Hover')[0].destroy();
+            else refresh = false;
+        }
+        // Gumgum 
+        else if(global_bidder_name == "gumgum") {
+            //close if GumGum container exists, otherwise don't refresh (must have been manually closed)
+            if(document.getElementById("GG_PXS") && document.getElementById("GG_PXS").parentNode){
+                document.getElementById("GG_PXS").parentNode.remove();
+            }
+            else refresh = false;
+        }
+        // Ogury
+        else if(global_bidder_name == "ogury"){
+            if(document.getElementById("ogy-ad-slot")){
+                window.top.dispatchEvent(new Event('ogy_hide'));
+
+                if(document.getElementById("ogy-ad-slot")) document.getElementById("ogy-ad-slot").remove();
+            }
+            else refresh=false;
+        }
+        
+        // Refresh slot (if container wasn't manually closed)
+        if(refresh){
+            sticky_refresh_counter++;
+            
+            //safeguards (max refresh check, minimum time between refreshes)
+            if(sticky_refresh_counter > 12){
+                refresh = false;
+                refresh_timer.delete();
+                document.removeEventListener("visibilitychange", visibility_change_logic);
+                
+                return;
+            }
+            
+            if(last_refresh_time != ""){
+                var current_time = new Date().getTime();
+                var diff_time = current_time - last_refresh_time;
+                
+                if(diff_time<(30*1000)){
+                    output_logging(diff_time + " less than 30 seconds since last refresh, something wrong with timer");
+                    refresh = false;
+                    
+                    refresh_timer.delete();
+                    document.removeEventListener("visibilitychange", visibility_change_logic);
+                    
+                    return;
+                }
+            }
+
+            last_refresh_time = new Date().getTime();
+            output_logging("slot "+global_ad_slot_name+" refreshed");
+
+            var sticky_refresh_counter_display = (sticky_refresh_counter < 10) ? "0"+sticky_refresh_counter : sticky_refresh_counter;
+            
+            if(document.getElementById('sticky_ad_container')) document.getElementById('sticky_ad_container').dataset.targeting="{\"sticky_refresh\":\""+sticky_refresh_counter_display+"\"}";
+            htlbid.forceRefresh([global_ad_slot_name]);
+        }
+        else{
+            output_logging('no refresh - container must have been closed')
+        }
+    }
+    // Force close sticky area
+    function close_sticky(){
+        document.getElementById('outer_sticky').remove();
+        refresh = false;
+        
+        output_logging('refresh timer ended');
+        refresh_timer.delete();
+    }
+    
+    /***************************************
+    ------------ REPORTING CODE ------------
+    ***************************************/
+    // Get $_GET variables
+    var uri = decodeURIComponent(window.location.search.substring(1)).split('&');
+
+    var get_vars = {};
+    for(var x = 0; x < uri.length; x++){
+        var parts = uri[x].split('=');
+        get_vars[parts[0]] = parts[1];
+    }
+
+    // UTM options we track
+    var utm_vars  = [
+          'utm_medium',
+          'utm_source',
+          'utm_campaign',
+          'utm_term',
+          'utm_content',
+          'utm_template',
+          'utm_referrer',
+          'utm_adset',
+          'utm_subid',
+          'gclid',
+          'fbclid'
+    ];
+
+    var utm_confirmed = {}, this_utm_var;
+
+    // See if any UTM variables are defined in the query parameters or session storage
+    utm_vars.forEach(function(utm_var){
+        // (can be blank, so check for null (not set))
+        if(sessionStorage.getItem(utm_var) !== null) this_utm_var = sessionStorage.getItem(utm_var);
+        else{
+            this_utm_var = (typeof get_vars[utm_var] == 'undefined') ? "" : get_vars[utm_var];
+            sessionStorage.setItem(utm_var, this_utm_var);
+        }
+        
+        utm_confirmed[utm_var] = this_utm_var;
+    });
+
+    // Determine browser
+    var browser = '';
+    
+    if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i)) browser = 'iOS';
+    else if(/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'opera';
+    else if(/MSIE (\d+\.\d+);/.test(navigator.userAgent)) browser = 'MSIE';
+    else if(/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'netscape';
+    else if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'chrome';
+    else if(/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'safari';
+    else if(/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) browser = 'firefox';
+    else browser = 'internet_explorer';
+    
+    var session_guid, session_referrer;
+    // Check for session guid in session storage
+    if(sessionStorage.getItem("session_guid")) session_guid = sessionStorage.getItem("session_guid");
+    else{
+        session_guid = generate_uuid();
+        sessionStorage.setItem("session_guid", session_guid);
+    }
+
+    // Check for referrer in session storage (can be blank, so check for null (not set))
+    if(sessionStorage.getItem("session_referrer") !== null) session_referrer = sessionStorage.getItem("session_referrer");
+    else{
+        session_referrer = document.referrer || "";
+        sessionStorage.setItem("session_referrer", session_referrer);
+    }
+
+    var page_tracking_data = {
+        "referrer"          : validate_value(session_referrer, "string"),
+        // UTM variables
+        "utm_variables" : {
+            "utm_source"        : validate_value(utm_confirmed.utm_source,   "string", 100),
+            "utm_campaign"      : validate_value(utm_confirmed.utm_campaign, "string"),
+            "utm_medium"        : validate_value(utm_confirmed.utm_medium,   "string", 100),
+            "utm_term"          : validate_value(utm_confirmed.utm_term,     "string", 100),
+            "utm_content"       : validate_value(utm_confirmed.utm_content,  "string", 100),
+            "utm_template"      : validate_value(utm_confirmed.utm_template, "string", 100),
+            "utm_referrer"      : validate_value(utm_confirmed.utm_referrer, "string", 100),
+            "utm_adset"         : validate_value(utm_confirmed.utm_adset,    "string", 100),
+            "utm_subid"         : validate_value(utm_confirmed.utm_subid,    "string", 100) 
+        },
+        // User information
+        "user"              : {
+            "session_guid"      : validate_value(session_guid,                       "string"),
+            "os"                : validate_value(get_os(),                           "string", 50),
+            "browser"           : validate_value(browser,                            "string", 50),
+            "device"            : validate_value((is_mobile ? "mobile" : "desktop"), "string", 15),
+            "country"           : ""
+        },
+        // Page information
+        "page"              : {
+            "page_guid"         : validate_value(generate_uuid(),          "string"),
+            "url"               : validate_value(window.location.href,     "string"),
+            "url_path"          : validate_value(window.location.pathname, "string", 200)
+            // "editor"            : validate_value(properPage.page_meta.editor, "string", 150),
+            // "writer"            : validate_value(properPage.page_meta.writer, "string", 150)
+        },
+        // Ad unit information
+        "ad_unit"          : {}
+
+
+
+
+
+        // Not sure if we are going to use these, comment out for now
+        // "category"          : validate_value(page_meta.category),
+        // "tags"              : validate_value(page_meta.tags.join(",")),
+        // "website"           : validate_value(site_name),
+        // "is_mobile"         : validate_value(device_type),
+        // "is_isolated"       : validate_value(isolated),
+        // "session_depth"     : validate_value(sessionData.depth),
+        // "page_type"         : validate_value(page_meta.page_type),
+        // "custom"            : validateCustom(page_meta.custom),
+        // 
+        // "use_ssl"           : validate_value(use_ssl),
+        // "resolution_width"  : validate_value(width),
+        // "resolution_height" : validate_value(height),
+        // "gclid"              : validate_value(sessionData.gclid),
+        // "fbclid"            : validate_value(sessionData.fbclid),
+        // "buyer"             : validate_value(page_meta.buyer),
+        // "split"             : validate_value(page_meta.split),
+        // "adblock"           : validate_value(adblock.detected)
+    };
+    
+    // Logging
+    function output_logging(content){
+        if(project_settings.logging_turned_on){
+            if(typeof content == "string") console.log(project_settings.site_name + " Ads: " + content);
+            else console.log(content);
+        }
+    }
+    // Get OS
+    function get_os(){
+        var os = navigator.userAgent;
+        
+        var return_os = "";
+        
+        if(os.search('Windows') !== -1) return_os = "Windows";
+        else if(os.search('Mac') !== -1) return_os = "MacOS";
+        else if(os.search('X11') !== -1 && !(os.search('Linux') !== -1)) return_os = "UNIX";
+        else if(os.search('Linux') !== -1 && os.search('X11') !== -1) return_os = "Linux"
+        
+        return return_os;
+    }
+    // Validate any value benig sent in reporting
+    function validate_value(value, type, max_length = 255){
+        // Validate string logic
+        if(type == "string"){
+            // Convert number to string
+            if(typeof value === 'number') value = value.toString();
+            
+            // If it's not a string, make it empty by default
+            if(typeof value !== 'string') value = "";
+            
+            // Trim max length
+            if(value.length > max_length) value = value.substring(0, max_length);
+        }
+        // Validate number logic
+        else if(type == "number"){
+            // Convert string to number
+            if(typeof value === 'string') value = value.toString();
+            
+            // If it's not a number, make it 0 by default
+            if(typeof value !== 'number') value = 0;
+        }
+        // Validate boolean logic
+        else if(type == "boolean"){
+            // Convert string to boolean
+            if(typeof value === 'string'){
+                if(['false', '0'].includes(value)) value = false;
+                else if(['true', '1'].includes(value)) value = true;
+            }
+            // Convert number to boolean
+            else if(typeof value === 'number'){
+                if(value == 0) value = false;
+                else if(value == 1) value = true;
+            }
+            
+            // If it's not a boolean, make it false by default
+            if(typeof value !== 'boolean') value = false;
+        }
+        
+        return value;
+    }
+    // Generate UUID (unique ID)
+    function generate_uuid(){
+        var d = new Date().getTime();
+
+        // Use high-precision timer if available (time on page)
+        if(window.performance && typeof window.performance.now === "function"){
+            d += performance.now();
+        }
+
+        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = (d + Math.random()*16)%16 | 0;
+            d = Math.floor(d/16);
+
+            return (c == 'x' ? r : (r&0x3|0x8)).toString(16);
+        });
+
+        return uuid;
+    }
+    // Function to send Requests for data logging
+    function send_bid_report(data){
+        // If there is no report endpoint
+        if(project_settings.report_url == "") return;
+        
+        var request = new XMLHttpRequest();
+        
+        request.open("post", project_settings.report_url, 1);
+
+        request.setRequestHeader("Content-Type", "application/json; charset=UTF-8")
+
+        request.onload = function(){
+            if(request.status == 200) output_logging("Bid Report sent");
+            else output_logging("Failed to send bid report");
+        }
+
+        request.send(JSON.stringify(data));
+    }
+    // Timer for leaving the page and pausing refresh
+    function refresh_timer_tracker(seconds, oncomplete){
+        console.log('refresh_timer_tracker: called');
+        var timerId, start, remaining = parseInt(seconds)*1000;
+
+        this.pause = function() {
+            window.clearTimeout(timerId);
+            timerId = null;
+            remaining -= Date.now() - start;
+            output_logging('refresh_timer_tracker: pause = '+remaining);
+        };
+
+        this.resume = function() {
+            if (timerId) return;
+
+            start = Date.now();
+            timerId = window.setTimeout(oncomplete, remaining);
+            output_logging('refresh_timer_tracker: resume = '+remaining);
+        };
+
+        this.delete = function(){
+            if (!timerId) return;
+            clearInterval(timerId);
+            output_logging('refresh_timer_tracker: delete');
+        }
+
+
+        this.resume();
+
+        return this;
+    }
+    
+    return {
+        data: page_tracking_data,
+        close_sticky: close_sticky
+    };
+})(site_htl_settings);				</script>
+					
+				<script async src="https://htlbid.com/v3/tvtropes.org/htlbid.js"></script>
+
+				<!-- Bombora -->
+				<script>
+				!function(e,t,c,n,o,a,m){e._bmb||(o=e._bmb=function(){o.x?o.x.apply(o,arguments):o.q.push(arguments)},o.q=[],a=t.createElement(c),a.async=true,a.src="https://vi.ml314.com/get?eid=90820&tk=wh2f3nQiCsEF22bcOc3am6J9QS7SqBu7WCIKhTJmEBRc03d&fp="+(e.localStorage&&e.localStorage.getItem(n)||""),m=t.getElementsByTagName(c)[0],m.parentNode.insertBefore(a,m))}(window,document,"script","_ccmaid");
+
+				window.googletag = window.googletag || {cmd: []};
+				googletag.cmd.push(function() {
+					_bmb('vi', function(data){
+						if (data != null) {
+							var tmpSegment = [
+								data.industry_id,
+								data.revenue_id,
+								data.size_id,
+								data.functional_area_id,
+								data.professional_group_id,
+								data.seniority_id,
+								data.decision_maker_id,
+								data.install_data_id,
+								data.topic_id,
+								data.interest_group_id,
+								data.segment,
+								data.b2b_interest_cluster_id
+								].filter(Boolean).join(',');
+
+							tmpSegment != '' && googletag.pubads().setTargeting("bmb",tmpSegment.split(','));
+						}
+					});
+				});
+				</script>
+				<script>
+				(function (w,d,t) {
+					_ml = w._ml || {};
+					_ml.eid = '90820';
+					var s, cd, tag; s = d.getElementsByTagName(t)[0]; cd = new Date();
+					tag = d.createElement(t); tag.async = 1;
+					tag.src = 'https://ml314.com/tag.aspx?' + cd.getDate() + cd.getMonth();
+					s.parentNode.insertBefore(tag, s);
+				})(window,document,'script');
+				</script>
+				<!-- Bombora -->
+						
+			
+											<script async src="https://fundingchoicesmessages.google.com/i/pub-2575788690798282?ers=1" nonce="7aDjgy4Z6ho9CCJZZfPh4g"></script><script nonce="7aDjgy4Z6ho9CCJZZfPh4g">(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+					
+					<script>(function(){/*
+							 Copyright The Closure Library Authors.
+							 SPDX-License-Identifier: Apache-2.0
+							*/
+							'use strict';var aa=function(a){var b=0;return function(){return b<a.length?{done:!1,value:a[b++]}:{done:!0}}},ba="function"==typeof Object.create?Object.create:function(a){var b=function(){};b.prototype=a;return new b},k;if("function"==typeof Object.setPrototypeOf)k=Object.setPrototypeOf;else{var m;a:{var ca={a:!0},n={};try{n.__proto__=ca;m=n.a;break a}catch(a){}m=!1}k=m?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw new TypeError(a+" is not extensible");return a}:null}
+							var p=k,q=function(a,b){a.prototype=ba(b.prototype);a.prototype.constructor=a;if(p)p(a,b);else for(var c in b)if("prototype"!=c)if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else a[c]=b[c];a.v=b.prototype},r=this||self,da=function(){},t=function(a){return a};var u;var w=function(a,b){this.g=b===v?a:""};w.prototype.toString=function(){return this.g+""};var v={},x=function(a){if(void 0===u){var b=null;var c=r.trustedTypes;if(c&&c.createPolicy){try{b=c.createPolicy("goog#html",{createHTML:t,createScript:t,createScriptURL:t})}catch(d){r.console&&r.console.error(d.message)}u=b}else u=b}a=(b=u)?b.createScriptURL(a):a;return new w(a,v)};var A=function(){return Math.floor(2147483648*Math.random()).toString(36)+Math.abs(Math.floor(2147483648*Math.random())^Date.now()).toString(36)};var B={},C=null;var D="function"===typeof Uint8Array;function E(a,b,c){return"object"===typeof a?D&&!Array.isArray(a)&&a instanceof Uint8Array?c(a):F(a,b,c):b(a)}function F(a,b,c){if(Array.isArray(a)){for(var d=Array(a.length),e=0;e<a.length;e++){var f=a[e];null!=f&&(d[e]=E(f,b,c))}Array.isArray(a)&&a.s&&G(d);return d}d={};for(e in a)Object.prototype.hasOwnProperty.call(a,e)&&(f=a[e],null!=f&&(d[e]=E(f,b,c)));return d}
+							function ea(a){return F(a,function(b){return"number"===typeof b?isFinite(b)?b:String(b):b},function(b){var c;void 0===c&&(c=0);if(!C){C={};for(var d="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(""),e=["+/=","+/","-_=","-_.","-_"],f=0;5>f;f++){var h=d.concat(e[f].split(""));B[f]=h;for(var g=0;g<h.length;g++){var l=h[g];void 0===C[l]&&(C[l]=g)}}}c=B[c];d=Array(Math.floor(b.length/3));e=c[64]||"";for(f=h=0;h<b.length-2;h+=3){var y=b[h],z=b[h+1];l=b[h+2];g=c[y>>2];y=c[(y&3)<<
+							4|z>>4];z=c[(z&15)<<2|l>>6];l=c[l&63];d[f++]=""+g+y+z+l}g=0;l=e;switch(b.length-h){case 2:g=b[h+1],l=c[(g&15)<<2]||e;case 1:b=b[h],d[f]=""+c[b>>2]+c[(b&3)<<4|g>>4]+l+e}return d.join("")})}var fa={s:{value:!0,configurable:!0}},G=function(a){Array.isArray(a)&&!Object.isFrozen(a)&&Object.defineProperties(a,fa);return a};var H;var J=function(a,b,c){var d=H;H=null;a||(a=d);d=this.constructor.u;a||(a=d?[d]:[]);this.j=d?0:-1;this.h=null;this.g=a;a:{d=this.g.length;a=d-1;if(d&&(d=this.g[a],!(null===d||"object"!=typeof d||Array.isArray(d)||D&&d instanceof Uint8Array))){this.l=a-this.j;this.i=d;break a}void 0!==b&&-1<b?(this.l=Math.max(b,a+1-this.j),this.i=null):this.l=Number.MAX_VALUE}if(c)for(b=0;b<c.length;b++)a=c[b],a<this.l?(a+=this.j,(d=this.g[a])?G(d):this.g[a]=I):(d=this.l+this.j,this.g[d]||(this.i=this.g[d]={}),(d=this.i[a])?
+							G(d):this.i[a]=I)},I=Object.freeze(G([])),K=function(a,b){if(-1===b)return null;if(b<a.l){b+=a.j;var c=a.g[b];return c!==I?c:a.g[b]=G([])}if(a.i)return c=a.i[b],c!==I?c:a.i[b]=G([])},M=function(a,b){var c=L;if(-1===b)return null;a.h||(a.h={});if(!a.h[b]){var d=K(a,b);d&&(a.h[b]=new c(d))}return a.h[b]};J.prototype.toJSON=function(){var a=N(this,!1);return ea(a)};
+							var N=function(a,b){if(a.h)for(var c in a.h)if(Object.prototype.hasOwnProperty.call(a.h,c)){var d=a.h[c];if(Array.isArray(d))for(var e=0;e<d.length;e++)d[e]&&N(d[e],b);else d&&N(d,b)}return a.g},O=function(a,b){H=b=b?JSON.parse(b):null;a=new a(b);H=null;return a};J.prototype.toString=function(){return N(this,!1).toString()};var P=function(a){J.call(this,a)};q(P,J);function ha(a){var b,c=(a.ownerDocument&&a.ownerDocument.defaultView||window).document,d=null===(b=c.querySelector)||void 0===b?void 0:b.call(c,"script[nonce]");(b=d?d.nonce||d.getAttribute("nonce")||"":"")&&a.setAttribute("nonce",b)};var Q=function(a,b){b=String(b);"application/xhtml+xml"===a.contentType&&(b=b.toLowerCase());return a.createElement(b)},R=function(a){this.g=a||r.document||document};R.prototype.appendChild=function(a,b){a.appendChild(b)};var S=function(a,b,c,d,e,f){try{var h=a.g,g=Q(a.g,"SCRIPT");g.async=!0;g.src=b instanceof w&&b.constructor===w?b.g:"type_error:TrustedResourceUrl";ha(g);h.head.appendChild(g);g.addEventListener("load",function(){e();d&&h.head.removeChild(g)});g.addEventListener("error",function(){0<c?S(a,b,c-1,d,e,f):(d&&h.head.removeChild(g),f())})}catch(l){f()}};var ia=r.atob("aHR0cHM6Ly93d3cuZ3N0YXRpYy5jb20vaW1hZ2VzL2ljb25zL21hdGVyaWFsL3N5c3RlbS8xeC93YXJuaW5nX2FtYmVyXzI0ZHAucG5n"),ja=r.atob("WW91IGFyZSBzZWVpbmcgdGhpcyBtZXNzYWdlIGJlY2F1c2UgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlIGlzIGludGVyZmVyaW5nIHdpdGggdGhpcyBwYWdlLg=="),ka=r.atob("RGlzYWJsZSBhbnkgYWQgb3Igc2NyaXB0IGJsb2NraW5nIHNvZnR3YXJlLCB0aGVuIHJlbG9hZCB0aGlzIHBhZ2Uu"),la=function(a,b,c){this.h=a;this.j=new R(this.h);this.g=null;this.i=[];this.l=!1;this.o=b;this.m=c},V=function(a){if(a.h.body&&!a.l){var b=
+							function(){T(a);r.setTimeout(function(){return U(a,3)},50)};S(a.j,a.o,2,!0,function(){r[a.m]||b()},b);a.l=!0}},T=function(a){for(var b=W(1,5),c=0;c<b;c++){var d=X(a);a.h.body.appendChild(d);a.i.push(d)}b=X(a);b.style.bottom="0";b.style.left="0";b.style.position="fixed";b.style.width=W(100,110).toString()+"%";b.style.zIndex=W(2147483544,2147483644).toString();b.style["background-color"]=ma(249,259,242,252,219,229);b.style["box-shadow"]="0 0 12px #888";b.style.color=ma(0,10,0,10,0,10);b.style.display=
+							"flex";b.style["justify-content"]="center";b.style["font-family"]="Roboto, Arial";c=X(a);c.style.width=W(80,85).toString()+"%";c.style.maxWidth=W(750,775).toString()+"px";c.style.margin="24px";c.style.display="flex";c.style["align-items"]="flex-start";c.style["justify-content"]="center";d=Q(a.j.g,"IMG");d.className=A();d.src=ia;d.style.height="24px";d.style.width="24px";d.style["padding-right"]="16px";var e=X(a),f=X(a);f.style["font-weight"]="bold";f.textContent=ja;var h=X(a);h.textContent=ka;Y(a,
+							e,f);Y(a,e,h);Y(a,c,d);Y(a,c,e);Y(a,b,c);a.g=b;a.h.body.appendChild(a.g);b=W(1,5);for(c=0;c<b;c++)d=X(a),a.h.body.appendChild(d),a.i.push(d)},Y=function(a,b,c){for(var d=W(1,5),e=0;e<d;e++){var f=X(a);b.appendChild(f)}b.appendChild(c);c=W(1,5);for(d=0;d<c;d++)e=X(a),b.appendChild(e)},W=function(a,b){return Math.floor(a+Math.random()*(b-a))},ma=function(a,b,c,d,e,f){return"rgb("+W(Math.max(a,0),Math.min(b,255)).toString()+","+W(Math.max(c,0),Math.min(d,255)).toString()+","+W(Math.max(e,0),Math.min(f,
+							255)).toString()+")"},X=function(a){a=Q(a.j.g,"DIV");a.className=A();return a},U=function(a,b){0>=b||null!=a.g&&0!=a.g.offsetHeight&&0!=a.g.offsetWidth||(na(a),T(a),r.setTimeout(function(){return U(a,b-1)},50))},na=function(a){var b=a.i;var c="undefined"!=typeof Symbol&&Symbol.iterator&&b[Symbol.iterator];b=c?c.call(b):{next:aa(b)};for(c=b.next();!c.done;c=b.next())(c=c.value)&&c.parentNode&&c.parentNode.removeChild(c);a.i=[];(b=a.g)&&b.parentNode&&b.parentNode.removeChild(b);a.g=null};var pa=function(a,b,c,d,e){var f=oa(c),h=function(l){l.appendChild(f);r.setTimeout(function(){f?(0!==f.offsetHeight&&0!==f.offsetWidth?b():a(),f.parentNode&&f.parentNode.removeChild(f)):a()},d)},g=function(l){document.body?h(document.body):0<l?r.setTimeout(function(){g(l-1)},e):b()};g(3)},oa=function(a){var b=document.createElement("div");b.className=a;b.style.width="1px";b.style.height="1px";b.style.position="absolute";b.style.left="-10000px";b.style.top="-10000px";b.style.zIndex="-10000";return b};var L=function(a){J.call(this,a)};q(L,J);var qa=function(a){J.call(this,a)};q(qa,J);var ra=function(a,b){this.l=a;this.m=new R(a.document);this.g=b;this.i=K(this.g,1);b=M(this.g,2);this.o=x(K(b,4)||"");this.h=!1;b=M(this.g,13);b=x(K(b,4)||"");this.j=new la(a.document,b,K(this.g,12))};ra.prototype.start=function(){sa(this)};
+							var sa=function(a){ta(a);S(a.m,a.o,3,!1,function(){a:{var b=a.i;var c=r.btoa(b);if(c=r[c]){try{var d=O(P,r.atob(c))}catch(e){b=!1;break a}b=b===K(d,1)}else b=!1}b?Z(a,K(a.g,14)):(Z(a,K(a.g,8)),V(a.j))},function(){pa(function(){Z(a,K(a.g,7));V(a.j)},function(){return Z(a,K(a.g,6))},K(a.g,9),K(a.g,10),K(a.g,11))})},Z=function(a,b){a.h||(a.h=!0,a=new a.l.XMLHttpRequest,a.open("GET",b,!0),a.send())},ta=function(a){var b=r.btoa(a.i);a.l[b]&&Z(a,K(a.g,5))};(function(a,b){r[a]=function(c){for(var d=[],e=0;e<arguments.length;++e)d[e-0]=arguments[e];r[a]=da;b.apply(null,d)}})("__h82AlnkH6D91__",function(a){"function"===typeof window.atob&&(new ra(window,O(qa,window.atob(a)))).start()});}).call(this);
+
+							window.__h82AlnkH6D91__("WyJwdWItMjU3NTc4ODY5MDc5ODI4MiIsW251bGwsbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9iL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyIl0sbnVsbCxudWxsLCJodHRwczovL2Z1bmRpbmdjaG9pY2VzbWVzc2FnZXMuZ29vZ2xlLmNvbS9lbC9BR1NLV3hWV0tMOXhFeS1ZVk1sOTdzcC10MW5mbkxvWmZweWVjaGRJdUxJU244LXpjbUwxM1R5Mlhhb2RoQTJFU3VNS3ljQm1kVHgxSUNlMVBrX2hIeUxHa1ZZNHJ3XHUwMDNkXHUwMDNkP3RlXHUwMDNkVE9LRU5fRVhQT1NFRCIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZCeVhDdDlWajY1eXNrMWFHVW9LUUpLdktrTlh4WVdlRDBhYnhmS3RVUi00eDZfRTNWOXpqSm5vYkFfVzIxeGNDb3F3M1RmN1dYRmxXZFZaazVMMFlQQ2dcdTAwM2RcdTAwM2Q/YWJcdTAwM2QxXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFV4bEsxQ0dxcEpGY3lvcXZXZ0ZnWWRBRjhMMzBOU0Y1ci1paGZSd1VRNzV4YmF6NGxydWVfRUhoWmU1ai00UUhRYXc4MUVZREFkQ2pBN21Tb1BxUUsxaFFcdTAwM2RcdTAwM2Q/YWJcdTAwM2QyXHUwMDI2c2JmXHUwMDNkMSIsImh0dHBzOi8vZnVuZGluZ2Nob2ljZXNtZXNzYWdlcy5nb29nbGUuY29tL2VsL0FHU0tXeFZJUWxpOV9jN0NuWWlHWkU3S2xIV2JWVi10NlpYQ2hQTnlHVTRobGhmSjdLQnJnNjllSFhHYm9aSXRqRm42MDViNWpuaG5KYkxCcU1ySURyY2lLVEk0VmdcdTAwM2RcdTAwM2Q/c2JmXHUwMDNkMiIsImRpdi1ncHQtYWQiLDIwLDEwMCwiY0hWaUxUSTFOelUzT0RnMk9UQTNPVGd5T0RJXHUwMDNkIixbbnVsbCxudWxsLG51bGwsImh0dHBzOi8vd3d3LmdzdGF0aWMuY29tLzBlbW4vZi9wL3B1Yi0yNTc1Nzg4NjkwNzk4MjgyLmpzP3VzcXBcdTAwM2RDQkEiXSwiaHR0cHM6Ly9mdW5kaW5nY2hvaWNlc21lc3NhZ2VzLmdvb2dsZS5jb20vZWwvQUdTS1d4V1hNUEJXZjVaNURyT1VGdDZwVVR5eGh1YzBFNlVGQnJJZUhuUUNCMVlUOWVtYlJTbGxYQ3F6NDV5ODdqT3RVWC1SX3JkcmdudFdjejdtazA2WkZYWDQyd1x1MDAzZFx1MDAzZCJd");
+					</script>
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+
+			<title>work pages in Film - TV Tropes</title>
+            <meta name="description" content="" />
+            
+
+                        <link rel="shortcut icon" href="https://assets.tvtropes.org/img/icons/favicon.ico" type="image/x-icon" />
+
+                        <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:site" content="@tvtropes" />
+            <meta name="twitter:owner" content="@tvtropes" />
+            <meta name="twitter:title" content="work pages in Film - TV Tropes" />
+            <meta name="twitter:description" content="" />
+			            	<meta name="twitter:image:src" content="https://static.tvtropes.org/logo_blue_small.png" />
+	        
+                        <meta property="og:site_name" content="TV Tropes" />
+            <meta property="og:locale" content="en_US" />
+            <meta property="article:publisher" content="https://www.facebook.com/tvtropes" />
+			<meta property="og:title" content="work pages in Film" />
+			<meta property="og:type" content="" />
+							<meta property="og:url" content="https://tvtropes.org/pmwiki/pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=1" />
+			
+			<meta property="og:image" content="https://static.tvtropes.org/logo_blue_small.png" />
+			<meta property="og:description" content="" />
+
+						
+
+			            <link rel="apple-touch-icon" sizes="57x57" href="https://assets.tvtropes.org/img/icons/apple-icon-57x57.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="60x60" href="https://assets.tvtropes.org/img/icons/apple-icon-60x60.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="72x72" href="https://assets.tvtropes.org/img/icons/apple-icon-72x72.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="76x76" href="https://assets.tvtropes.org/img/icons/apple-icon-76x76.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="114x114" href="https://assets.tvtropes.org/img/icons/apple-icon-114x114.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="120x120" href="https://assets.tvtropes.org/img/icons/apple-icon-120x120.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="144x144" href="https://assets.tvtropes.org/img/icons/apple-icon-144x144.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="152x152" href="https://assets.tvtropes.org/img/icons/apple-icon-152x152.png" type="image/png">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://assets.tvtropes.org/img/icons/apple-icon-180x180.png" type="image/png">
+            <link rel="icon" sizes="16x16" href="https://assets.tvtropes.org/img/icons/favicon-16x16.png" type="image/png">
+            <link rel="icon" sizes="32x32" href="https://assets.tvtropes.org/img/icons/favicon-32x32.png" type="image/png">
+            <link rel="icon" sizes="96x96" href="https://assets.tvtropes.org/img/icons/favicon-96x96.png" type="image/png">
+            <link rel="icon" sizes="192x192" href="https://assets.tvtropes.org/img/icons/favicon-192x192.png" type="image/png">
+
+                        
+
+						<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+                        <link rel="stylesheet" href="https://assets.tvtropes.org/design/assets/bundle.css?rev=d77d98b7671da37d9a794abba2c9266166e994c0" />
+
+                                                
+                        
+                        
+                        						
+            <script>
+                function object(objectId) {
+                    if (document.getElementById && document.getElementById(objectId)) {
+                        return document.getElementById(objectId);
+                    } else if (document.all && document.all(objectId)) {
+                        return document.all(objectId);
+                    } else if (document.layers && document.layers[objectId]) {
+                        return document.layers[objectId];
+                    } else {
+                        return false;
+                    }
+                }
+
+                // JAVASCRIPT COOKIES CODE: for getting and setting user viewing preferences
+                var cookies = {
+                    create: function (name, value, days2expire, path) {
+                        var date = new Date();
+                        date.setTime(date.getTime() + (days2expire * 24 * 60 * 60 * 1000));
+                        var expires = date.toUTCString();
+                        document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+                    },
+										createWithExpire: function(name, value, expires, path) {
+												document.cookie = name + '=' + value + ';' + 'expires=' + expires + ';domain=.tvtropes.org;' + 'path=' + path + ';';
+										},
+                    read: function (name) {
+                        var cookie_value = "",
+                            current_cookie = "",
+                            name_expr = name + "=",
+                            all_cookies = document.cookie.split(';'),
+                            n = all_cookies.length;
+
+                        for (var i = 0; i < n; i++) {
+                            current_cookie = all_cookies[i].trim();
+                            if (current_cookie.indexOf(name_expr) === 0) {
+                                cookie_value = current_cookie.substring(name_expr.length, current_cookie.length);
+                                break;
+                            }
+                        }
+                        return cookie_value;
+                    },
+                    update: function (name, val) {
+                        this.create(name, val, 300, "/");
+                    },
+                    remove: function (name) {
+                        //delete cookie with and without domain setting
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=.tvtropes.org; path=/;";
+                        document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;";
+                    }
+                };
+
+                function updateUserPrefs() {
+                    //GENERAL: detect and set browser, if not cookied (will be treated like a user-preference and added to the #user-pref element)
+                    if( !cookies.read('user-browser') ){
+                        var broswer = '';
+
+                        if(navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) ){
+                            browser = 'iOS';
+                        } else if (/Opera[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'opera';
+                        } else if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
+                            browser = 'MSIE';
+                        } else if (/Navigator[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'netscape';
+                        } else if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'chrome';
+                        } else if (/Safari[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'safari';
+                            /Version[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+                            browserVersion = new Number(RegExp.$1);
+                        } else if (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
+                            browser = 'firefox';
+                        } else {
+                            browser = 'internet_explorer';
+                        }
+                        cookies.create('user-browser',browser,1,'/');
+                        document.getElementById('user-prefs').classList.add('browser-' + browser);
+                    } else {
+                        document.getElementById('user-prefs').classList.add('browser-' + cookies.read('user-browser'));
+                    }
+                    //update user preference settings
+                    if (cookies.read('wide-load') !== '') document.getElementById('user-prefs').classList.add('wide-load');
+                    if (cookies.read('night-vision') !== '') document.getElementById('user-prefs').classList.add('night-vision');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('user-prefs').classList.add('sticky-header');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('user-prefs').classList.add('show-spoilers');
+                    if (cookies.read('folders-open') !== '') document.getElementById('user-prefs').classList.add('folders-open');
+                    if (cookies.read('lefthand-sidebar') !== '') document.getElementById('user-prefs').classList.add('lefthand-sidebar');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('user-prefs').classList.add('highlight-links');
+                    if (cookies.read('forum-gingerbread') !== '') document.getElementById('user-prefs').classList.add('forum-gingerbread');
+                    //if the user is logged in, update cookies based on their database settings
+                                        //updates element
+                    if(cookies.read('shared-avatars') !== '') document.getElementById('user-prefs').classList.add('shared-avatars');
+                    if(cookies.read('new-search') !== '') document.getElementById('user-prefs').classList.add('new-search');
+                    if(cookies.read('stop-auto-play-video') !== '') document.getElementById('user-prefs').classList.add('stop-auto-play-video');
+                    //desktop view on mobile
+                    if (cookies.read('desktop-on-mobile') !== ''){
+                        document.getElementById('user-prefs').classList.add('desktop-on-mobile');
+
+                        var viewport = document.querySelector("meta[name=viewport]");
+                        viewport.setAttribute('content', 'width=1000');
+                    }
+
+                }
+
+                function updateDesktopPrefs() {
+                    if (cookies.read('wide-load') !== '') document.getElementById('sidebar-toggle-wideload').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('sidebar-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('sidebar-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('sidebar-toggle-showspoilers').classList.add('active');
+
+                }
+
+                function updateMobilePrefs() {
+                    if (cookies.read('show-spoilers') !== '') document.getElementById('mobile-toggle-showspoilers').classList.add('active');
+                    if (cookies.read('night-vision') !== '') document.getElementById('mobile-toggle-nightvision').classList.add('active');
+                    if (cookies.read('sticky-header') !== '') document.getElementById('mobile-toggle-stickyheader').classList.add('active');
+                    if (cookies.read('highlight-links') !== '') document.getElementById('mobile-toggle-highlightlinks').classList.add('active');
+
+                }
+
+                function is_mobile() {
+	                if(document.body.clientWidth && document.body.clientWidth<=768) return true;
+	                else return false;
+                }
+
+            </script>
+						
+                        <script type="text/javascript">
+
+                var tvtropes_config = {
+                    asteri_stream_enabled : "1",
+                    is_logged_in         : "",
+                    handle               : "",
+                    get_asteri_stream     : "",
+                    revnum               : "d77d98b7671da37d9a794abba2c9266166e994c0",
+                    img_domain           : "https://static.tvtropes.org",
+                    adblock              : "1",
+                    adblock_url          : "propermessage.io",
+                    pause_editing        : "0",
+                    pause_editing_msg    : "",
+                    pause_site_changes   : "",
+                    assets_domain        : "https://assets.tvtropes.org"
+                };
+            </script>
+						
+                        						
+												<script type="text/javascript">
+						  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+						  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+						  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+						  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+						  ga('create', 'UA-3821842-1', 'auto');
+						  ga('send', 'pageview');
+						</script>
+
+						        </head>
+ <body class="">
+        <i id="user-prefs"></i>
+    <script>updateUserPrefs();</script>
+
+    <div id="fb-root"></div>
+
+    <div id="modal-box"></div>
+
+    <header id="main-header-bar" class="headroom-element ">
+        <div id="main-header-bar-inner">
+
+            <span id="header-spacer-left" class="header-spacer"></span>
+
+            <a href="#mobile-menu" id="main-mobile-toggle" class="mobile-menu-toggle-button tablet-on"><span></span><span></span><span></span></a>
+
+            <a href="/" id="main-header-logoButton" class="no-dev"></a>
+
+            <span id="header-spacer-right" class="header-spacer"></span>
+
+            <nav id="main-header-nav" class="tablet-off">
+                <a href="/pmwiki/pmwiki.php/Main/Tropes">Tropes</a>
+                <a href="/pmwiki/pmwiki.php/Main/Media">Media</a>
+                <a href="/pmwiki/browse.php" class="nav-browse">Browse</a>
+                <a href="/pmwiki/index_report.php">Indexes</a>
+                <a href="/pmwiki/topics.php">Forums</a>
+                <a href="/pmwiki/recent_videos.php" class="nav-browse">Videos</a>
+            </nav>
+
+            <div id="main-header-bar-right">
+                                <div id="signup-login-box" class="font-xs mobile-off">
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="signup">Join</a>
+                    <a href="/pmwiki/login.php" class="hover-underline bold" data-modal-target="login">Login</a>
+                </div>
+                
+                                <div id="signup-login-mobileToggle" class="mobile-on inline">
+                    <a href="/pmwiki/login.php" data-modal-target="login"><i class="fa fa-user"></i></a>
+                </div>
+                
+                <div id="search-box">
+                    <form class="search" action="/pmwiki/search_result.php">
+                        <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+                        <input type="submit" class="submit-button" value="&#xf002;" />
+                                                <input type="hidden" name="search_type" value="article">
+                        <input type="hidden" name="page_type" value="all">
+                                                <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+                        <input type="hidden" name="cof" value="FORID:10">
+                        <input type="hidden" name="ie" value="ISO-8859-1">
+                        <input name="siteurl" type="hidden" value="">
+                        <input name="ref" type="hidden" value="">
+                        <input name="ss" type="hidden" value="">
+                    </form>
+                    <a href="#close-search" class="mobile-on mobile-search-toggle close-x"><i class="fa fa-close"></i></a>
+                </div>
+
+                <div id="random-box">
+                    <a href="/pmwiki/pmwiki.php/Main/BridgeLogic" class="button-random-trope" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random trope');"></a>
+                    <a href="/pmwiki/pmwiki.php/VideoGame/KartRiderDrift" class="button-random-media" rel="nofollow" onclick="ga('send', 'event', 'button', 'click', 'random media');"></a>
+                </div>
+
+            </div>
+
+        </div>
+
+        <div id="mobile-menu" class="tablet-on"><div class="mobile-menu-options">
+
+    <div class="nav-wrapper">
+        <a href="/pmwiki/pmwiki.php/Main/Tropes" class="xl">Tropes</a>
+        <a href="/pmwiki/pmwiki.php/Main/Media" class="xl">Media</a>
+        <a href="/pmwiki/browse.php" class="xl">Browse</a>
+        <a href="/pmwiki/index_report.php" class="xl">Indexes</a>
+        <a href="/pmwiki/topics.php" class="xl">Forums</a>
+        <a href="/pmwiki/recent_videos.php" class="xl">Videos</a>
+
+        <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+        <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+        <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+        <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+        <a href="/pmwiki/query.php?type=wl">Wishlist</a>
+        
+        <a href="#tools" data-click-toggle="active">Tools <i class="fa fa-chevron-down"></i></a>
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/cutlist.php">Cut List</a>
+            <a href="/pmwiki/changes.php">New Edits</a>
+            <a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a>
+            <a href="/pmwiki/launches.php">Launches</a>
+            <a href="/pmwiki/img_list.php">Images List</a>
+            <a href="/pmwiki/crown_activity.php">Crowner Activity</a>
+            <a href="/pmwiki/no_types.php">Un-typed Pages</a>
+            <a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a>
+        </div>
+
+        <a href="#hq" data-click-toggle="active">Tropes HQ <i class="fa fa-chevron-down"></i></a>
+
+        <div class="tools-dropdown mobile-dropdown-linkList">
+            <a href="/pmwiki/about.php">About Us</a>
+            <a href="/pmwiki/contact.php">Contact Us</a>
+            <a href="mailto:advertising@proper.io">Advertise</a>
+            <a href="/pmwiki/dmca.php">DMCA Notice</a>
+            <a href="/pmwiki/privacypolicy.php">Privacy Policy</a>
+        </div>
+
+        <a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a>
+        <a href="/pmwiki/query.php?type=bug">Report Bug</a>
+
+        <div class="toggle-switches">
+            <ul class="mobile-menu display-toggles">
+                <li>Show Spoilers <div id="mobile-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+                <li>Night Vision <div id="mobile-toggle-nightvision" class="display-toggle night-vision"></div></li>
+                <li>Sticky Header <div id="mobile-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+                <li>Highlight Links <div id="mobile-toggle-highlightlinks" class="display-toggle highlight-links"></div></li>
+            </ul>
+            <script>updateMobilePrefs();</script>
+        </div>
+
+    </div>
+
+</div>
+</div>
+
+    </header>
+
+    <div id="homepage-introBox-mobile" class="mobile-on">
+                  <a href="/"><img src="/images/logo-white-big.png" class="logo-small" /></a>
+        
+        <form class="search" action="/pmwiki/search_result.php" style="margin:10px -5px -6px -5px;">
+            <input type="text" name="q" class="search-box" placeholder="Search" value="" required>
+            <input type="submit" class="submit-button" value="&#xf002;" />
+                        <input type="hidden" name="search_type" value="article">
+            <input type="hidden" name="page_type" value="all">
+                        <input type="hidden" name="cx" value="partner-pub-6610802604051523:amzitfn8e7v">
+            <input type="hidden" name="cof" value="FORID:10">
+            <input type="hidden" name="ie" value="ISO-8859-1">
+            <input name="siteurl" type="hidden" value="">
+            <input name="ref" type="hidden" value="">
+            <input name="ss" type="hidden" value="">
+        </form>
+
+            </div>
+    
+                <div id="outer_sticky" style="display: none;">
+            <div id="close_sticky" onclick="ads_project.close_sticky(); return false;"><i class="fa fa-close"></i></div>
+            
+            <script>
+                if(is_mobile()) {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_m_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+                else {
+                    document.write("<div id=\"sticky_ad_container\" class=\"htlad-tvtropes_dt_sticky\" data-targeting='{\"sticky_refresh\": \"01\"}'></div>");
+                }
+            </script>
+        </div>
+
+                <div id="tvtropes_oop_ad_slot" style="display: none;"></div>
+    <div id="header-fad-wrapper" class="fad">
+    <div id="header-fad">
+    <div class="fad-size-970x90" style="height:20px">&nbsp;</div>    </div>
+</div>
+
+<div id="main-container">
+
+    
+        <div id="action-bar-top" class="action-bar mobile-off">
+
+        <div class="action-bar-right">
+            <p>Follow TV Tropes</p>
+            <a href="https://www.facebook.com/TVTropes" class="button-fb">
+                <i class="fa fa-facebook"></i></a>
+            <a href="https://www.twitter.com/TVTropes" class="button-tw">
+                <i class="fa fa-twitter"></i></a>
+            <a href="https://www.reddit.com/r/TVTropes" class="button-re">
+                <i class="fa fa-reddit-alien"></i></a>
+        </div>
+
+                <nav class="actions-wrapper" itemscope itemtype="http://schema.org/SiteNavigationElement">
+            <ul id="top_main_list" class="page-actions">
+                <li class="link-changes"><a href="/pmwiki/cutlist.php">
+                <i class="fa fa-cut"></i> Cutlist</a></li><li class="link-launches"><a href="/pmwiki/changes.php">
+                <i class="fa fa-pencil-square-o"></i> New Edits</a></li><li class="link-discards"><a href="/pmwiki/recent_edit_reasons.php">
+                <i class="fa fa-quote-left"></i> Edit Reasons</a></li><li class="link-cutList"><a href="/pmwiki/crown_activity.php">
+                <i class="fa crowner-icon">&#9819;</i> Crowner Activity</a></li>            </ul>
+                            <button id="top_more_button" onclick="toggle_more_menu('top');" type="button" class="nav__dropdown-toggle">More</button>
+                        <ul id="top_more_list" class="more_menu hidden_more_list">
+                <li class="link-cutList more_list_item"><a href="/pmwiki/img_list.php">
+                <i class="fa fa-picture-o"></i> Images List</a></li><li class="link-videos more_list_item"><a href="/pmwiki/recent_videos.php">
+                <i class="fa fa-picture-o"></i> Recent Videos</a></li><li class="link-cutList more_list_item"><a href="/pmwiki/articles_new.php">
+                <i class="fa fa-newspaper-o"></i> New Articles</a></li>            </ul>
+        </nav> 
+
+        <div class="WikiWordModalStub"></div>
+        <div class="ImgUploadModalStub" data-page-type="Misc"></div>
+
+        <div class="login-alert" style="display: none;">
+            You need to <a href="/pmwiki/login.php" style="color:#21A0E8">login</a> to do this. <a href="/pmwiki/login.php?tab=register_account" style="color:#21A0E8">Get Known</a> if you don't have an account
+        </div>
+
+    </div>
+    
+    <div id="main-content" class="page-Misc ">
+
+        
+        
+        <div id="main-entry" class="with-sidebar">
+
+        
+<!-- HIDDEN INPUTS FOR JS -->
+<input type="hidden" id="groupname-hidden" value=""/>
+<input type="hidden" id="title-hidden" value=""/>
+
+
+
+
+<h1 itemprop="headline" class="entry-title">work pages in Film</h1>
+
+<a href="#mobile-actions-toggle" id="mobile-actionbar-toggle" class="mobile-actionbar-toggle mobile-on" data-click-toggle="active" >
+<p class="tiny-off">Go To</p><span></span><span></span><span></span><i class="fa fa-pencil"></i></a>
+<nav id="mobile-actions-bar" class="mobile-actions-wrapper mobile-on"></nav>
+<div id="main-article" class="article-content retro-folders" itemprop="mainContentOfPage">
+
+		
+    <div id="wikimiddle" style="width:95%;">
+<p style="text-align:center;">
+	List of pages in Film having page type: work:
+</p>
+<table style="width:50%">
+	<tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aadai">&nbsp;&nbsp;Aadai</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AaronLovesAngela">&nbsp;&nbsp;Aaron Loves Angela</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbacusSmallEnoughToJail">&nbsp;&nbsp;Abacus Small Enough To Jail</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABadMomsChristmas">&nbsp;&nbsp;A Bad Moms Christmas</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbandonedMine">&nbsp;&nbsp;Abandoned Mine</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABattleOfWits">&nbsp;&nbsp;A Battle Of Wits</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABayOfBlood">&nbsp;&nbsp;A Bay Of Blood</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABBATheMovie">&nbsp;&nbsp;ABBA The Movie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbbotOfShaolin">&nbsp;&nbsp;Abbot Of Shaolin</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbbottAndCostelloMeetDrJekyllAndMrHyde">&nbsp;&nbsp;Abbott And Costello Meet Dr Jekyll And Mr Hyde</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbbottAndCostelloMeetFrankenstein">&nbsp;&nbsp;Abbott And Costello Meet Frankenstein</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbbottAndCostelloMeetTheInvisibleMan">&nbsp;&nbsp;Abbott And Costello Meet The Invisible Man</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbbottAndCostelloMeetTheKillerBorisKarloff">&nbsp;&nbsp;Abbott And Costello Meet The Killer Boris Karloff</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbbottAndCostelloMeetTheMummy">&nbsp;&nbsp;Abbott And Costello Meet The Mummy</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABCsOfDeath2">&nbsp;&nbsp;AB Cs Of Death 2</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbductedInPlainSight">&nbsp;&nbsp;Abducted In Plain Sight</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Abduction">&nbsp;&nbsp;Abduction</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbductionOfEden">&nbsp;&nbsp;Abduction Of Eden</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABeautifulDayInTheNeighborhood">&nbsp;&nbsp;A Beautiful Day In The Neighborhood</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABeautifulMind">&nbsp;&nbsp;A Beautiful Mind</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Abel">&nbsp;&nbsp;Abel</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Abeltje">&nbsp;&nbsp;Abeltje</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABetterTomorrow">&nbsp;&nbsp;A Better Tomorrow</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABirdersGuideToEverything">&nbsp;&nbsp;A Birders Guide To Everything</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABittersweetLife">&nbsp;&nbsp;A Bittersweet Life</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABlueprintForMurder">&nbsp;&nbsp;A Blueprint For Murder</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABNKKBSNPLAko">&nbsp;&nbsp;ABNKKBSNPL Ako</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Abominable">&nbsp;&nbsp;Abominable</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutAlex">&nbsp;&nbsp;About Alex</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutElly">&nbsp;&nbsp;About Elly</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutLastNight">&nbsp;&nbsp;About Last Night</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutLittleRedRidingHood">&nbsp;&nbsp;About Little Red Riding Hood</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutSchmidt">&nbsp;&nbsp;About Schmidt</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutScout">&nbsp;&nbsp;About Scout</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboutTime">&nbsp;&nbsp;About Time</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboveTheLaw1988">&nbsp;&nbsp;Above The Law 1988</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboveTheLaw2017">&nbsp;&nbsp;Above The Law 2017</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AboveTheShadows">&nbsp;&nbsp;Above The Shadows</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABoyAndHisDog1946">&nbsp;&nbsp;A Boy And His Dog 1946</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABoyCalledPo">&nbsp;&nbsp;A Boy Called Po</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbrahamLincoln1930">&nbsp;&nbsp;Abraham Lincoln 1930</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbrahamLincolnVampireHunter">&nbsp;&nbsp;Abraham Lincoln Vampire Hunter</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbrahamLincolnVsZombies">&nbsp;&nbsp;Abraham Lincoln Vs Zombies</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbraxasGuardianOfTheUniverse">&nbsp;&nbsp;Abraxas Guardian Of The Universe</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABreathOfScandal">&nbsp;&nbsp;A Breath Of Scandal</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABridesRevenge">&nbsp;&nbsp;A Brides Revenge</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABridgeTooFar">&nbsp;&nbsp;A Bridge Too Far</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABrighterSummerDay">&nbsp;&nbsp;A Brighter Summer Day</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABronxMorning">&nbsp;&nbsp;A Bronx Morning</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABronxTale">&nbsp;&nbsp;A Bronx Tale</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbsenceOfMalice">&nbsp;&nbsp;Absence Of Malice</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Absentia">&nbsp;&nbsp;Absentia</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Absolon">&nbsp;&nbsp;Absolon</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbsoluteBeginners">&nbsp;&nbsp;Absolute Beginners</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbsolutelyAnything">&nbsp;&nbsp;Absolutely Anything</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbsolutelyFabulous">&nbsp;&nbsp;Absolutely Fabulous</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbsolutePower1997">&nbsp;&nbsp;Absolute Power 1997</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Absolution">&nbsp;&nbsp;Absolution</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Absurd1981">&nbsp;&nbsp;Absurd 1981</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AbsurdAccident">&nbsp;&nbsp;Absurd Accident</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABucketOfBlood">&nbsp;&nbsp;A Bucket Of Blood</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ABulletForTheGeneral">&nbsp;&nbsp;A Bullet For The General</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACanterburyTale">&nbsp;&nbsp;A Canterbury Tale</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACaseOfRape">&nbsp;&nbsp;A Case Of Rape</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACaseOfSpringFever">&nbsp;&nbsp;A Case Of Spring Fever</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Accepted">&nbsp;&nbsp;Accepted</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Accident">&nbsp;&nbsp;Accident</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AccidentalHero">&nbsp;&nbsp;Accidental Hero</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AccidentMan">&nbsp;&nbsp;Accident Man</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AccordingToGreta">&nbsp;&nbsp;According To Greta</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AccordingToSpencer">&nbsp;&nbsp;According To Spencer</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AceAttorney2012">&nbsp;&nbsp;Ace Attorney 2012</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AceHigh">&nbsp;&nbsp;Ace High</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AceInTheHole1951">&nbsp;&nbsp;Ace In The Hole 1951</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AceOfAces">&nbsp;&nbsp;Ace Of Aces</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACertainSacrifice">&nbsp;&nbsp;A Certain Sacrifice</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AcesGoPlaces">&nbsp;&nbsp;Aces Go Places</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AceVentura">&nbsp;&nbsp;Ace Ventura</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChairyTale">&nbsp;&nbsp;A Chairy Tale</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChildIsWaiting">&nbsp;&nbsp;A Child Is Waiting</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChineseGhostStory">&nbsp;&nbsp;A Chinese Ghost Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChineseOdyssey">&nbsp;&nbsp;A Chinese Odyssey</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasCarol1938">&nbsp;&nbsp;A Christmas Carol 1938</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasCarol1984">&nbsp;&nbsp;A Christmas Carol 1984</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasCarol1999">&nbsp;&nbsp;A Christmas Carol 1999</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasCarol2000">&nbsp;&nbsp;A Christmas Carol 2000</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasCarolGoesWrong">&nbsp;&nbsp;A Christmas Carol Goes Wrong</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasCarolTheMusical">&nbsp;&nbsp;A Christmas Carol The Musical</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasHorrorStory">&nbsp;&nbsp;A Christmas Horror Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasPrince">&nbsp;&nbsp;A Christmas Prince</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasStory">&nbsp;&nbsp;A Christmas Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChristmasStoryChristmas">&nbsp;&nbsp;A Christmas Story Christmas</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AChumpAtOxford">&nbsp;&nbsp;A Chump At Oxford</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACinderellaStory">&nbsp;&nbsp;A Cinderella Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACinderellaStoryChristmasWish">&nbsp;&nbsp;A Cinderella Story Christmas Wish</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACinderellaStoryOnceUponASong">&nbsp;&nbsp;A Cinderella Story Once Upon A Song</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACityOfSadness">&nbsp;&nbsp;A City Of Sadness</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AClassicHorrorStory">&nbsp;&nbsp;A Classic Horror Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AClockworkOrange">&nbsp;&nbsp;A Clockwork Orange</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AColdNightsDeath">&nbsp;&nbsp;A Cold Nights Death</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AColtIsMyPassport">&nbsp;&nbsp;A Colt Is My Passport</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACornerInWheat">&nbsp;&nbsp;A Corner In Wheat</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACountessFromHongKong">&nbsp;&nbsp;A Countess From Hong Kong</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACountryChristmas">&nbsp;&nbsp;A Country Christmas</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACrimeInParadise">&nbsp;&nbsp;A Crime In Paradise</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Acrimony">&nbsp;&nbsp;Acrimony</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AcrossThePacific">&nbsp;&nbsp;Across The Pacific</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AcrossTheUniverse2007">&nbsp;&nbsp;Across The Universe 2007</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AcrossTheWideMissouri">&nbsp;&nbsp;Across The Wide Missouri</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AcrossToSingapore">&nbsp;&nbsp;Across To Singapore</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ActionJackson">&nbsp;&nbsp;Action Jackson</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ActOfValor">&nbsp;&nbsp;Act Of Valor</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ActOfVengeance">&nbsp;&nbsp;Act Of Vengeance</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ActOfViolence">&nbsp;&nbsp;Act Of Violence</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ActsOfVengeance2017">&nbsp;&nbsp;Acts Of Vengeance 2017</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACureForPokeritis">&nbsp;&nbsp;A Cure For Pokeritis</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACureForWellness">&nbsp;&nbsp;A Cure For Wellness</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ACuriousConjunctionOfCoincidences">&nbsp;&nbsp;A Curious Conjunction Of Coincidences</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adalen31">&nbsp;&nbsp;Adalen 31</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adam2009">&nbsp;&nbsp;Adam 2009</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adam2019">&nbsp;&nbsp;Adam 2019</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdamAndPaul">&nbsp;&nbsp;Adam And Paul</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdamChaplin">&nbsp;&nbsp;Adam Chaplin</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdamsApples">&nbsp;&nbsp;Adams Apples</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdamsRib">&nbsp;&nbsp;Adams Rib</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADangerousLife">&nbsp;&nbsp;A Dangerous Life</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADangerousMan">&nbsp;&nbsp;A Dangerous Man</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADangerousMethod">&nbsp;&nbsp;A Dangerous Method</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adaptation">&nbsp;&nbsp;Adaptation</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADarkSong">&nbsp;&nbsp;A Dark Song</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdAstra">&nbsp;&nbsp;Ad Astra</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADateWithYourFamily">&nbsp;&nbsp;A Date With Your Family</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADayAtTheRaces">&nbsp;&nbsp;A Day At The Races</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADayInTheCountry">&nbsp;&nbsp;A Day In The Country</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADayOfJudgment">&nbsp;&nbsp;A Day Of Judgment</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADayWithoutAMexican">&nbsp;&nbsp;A Day Without A Mexican</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AddictedToFresno">&nbsp;&nbsp;Addicted To Fresno</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AddictedToLove">&nbsp;&nbsp;Addicted To Love</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADeadlySecret">&nbsp;&nbsp;A Deadly Secret</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdeleHasntHadHerDinnerYet">&nbsp;&nbsp;Adele Hasnt Had Her Dinner Yet</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADifferentApproach">&nbsp;&nbsp;A Different Approach</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADivasChristmasCarol">&nbsp;&nbsp;A Divas Christmas Carol</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Admiral">&nbsp;&nbsp;Admiral</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Admission">&nbsp;&nbsp;Admission</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADogsLife">&nbsp;&nbsp;A Dogs Life</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADogsPurpose">&nbsp;&nbsp;A Dogs Purpose</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdoptingTerror">&nbsp;&nbsp;Adopting Terror</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADoubleLife">&nbsp;&nbsp;A Double Life</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adrift2006">&nbsp;&nbsp;Adrift 2006</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adrift2018">&nbsp;&nbsp;Adrift 2018</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AduaAndHerFriends">&nbsp;&nbsp;Adua And Her Friends</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ADuckingTheyDidGo">&nbsp;&nbsp;A Ducking They Did Go</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdultLifeSkills">&nbsp;&nbsp;Adult Life Skills</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdultSwimYuleLog">&nbsp;&nbsp;Adult Swim Yule Log</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdvanceToTheRear">&nbsp;&nbsp;Advance To The Rear</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Advantageous">&nbsp;&nbsp;Advantageous</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdventureInSahara">&nbsp;&nbsp;Adventure In Sahara</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Adventureland">&nbsp;&nbsp;Adventureland</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdventuresInBabysitting">&nbsp;&nbsp;Adventures In Babysitting</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdventuresInBabysitting2016">&nbsp;&nbsp;Adventures In Babysitting 2016</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdventuresInDinosaurCity">&nbsp;&nbsp;Adventures In Dinosaur City</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AdviseAndConsent">&nbsp;&nbsp;Advise And Consent</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aelita">&nbsp;&nbsp;Aelita</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AeonFlux">&nbsp;&nbsp;Aeon Flux</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFaceInTheCrowd">&nbsp;&nbsp;A Face In The Crowd</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFairlyOddChristmas">&nbsp;&nbsp;A Fairly Odd Christmas</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFairlyOddMovieGrowUpTimmyTurner">&nbsp;&nbsp;A Fairly Odd Movie Grow Up Timmy Turner</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFairlyOddSummer">&nbsp;&nbsp;A Fairly Odd Summer</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFantasticFearOfEverything">&nbsp;&nbsp;A Fantastic Fear Of Everything</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFantasticWoman">&nbsp;&nbsp;A Fantastic Woman</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFarewellToArms">&nbsp;&nbsp;A Farewell To Arms</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFarOffPlace">&nbsp;&nbsp;A Far Off Place</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFewGoodMen">&nbsp;&nbsp;A Few Good Men</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Afflicted">&nbsp;&nbsp;Afflicted</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Affliction">&nbsp;&nbsp;Affliction</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFieldInEngland">&nbsp;&nbsp;A Field In England</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFilmWithMeInIt">&nbsp;&nbsp;A Film With Me In It</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFineMess">&nbsp;&nbsp;A Fine Mess</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFinePair">&nbsp;&nbsp;A Fine Pair</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFishCalledWanda">&nbsp;&nbsp;A Fish Called Wanda</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFistfulOfDollars">&nbsp;&nbsp;A Fistful Of Dollars</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFistfulOfDynamite">&nbsp;&nbsp;A Fistful Of Dynamite</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFoolThereWas">&nbsp;&nbsp;A Fool There Was</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AForeignAffair">&nbsp;&nbsp;A Foreign Affair</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFreeSoul">&nbsp;&nbsp;A Free Soul</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfricaAddio">&nbsp;&nbsp;Africa Addio</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFriendToDieFor">&nbsp;&nbsp;A Friend To Die For</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/After2012">&nbsp;&nbsp;After 2012</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterDarkMySweet">&nbsp;&nbsp;After Dark My Sweet</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterDeath">&nbsp;&nbsp;After Death</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterEarth">&nbsp;&nbsp;After Earth</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterHours">&nbsp;&nbsp;After Hours</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterLastSeason">&nbsp;&nbsp;After Last Season</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterLife">&nbsp;&nbsp;After Life</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterlifeOfTheParty">&nbsp;&nbsp;Afterlife Of The Party</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aftermath1994">&nbsp;&nbsp;Aftermath 1994</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aftermath2021">&nbsp;&nbsp;Aftermath 2021</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfternoonDelight">&nbsp;&nbsp;Afternoon Delight</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterRain">&nbsp;&nbsp;After Rain</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterSchoolMassacre">&nbsp;&nbsp;After School Massacre</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aftershock">&nbsp;&nbsp;Aftershock</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aftersun">&nbsp;&nbsp;Aftersun</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterTheDark">&nbsp;&nbsp;After The Dark</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterTheFox">&nbsp;&nbsp;After The Fox</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterTheRain">&nbsp;&nbsp;After The Rain</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterTheSunset">&nbsp;&nbsp;After The Sunset</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterTheThinMan">&nbsp;&nbsp;After The Thin Man</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterTheWedding">&nbsp;&nbsp;After The Wedding</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AfterYang">&nbsp;&nbsp;After Yang</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFunnyThingHappenedOnTheWayToThorsHammer">&nbsp;&nbsp;A Funny Thing Happened On The Way To Thors Hammer</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AFutileAndStupidGesture">&nbsp;&nbsp;A Futile And Stupid Gesture</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgainstACrookedSky">&nbsp;&nbsp;Against A Crooked Sky</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgainstAllFlags">&nbsp;&nbsp;Against All Flags</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgainstTheRopes">&nbsp;&nbsp;Against The Ropes</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgainstTheWall">&nbsp;&nbsp;Against The Wall</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGeneration">&nbsp;&nbsp;A Generation</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgentCarter">&nbsp;&nbsp;Agent Carter</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgentCodyBanks">&nbsp;&nbsp;Agent Cody Banks</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgentForHARM">&nbsp;&nbsp;Agent For HARM</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGentleNight">&nbsp;&nbsp;A Gentle Night</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgeOfConsent">&nbsp;&nbsp;Age Of Consent</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgeOfDinosaurs">&nbsp;&nbsp;Age Of Dinosaurs</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgeOfSummerhood">&nbsp;&nbsp;Age Of Summerhood</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AggieApplebyMakerOfMen">&nbsp;&nbsp;Aggie Appleby Maker Of Men</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGhostStory">&nbsp;&nbsp;A Ghost Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGirlLikeGrace">&nbsp;&nbsp;A Girl Like Grace</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGirlLikeHer">&nbsp;&nbsp;A Girl Like Her</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGirlNamedSooner">&nbsp;&nbsp;A Girl Named Sooner</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGirlWalksHomeAloneAtNight">&nbsp;&nbsp;A Girl Walks Home Alone At Night</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgnesAndHisBrothers">&nbsp;&nbsp;Agnes And His Brothers</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AgnesOfGod">&nbsp;&nbsp;Agnes Of God</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGnomeNamedGnorm">&nbsp;&nbsp;A Gnome Named Gnorm</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGoodDayToDieHard">&nbsp;&nbsp;A Good Day To Die Hard</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGoodWomanIsHardToFind">&nbsp;&nbsp;A Good Woman Is Hard To Find</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGoodYear">&nbsp;&nbsp;A Good Year</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Agora">&nbsp;&nbsp;Agora</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGuideToRecognizingYourSaints">&nbsp;&nbsp;A Guide To Recognizing Your Saints</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AguirreTheWrathOfGod">&nbsp;&nbsp;Aguirre The Wrath Of God</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGunfight">&nbsp;&nbsp;A Gunfight</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGunForGeorge">&nbsp;&nbsp;A Gun For George</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGunInHisHand">&nbsp;&nbsp;A Gun In His Hand</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGuyNamedJoe">&nbsp;&nbsp;A Guy Named Joe</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AGuyThing">&nbsp;&nbsp;A Guy Thing</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHardDay">&nbsp;&nbsp;A Hard Day</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHardDaysNight">&nbsp;&nbsp;A Hard Days Night</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHauntedHouse">&nbsp;&nbsp;A Haunted House</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHauntingAtSilverFalls">&nbsp;&nbsp;A Haunting At Silver Falls</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHauntingInVenice">&nbsp;&nbsp;A Haunting In Venice</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AhBoysToMen">&nbsp;&nbsp;Ah Boys To Men</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHeartInWinter">&nbsp;&nbsp;A Heart In Winter</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHenInTheWind">&nbsp;&nbsp;A Hen In The Wind</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHeroNeverDies">&nbsp;&nbsp;A Hero Never Dies</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHiddenLife">&nbsp;&nbsp;A Hidden Life</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHistoryOfViolence">&nbsp;&nbsp;A History Of Violence</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHomeTooFar">&nbsp;&nbsp;A Home Too Far</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AHorribleWayToDie">&nbsp;&nbsp;A Horrible Way To Die</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AIArtificialIntelligence">&nbsp;&nbsp;AI Artificial Intelligence</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AikokuSentaiDaiNippon">&nbsp;&nbsp;Aikoku Sentai Dai Nippon</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AintThemBodiesSaints">&nbsp;&nbsp;Aint Them Bodies Saints</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Air2023">&nbsp;&nbsp;Air 2023</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirAmerica">&nbsp;&nbsp;Air America</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Airborne">&nbsp;&nbsp;Airborne</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirBud">&nbsp;&nbsp;Air Bud</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirBuddies">&nbsp;&nbsp;Air Buddies</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirBuddies2006">&nbsp;&nbsp;Air Buddies 2006</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirDoll">&nbsp;&nbsp;Air Doll</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirForceOne">&nbsp;&nbsp;Air Force One</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Airheads">&nbsp;&nbsp;Airheads</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Airplane">&nbsp;&nbsp;Airplane</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirplaneIITheSequel">&nbsp;&nbsp;Airplane II The Sequel</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Airport">&nbsp;&nbsp;Airport</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirRage">&nbsp;&nbsp;Air Rage</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AirRaidWardens">&nbsp;&nbsp;Air Raid Wardens</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Ajami">&nbsp;&nbsp;Ajami</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Ajnabee">&nbsp;&nbsp;Ajnabee</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AJollyBadFellow">&nbsp;&nbsp;A Jolly Bad Fellow</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AJuryOfHerPeers">&nbsp;&nbsp;A Jury Of Her Peers</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AK47">&nbsp;&nbsp;AK 47</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AkeelahAndTheBee">&nbsp;&nbsp;Akeelah And The Bee</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AKidFromTibet">&nbsp;&nbsp;A Kid From Tibet</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AKidInKingArthursCourt">&nbsp;&nbsp;A Kid In King Arthurs Court</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AKidLikeJake">&nbsp;&nbsp;A Kid Like Jake</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AKillersBlues">&nbsp;&nbsp;A Killers Blues</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AKingInNewYork">&nbsp;&nbsp;A King In New York</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AkiraKurosawasDreams">&nbsp;&nbsp;Akira Kurosawas Dreams</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AKnightsTale">&nbsp;&nbsp;A Knights Tale</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Akunin">&nbsp;&nbsp;Akunin</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aladdin1990">&nbsp;&nbsp;Aladdin 1990</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aladdin2019">&nbsp;&nbsp;Aladdin 2019</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlanPartridgeAlphaPapa">&nbsp;&nbsp;Alan Partridge Alpha Papa</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alaska">&nbsp;&nbsp;Alaska</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlbertNobbs">&nbsp;&nbsp;Albert Nobbs</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlbionTheEnchantedStallion">&nbsp;&nbsp;Albion The Enchanted Stallion</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlDiLaDellaLegge">&nbsp;&nbsp;Al Di La Della Legge</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALeagueOfTheirOwn">&nbsp;&nbsp;A League Of Their Own</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AletaVampireMistress">&nbsp;&nbsp;Aleta Vampire Mistress</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALetterToThePresident">&nbsp;&nbsp;A Letter To The President</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALetterToThreeWives">&nbsp;&nbsp;A Letter To Three Wives</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexAndEmma">&nbsp;&nbsp;Alex And Emma</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alexander">&nbsp;&nbsp;Alexander</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexanderAndTheTerribleHorribleNoGoodVeryBadDay">&nbsp;&nbsp;Alexander And The Terrible Horrible No Good Very Bad Day</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexanderNevsky">&nbsp;&nbsp;Alexander Nevsky</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexandersRagtimeBand">&nbsp;&nbsp;Alexanders Ragtime Band</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexanderTheGreat1956">&nbsp;&nbsp;Alexander The Great 1956</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexanderTheGreat1968">&nbsp;&nbsp;Alexander The Great 1968</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexCross">&nbsp;&nbsp;Alex Cross</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlexStrangelove">&nbsp;&nbsp;Alex Strangelove</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alfie">&nbsp;&nbsp;Alfie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Algiers">&nbsp;&nbsp;Algiers</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Ali">&nbsp;&nbsp;Ali</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliAndRatuRatuQueens">&nbsp;&nbsp;Ali And Ratu Ratu Queens</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alibi1929">&nbsp;&nbsp;Alibi 1929</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alice1988">&nbsp;&nbsp;Alice 1988</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alice1990">&nbsp;&nbsp;Alice 1990</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceDoesntLiveHereAnymore">&nbsp;&nbsp;Alice Doesnt Live Here Anymore</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceInMurderland">&nbsp;&nbsp;Alice In Murderland</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceInTheCities">&nbsp;&nbsp;Alice In The Cities</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceInWonderland1949">&nbsp;&nbsp;Alice In Wonderland 1949</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceInWonderland1985">&nbsp;&nbsp;Alice In Wonderland 1985</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceInWonderland1999">&nbsp;&nbsp;Alice In Wonderland 1999</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceInWonderland2010">&nbsp;&nbsp;Alice In Wonderland 2010</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlicesRestaurant">&nbsp;&nbsp;Alices Restaurant</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceSweetAlice">&nbsp;&nbsp;Alice Sweet Alice</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliceThroughTheLookingGlass">&nbsp;&nbsp;Alice Through The Looking Glass</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alien">&nbsp;&nbsp;Alien</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alien2OnEarth">&nbsp;&nbsp;Alien 2 On Earth</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alien3">&nbsp;&nbsp;Alien 3</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alien40thAnniversaryShorts">&nbsp;&nbsp;Alien40th Anniversary Shorts</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienAbduction2014">&nbsp;&nbsp;Alien Abduction 2014</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienAbductionIncidentInLakeCounty">&nbsp;&nbsp;Alien Abduction Incident In Lake County</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienCargo">&nbsp;&nbsp;Alien Cargo</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienCovenant">&nbsp;&nbsp;Alien Covenant</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienFromLA">&nbsp;&nbsp;Alien From LA</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienNation">&nbsp;&nbsp;Alien Nation</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienOutlaw">&nbsp;&nbsp;Alien Outlaw</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienResurrection">&nbsp;&nbsp;Alien Resurrection</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aliens">&nbsp;&nbsp;Aliens</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliensInTheAttic">&nbsp;&nbsp;Aliens In The Attic</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliensVsPredatorRequiem">&nbsp;&nbsp;Aliens Vs Predator Requiem</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienVsNinja">&nbsp;&nbsp;Alien Vs Ninja</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlienVsPredator">&nbsp;&nbsp;Alien Vs Predator</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliFearEatsTheSoul">&nbsp;&nbsp;Ali Fear Eats The Soul</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALifeLessOrdinary">&nbsp;&nbsp;A Life Less Ordinary</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALightBeneathTheirFeet">&nbsp;&nbsp;A Light Beneath Their Feet</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AliGIndahouse">&nbsp;&nbsp;Ali G Indahouse</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alimuom">&nbsp;&nbsp;Alimuom</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aline2021">&nbsp;&nbsp;Aline 2021</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlitaBattleAngel">&nbsp;&nbsp;Alita Battle Angel</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALittleBitZombie">&nbsp;&nbsp;A Little Bit Zombie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALittleChaos">&nbsp;&nbsp;A Little Chaos</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALittleHelp">&nbsp;&nbsp;A Little Help</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALittlePrincess1995">&nbsp;&nbsp;A Little Princess 1995</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alive">&nbsp;&nbsp;Alive</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alive2020">&nbsp;&nbsp;Alive 2020</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlkitrangDugo">&nbsp;&nbsp;Alkitrang Dugo</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllAboutE">&nbsp;&nbsp;All About E</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllAboutEve">&nbsp;&nbsp;All About Eve</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllAboutLilyChouChou">&nbsp;&nbsp;All About Lily Chou Chou</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllAboutMyMother">&nbsp;&nbsp;All About My Mother</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllAboutSteve">&nbsp;&nbsp;All About Steve</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllCheerleadersDie">&nbsp;&nbsp;All Cheerleaders Die</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlleluiaTheDevilsCarnival">&nbsp;&nbsp;Alleluia The Devils Carnival</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllesIsFamilie">&nbsp;&nbsp;Alles Is Familie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllesIsLiefde">&nbsp;&nbsp;Alles Is Liefde</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlleyCatsStrike">&nbsp;&nbsp;Alley Cats Strike</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllEyezOnMe">&nbsp;&nbsp;All Eyez On Me</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllGoodThings2010">&nbsp;&nbsp;All Good Things 2010</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllHailTheKing">&nbsp;&nbsp;All Hail The King</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllHallowsEve">&nbsp;&nbsp;All Hallows Eve</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Allied">&nbsp;&nbsp;Allied</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alligator">&nbsp;&nbsp;Alligator</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlligatorPie">&nbsp;&nbsp;Alligator Pie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllIsLost">&nbsp;&nbsp;All Is Lost</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllIsTrue">&nbsp;&nbsp;All Is True</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllIWantForChristmas">&nbsp;&nbsp;All I Want For Christmas</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllMonstersAttack">&nbsp;&nbsp;All Monsters Attack</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllMyFriendsAreDead">&nbsp;&nbsp;All My Friends Are Dead</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllMyFriendsHateMe">&nbsp;&nbsp;All My Friends Hate Me</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllMyLovedOnes">&nbsp;&nbsp;All My Loved Ones</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllOfMe">&nbsp;&nbsp;All Of Me</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllQuietOnTheWesternFront">&nbsp;&nbsp;All Quiet On The Western Front</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllQuietOnTheWesternFront1930">&nbsp;&nbsp;All Quiet On The Western Front 1930</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllQuietOnTheWesternFront2022">&nbsp;&nbsp;All Quiet On The Western Front 2022</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllSuperheroesMustDie">&nbsp;&nbsp;All Superheroes Must Die</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllThatHeavenAllows">&nbsp;&nbsp;All That Heaven Allows</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllThatJazz">&nbsp;&nbsp;All That Jazz</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheBeautyAndTheBloodshed">&nbsp;&nbsp;All The Beauty And The Bloodshed</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheBoysLoveMandyLane">&nbsp;&nbsp;All The Boys Love Mandy Lane</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheMarbles">&nbsp;&nbsp;All The Marbles</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheMoneyInTheWorld">&nbsp;&nbsp;All The Money In The World</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheOldKnives">&nbsp;&nbsp;All The Old Knives</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllThePresidentsMen">&nbsp;&nbsp;All The Presidents Men</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheRealGirls">&nbsp;&nbsp;All The Real Girls</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheseCreatures">&nbsp;&nbsp;All These Creatures</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllTheTroublesOfTheWorld">&nbsp;&nbsp;All The Troubles Of The World</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllThingsFair">&nbsp;&nbsp;All Things Fair</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllThisAndHeavenToo">&nbsp;&nbsp;All This And Heaven Too</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AllThroughTheNight">&nbsp;&nbsp;All Through The Night</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlludaMajaka">&nbsp;&nbsp;Alluda Majaka</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmightyThor">&nbsp;&nbsp;Almighty Thor</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmostAnAngel">&nbsp;&nbsp;Almost An Angel</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmostAngels">&nbsp;&nbsp;Almost Angels</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmostFamous">&nbsp;&nbsp;Almost Famous</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmostHeroes">&nbsp;&nbsp;Almost Heroes</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmostHuman">&nbsp;&nbsp;Almost Human</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlmostSummer">&nbsp;&nbsp;Almost Summer</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Aloha">&nbsp;&nbsp;Aloha</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlohaBobbyAndRose">&nbsp;&nbsp;Aloha Bobby And Rose</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AloneInTheDark1982">&nbsp;&nbsp;Alone In The Dark 1982</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AloneInTheDark2005">&nbsp;&nbsp;Alone In The Dark 2005</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALonelyPlaceToDie">&nbsp;&nbsp;A Lonely Place To Die</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AloneWithHer">&nbsp;&nbsp;Alone With Her</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlongCameASpider">&nbsp;&nbsp;Along Came A Spider</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlongCamePolly">&nbsp;&nbsp;Along Came Polly</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALongWayDown">&nbsp;&nbsp;A Long Way Down</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlongWithTheGodsTheTwoWorlds">&nbsp;&nbsp;Along With The Gods The Two Worlds</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALoudHouseChristmas">&nbsp;&nbsp;A Loud House Christmas</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALoveDivided">&nbsp;&nbsp;A Love Divided</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/ALowDownDirtyShame">&nbsp;&nbsp;A Low Down Dirty Shame</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alpha2018">&nbsp;&nbsp;Alpha 2018</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlphaDog">&nbsp;&nbsp;Alpha Dog</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alphaville">&nbsp;&nbsp;Alphaville</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alps">&nbsp;&nbsp;Alps</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlreadyTomorrowInHongKong">&nbsp;&nbsp;Already Tomorrow In Hong Kong</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlsinoAndTheCondor">&nbsp;&nbsp;Alsino And The Condor</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlteredStates">&nbsp;&nbsp;Altered States</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Altitude">&nbsp;&nbsp;Altitude</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Altitude2017">&nbsp;&nbsp;Altitude 2017</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Alto">&nbsp;&nbsp;Alto</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlvinAndTheChipmunks">&nbsp;&nbsp;Alvin And The Chipmunks</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlvinPurple">&nbsp;&nbsp;Alvin Purple</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Always">&nbsp;&nbsp;Always</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlwaysBeMyMaybe">&nbsp;&nbsp;Always Be My Maybe</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlwaysCrashingInTheSameCar">&nbsp;&nbsp;Always Crashing In The Same Car</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AlwaysWatchingAMarbleHornetsStory">&nbsp;&nbsp;Always Watching A Marble Hornets Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AM1200">&nbsp;&nbsp;AM 1200</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Amal">&nbsp;&nbsp;Amal</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManAndAWoman">&nbsp;&nbsp;A Man And A Woman</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManCalledHorse">&nbsp;&nbsp;A Man Called Horse</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManCalledNereus">&nbsp;&nbsp;A Man Called Nereus</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManCalledSledge">&nbsp;&nbsp;A Man Called Sledge</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManCalledTiger">&nbsp;&nbsp;A Man Called Tiger</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmandaKnoxMurderOnTrialInItaly">&nbsp;&nbsp;Amanda Knox Murder On Trial In Italy</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManEscaped">&nbsp;&nbsp;A Man Escaped</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AManWithAMaid">&nbsp;&nbsp;A Man With A Maid</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmarAkbarAnthony">&nbsp;&nbsp;Amar Akbar Anthony</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Amarcord">&nbsp;&nbsp;Amarcord</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AMarineStory">&nbsp;&nbsp;A Marine Story</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmarTeDuele">&nbsp;&nbsp;Amar Te Duele</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AMaSoeur">&nbsp;&nbsp;A Ma Soeur</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AMatterOfFaith">&nbsp;&nbsp;A Matter Of Faith</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AMatterOfLifeAndDeath">&nbsp;&nbsp;A Matter Of Life And Death</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmazingGrace">&nbsp;&nbsp;Amazing Grace</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmazingGraceAndChuck">&nbsp;&nbsp;Amazing Grace And Chuck</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Amazons">&nbsp;&nbsp;Amazons</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmazonWomenOnTheMoon">&nbsp;&nbsp;Amazon Women On The Moon</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Ambassada">&nbsp;&nbsp;Ambassada</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmberAlert">&nbsp;&nbsp;Amber Alert</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Ambulance">&nbsp;&nbsp;Ambulance</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Ambush">&nbsp;&nbsp;Ambush</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Amelia">&nbsp;&nbsp;Amelia</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Amelie">&nbsp;&nbsp;Amelie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/Amen">&nbsp;&nbsp;Amen</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/America">&nbsp;&nbsp;America</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/America3000">&nbsp;&nbsp;America 3000</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericaAmerica">&nbsp;&nbsp;America America</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanAnimals">&nbsp;&nbsp;American Animals</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanAssassin">&nbsp;&nbsp;American Assassin</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanBeauty">&nbsp;&nbsp;American Beauty</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanCarnage">&nbsp;&nbsp;American Carnage</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanCyborgSteelWarrior">&nbsp;&nbsp;American Cyborg Steel Warrior</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanDescent">&nbsp;&nbsp;American Descent</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanDreamer">&nbsp;&nbsp;American Dreamer</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanDreamz">&nbsp;&nbsp;American Dreamz</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanFactory">&nbsp;&nbsp;American Factory</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanGangster">&nbsp;&nbsp;American Gangster</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanGigolo">&nbsp;&nbsp;American Gigolo</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanGothic1988">&nbsp;&nbsp;American Gothic 1988</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanGraffiti">&nbsp;&nbsp;American Graffiti</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanHistoryX">&nbsp;&nbsp;American History X</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanHoney">&nbsp;&nbsp;American Honey</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanHustle">&nbsp;&nbsp;American Hustle</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanJustice">&nbsp;&nbsp;American Justice</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanMade">&nbsp;&nbsp;American Made</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanMary">&nbsp;&nbsp;American Mary</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanMe">&nbsp;&nbsp;American Me</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanMeltdown">&nbsp;&nbsp;American Meltdown</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanMovie">&nbsp;&nbsp;American Movie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanNightmare">&nbsp;&nbsp;American Nightmare</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanNightmare1983">&nbsp;&nbsp;American Nightmare 1983</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanNinja">&nbsp;&nbsp;American Ninja</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanOutlaws">&nbsp;&nbsp;American Outlaws</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanPie">&nbsp;&nbsp;American Pie</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanPiePresentsBetaHouse">&nbsp;&nbsp;American Pie Presents Beta House</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanPsycho">&nbsp;&nbsp;American Psycho</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanPsycho2AllAmericanGirl">&nbsp;&nbsp;American Psycho 2 All American Girl</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanRenegades">&nbsp;&nbsp;American Renegades</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanReunion">&nbsp;&nbsp;American Reunion</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanSatan">&nbsp;&nbsp;American Satan</a></td></tr><tr><td><a href="http://tvtropes.org/pmwiki/pmwiki.php/Film/AmericanScarecrow">&nbsp;&nbsp;American Scarecrow</a></td></tr>
+</table>
+
+<nav class="pagination-box button-group text-center gutter-topx2" data-total-pages="35" data-url-prefix="pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=">
+
+	<span class="pagination-jump-box-wrapper mobile-on">
+	<form class="pagination-jump-box hidden-until-active font-m">
+		<input value="1" type="tel">
+		<a href="#jump-to-page" title="Jump to page" class="color-white dead-button" onClick="activate_jump_menu(this);return false;">GO <i class="fa fa-angle-right"></i></a>
+	</form>
+	</span>
+
+	
+	
+	    	<a href="pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=1" class="mobile-off ">
+    	<span class="current-page">    	1    	</span>    </a>
+		<a href="pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=2" class="mobile-off ">
+    	    	2    	    </a>
+		<a href="pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=3" class="mobile-off ">
+    	    	3    	    </a>
+	
+		<a href="#jump-to-page" title="Jump to page" class="pagination-jump-box-toggle mobile-on dead-button" onClick="toggle_jump_menu(this);return false;">
+		<span class="font-s">page 1 of 35</span>
+  </a>
+
+	    <a href="pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=2">
+    	<span class="mobile-on"><i class="fa fa-angle-right"></i></span>
+    	<span class="mobile-off">Next</span>
+    </a>
+    
+    	<a href="pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=35">
+    	<i class="fa fa-angle-double-right"></i>
+    </a>
+	
+</nav>
+
+
+<script type="text/javascript">
+
+	function toggle_jump_menu(e){
+		$(e).siblings('.pagination-jump-box-wrapper').children('.pagination-jump-box').toggle('active');
+	}
+
+	function activate_jump_menu(e){
+			var p = $(e).siblings('input').val();
+			var t = $(e).closest('.pagination-box').data('total-pages');
+
+			if(p > 0 && p <= t){
+					window.location.href = $(e).closest('.pagination-box').data('url-prefix') + p;
+			}else{
+					show_modal('alert',encodeURIComponent('Whoops, that page might be out of range.'));
+			}
+	}
+
+</script>
+
+</div>
+</div>
+
+
+
+
+
+
+                
+
+                
+            </div>
+
+                
+                        <div id="main-content-sidebar"><div class="sidebar-item display-options">
+  <ul class="sidebar display-toggles">
+    <li>Show Spoilers <div id="sidebar-toggle-showspoilers" class="display-toggle show-spoilers"></div></li>
+    <li>Night Vision <div id="sidebar-toggle-nightvision" class="display-toggle night-vision"></div></li>
+    <li>Sticky Header <div id="sidebar-toggle-stickyheader" class="display-toggle sticky-header"></div></li>
+    <li>Wide Load <div id="sidebar-toggle-wideload" class="display-toggle wide-load"></div></li>
+  </ul>
+  <script>updateDesktopPrefs();</script>
+</div>
+
+        <div class="sidebar-item quick-links" itemtype="http://schema.org/SiteNavigationElement">
+
+        <p class="sidebar-item-title" data-title="Important Links">Important Links</p>
+
+        <div class="padded">
+            <a href="/pmwiki/query.php?type=att">Ask The Tropers</a>
+            <a href="/pmwiki/query.php?type=tf">Trope Finder</a>
+            <a href="/pmwiki/query.php?type=ykts">You Know That Show...</a>
+            <a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a>
+            <a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+            <a href="/pmwiki/review_activity.php">Reviews</a>
+            <a href="/pmwiki/ad-free-subscribe.php">Go Ad Free!</a>
+            <div class="crucial_browsing_dropdown">
+                <a href="javascript:void(0);" onclick="double_dropdown(); return false;" id="crucial_browsing_dropdown"><span class="new_blue">Crucial Browsing</span><i class="fa fa-angle-down"></i></a>
+                <ul id="main_dropdown">
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Genre</a>
+                        <ul>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ActionAdventureTropes' title='Main/ActionAdventureTropes'>Action Adventure</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ComedyTropes' title='Main/ComedyTropes'>Comedy</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CommercialsTropes' title='Main/CommercialsTropes'>Commercials</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/CrimeAndPunishmentTropes' title='Main/CrimeAndPunishmentTropes'>Crime &amp; Punishment</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/DramaTropes' title='Main/DramaTropes'>Drama</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/HorrorTropes' title='Main/HorrorTropes'>Horror</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/LoveTropes' title='Main/LoveTropes'>Love</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/NewsTropes' title='Main/NewsTropes'>News</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/ProfessionalWrestling' title='Main/ProfessionalWrestling'>Professional Wrestling</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SpeculativeFictionTropes' title='Main/SpeculativeFictionTropes'>Speculative Fiction</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/SportsStoryTropes' title='Main/SportsStoryTropes'>Sports Story</a></li>
+                            <li><a href='/pmwiki/pmwiki.php/Main/WarTropes' title='Main/WarTropes'>War</a></li>
+                            <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Media</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Media" title="Main/Media">All Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AnimationTropes" title="Main/AnimationTropes">Animation (Western)</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Anime" title="Main/Anime">Anime</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ComicBookTropes" title="Main/ComicBookTropes">Comic Book</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FanFic" title="FanFic/FanFics">Fan Fics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Film" title="Main/Film">Film</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/GameTropes" title="Main/GameTropes">Game</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Literature" title="Main/Literature">Literature</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MusicAndSoundEffects" title="Main/MusicAndSoundEffects">Music And Sound Effects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NewMediaTropes" title="Main/NewMediaTropes">New Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PrintMediaTropes" title="Main/PrintMediaTropes">Print Media</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Radio" title="Main/Radio">Radio</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SequentialArt" title="Main/SequentialArt">Sequential Art</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TabletopGames" title="Main/TabletopGames">Tabletop Games</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/UsefulNotes/Television" title="Main/Television">Television</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Theater" title="Main/Theater">Theater</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/VideogameTropes" title="Main/VideogameTropes">Videogame</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Webcomics" title="Main/Webcomics">Webcomics</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Narrative</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/UniversalTropes" title="Main/UniversalTropes">Universal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/AppliedPhlebotinum" title="Main/AppliedPhlebotinum">Applied Phlebotinum</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharacterizationTropes" title="Main/CharacterizationTropes">Characterization</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Characters" title="Main/Characters">Characters</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CharactersAsDevice" title="Main/CharactersAsDevice">Characters As Device</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Dialogue" title="Main/Dialogue">Dialogue</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Motifs" title="Main/Motifs">Motifs</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/NarrativeDevices" title="Main/NarrativeDevices">Narrative Devices</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Paratext" title="Main/Paratext">Paratext</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Plots" title="Main/Plots">Plots</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Settings" title="Main/Settings">Settings</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Spectacle" title="Main/Spectacle">Spectacle</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Other Categories</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BritishTellyTropes" title="Main/BritishTellyTropes">British Telly</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TheContributors" title="Main/TheContributors">The Contributors</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CreatorSpeak" title="Main/CreatorSpeak">Creator Speak</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Creators" title="Main/Creators">Creators</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DerivativeWorks" title="Main/DerivativeWorks">Derivative Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LanguageTropes" title="Main/LanguageTropes">Language</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/LawsAndFormulas" title="Main/LawsAndFormulas">Laws And Formulas</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ShowBusiness" title="Main/ShowBusiness">Show Business</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SplitPersonalityTropes" title="Main/SplitPersonalityTropes">Split Personality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/StockRoom" title="Main/StockRoom">Stock Room</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeTropes" title="Main/TropeTropes">Trope</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/Tropes" title="Main/Tropes">Tropes</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthAndLies" title="Main/TruthAndLies">Truth And Lies</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TruthInTelevision" title="Main/TruthInTelevision">Truth In Television</a></li>
+                        </ul>
+                    </li>
+
+                    <li class="first_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Topical Tropes</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/BetrayalTropes" title="Main/BetrayalTropes">Betrayal</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CensorshipTropes" title="Main/CensorshipTropes">Censorship</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/CombatTropes" title="Main/CombatTropes">Combat</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/DeathTropes" title="Main/DeathTropes">Death</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FamilyTropes" title="Main/FamilyTropes">Family</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FateAndProphecyTropes" title="Main/FateAndProphecyTropes">Fate And Prophecy</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/FoodTropes" title="Main/FoodTropes">Food</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/HolidayTropes" title="Main/HolidayTropes">Holiday</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MemoryTropes" title="Main/MemoryTropes">Memory</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoneyTropes" title="Main/MoneyTropes">Money</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/MoralityTropes" title="Main/MoralityTropes">Morality</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/PoliticsTropes" title="Main/PoliticsTropes">Politics</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ReligionTropes" title="Main/ReligionTropes">Religion</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/SchoolTropes" title="Main/SchoolTropes">School</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="resources_dropdown">
+                <a href="javascript:void(0);" onclick="second_double_dropdown(); return false;" id="resources_dropdown"><span class="new_blue blue">Resources</span><i class="fa fa-angle-down"></i></a>
+
+                <ul id="second_main_dropdown" class="padded font-s" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                                        <li class="second_dropdown"><a href="#test" data-click-toggle="active">Tools</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/IttyBittyWikiTools">Wiki Tools</a></li>
+                            <li><a href="/pmwiki/cutlist.php">Cut List</a></li>
+                            <li><a href="/pmwiki/changes.php">New Edits</a></li>
+                            <li><a href="/pmwiki/recent_edit_reasons.php">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/isolated_pages.php">Isolated Pages</a></li> 
+                            <li><a href="/pmwiki/launches.php">Launches</a></li>
+                            <li><a href="/pmwiki/img_list.php">Images List</a></li>
+                            <li><a href="/pmwiki/recent_videos.php">Recent Videos</a></li>
+                            <li><a href="/pmwiki/crown_activity.php">Crowner Activity</a></li>
+                            <li><a href="/pmwiki/no_types.php">Un-typed Pages</a></li>
+                            <li><a href="/pmwiki/page_type_audit.php">Recent Page Type Changes</a></li>
+                            <li><a href="/pmwiki/changelog.php">Changelog</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Templates</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Main/TropeEntryTemplate">Trope Entry</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Main/ProgramEntryTemplate">Works</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CharacterSheetTemplate">Character Sheet</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/PlayingWithWikiTemplate">Playing With</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/FanficRecs/TemplatePageForNewFandomRecommendations">Fandom</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="javascript:void(0);" data-click-toggle="active">Tips</a>
+                        <ul>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/CreatingNewRedirects">Creating New Redirects</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/Crosswicking">Cross Wicking</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TipsForEditing">Tips for Editing</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TextFormattingRules">Text Formatting Rules</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesGlossary">Glossary</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/EditReasonsAndWhyYouShouldUseThem">Edit Reasons</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/HandlingSpoilers">Handling Spoilers</a></li>
+                            <li><a href="/pmwiki/pmwiki.php/Administrivia/WordCruft">Word Cruft</a></li>
+                        </ul>
+                    </li>
+                    <li class="second_dropdown"><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=renames">Trope Repair Shop</a></li>
+                    <li class="second_dropdown"><a href="/pmwiki/conversations.php?topic=images">Image Pickin'</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="asteri-sidebar" style="display:none">
+            <p style="margin-top: 20px;" class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="asteri_cont"></div>
+        </div>
+        <script>
+            //asteri enabled
+            if((tvtropes_config.asteri_stream_enabled || tvtropes_config.get_asteri_stream == 'live')) {
+                //aster stream currently live and not a logged-in troper
+                if(!tvtropes_config.is_logged_in && cookies.read('asteri_event_active') != '') {
+                    document.getElementById('asteri-sidebar').style.display="";
+                }
+            }
+        </script>
+
+    </div>
+
+        
+            
+
+    
+        
+            <script>
+    if(!is_mobile()) {
+
+        //don't insert if content is too small on page
+        var tropes_insert_side_ad=true;
+        if(document.getElementById("main-article") && document.getElementById("main-article").clientHeight) {
+            var sidebar_height=document.getElementById("main-article").clientHeight;
+            if(sidebar_height>0 && sidebar_height<500) {
+                tropes_insert_side_ad=false;
+                console.log('ad parser: content too small for sidebar ad');
+            }
+        }
+
+        if(tropes_insert_side_ad) {
+
+       document.write(`
+        <div id="stick-cont"  class="sidebar-item sb-fad-unit">
+            <p class="sidebar-item-title" data-title="Advertisement">Advertisement:</p>
+            <div id="stick-bar" class="sidebar-section">
+                <div class="square_fad fad-size-300x600 fad-section text-center">
+                    <div class='tvtropes-ad-unit '>
+                      <div id='tvtropes_dt_inview' class='htlad-tvtropes_dt_inview'></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        `);
+        }
+
+    }
+    </script>
+    
+
+</div>
+        
+    </div>
+
+        <div id="action-bar-bottom" class="action-bar tablet-off">
+        <a href="#top-of-page" class="scroll-to-top dead-button" onclick="$('html, body').animate({scrollTop : 0},500);">Top</a>
+    </div>
+    
+</div>    <footer id="main-footer">
+        <div id="main-footer-inner">
+
+
+            <div class="footer-left">
+
+                <a href="/" class="img-link"><img data-src="/img/tvtropes-footer-logo.png" alt="TV Tropes" class="logo_image lazy-image" title="TV Tropes" /></a>
+
+                <form action="index.html" id="cse-search-box-mobile" class="navbar-form newsletter-signup validate modal-replies" name="" role="" data-ajax-get="/ajax/subscribe_email.php">
+
+                    <button class="btn-submit newsletter-signup-submit-button" type="submit" id="subscribe-btn"><i class="fa fa-paper-plane"></i></button>
+                    <input id="subscription-email" type="text" class="form-control" name="q" size="31" placeholder="Subscribe" value="" validate-type="email">
+
+                </form>
+
+                <ul class="social-buttons">
+                   <li><a class="btn fb" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-facebook']);" href="https://www.facebook.com/tvtropes"><i class="fa fa-facebook"></i></a></li>
+                   <li><a class="btn tw" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-twitter']);" href="https://www.twitter.com/tvtropes"><i class="fa fa-twitter"></i></a> </li>
+                                      <li><a class="btn rd" target="_blank" onclick="_gaq.push(['_trackEvent', 'btn-social-icon', 'click', 'btn-reddit']);" href="https://www.reddit.com/r/tvtropes"><i class="fa fa-reddit-alien"></i></a></li>
+                                   </ul>
+
+            </div>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">TVTropes</h4></li>
+                <li><a href="/pmwiki/pmwiki.php/Main/Administrivia">About TVTropes</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheGoalsOfTVTropes">TVTropes Goals</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TheTropingCode">Troping Code</a></li>
+                <li><a href="/pmwiki/pmwiki.php/Administrivia/TVTropesCustoms">TVTropes Customs</a></li>
+                <li><a href="/pmwiki/pmwiki.php/JustForFun/TropesOfLegend">Tropes of Legend</a></li>
+                <li><a href="/pmwiki/ad-free-subscribe.php">Go Ad-Free</a></li>
+                            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Community</h4></li>
+                <li><a href="/pmwiki/query.php?type=att">Ask The Tropers</a></li>
+                <li><a href="/pmwiki/tlp_activity.php">Trope Launch Pad</a></li>
+                <li><a href="/pmwiki/query.php?type=tf">Trope Finder</a></li>
+                <li><a href="/pmwiki/query.php?type=ykts">You Know That Show</a></li>
+                <li><a href="/pmwiki/lbs.php" data-modal-target="login">Live Blogs</a></li>
+                <li><a href="/pmwiki/query.php?type=wl">Wishlist</a></li>
+                <li><a href="/pmwiki/review_activity.php">Reviews</a></li>
+                <li><a href="/pmwiki/topics.php">Forum</a></li>
+            </ul>
+
+            <hr/>
+
+            <ul class="footer-menu" itemscope itemtype="http://schema.org/SiteNavigationElement">
+                <li><h4 class="footer-menu-header">Tropes HQ</h4></li>
+                <li><a href="/pmwiki/about.php">About Us</a></li>
+                                <li><a href="/pmwiki/contact.php">Contact Us</a></li>
+                <li><a href="/pmwiki/query.php?type=bug">Report Bug</a></li>
+                <li><a href="/pmwiki/dmca.php">DMCA Notice</a></li>
+                <li><a href="/pmwiki/privacypolicy.php">Privacy Policy</a></li>
+
+            </ul>
+
+        </div>
+
+        <div id="desktop-on-mobile-toggle" class="text-center gutter-top gutter-bottom tablet-on">
+          <a href="/pmwiki/switchDeviceCss.php?mobileVersion=1" rel="nofollow">Switch to <span class="txt-desktop">Desktop</span><span class="txt-mobile">Mobile</span> Version</a>
+        </div>
+
+        <div class="legal">
+            <p>TVTropes is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License. <br>Permissions beyond the scope of this license may be available from <a xmlns:cc="http://creativecommons.org/ns#" href="mailto:thestaff@tvtropes.org" rel="cc:morePermissions"> thestaff@tvtropes.org</a>.</p>
+            <br>
+            <div class="privacy_wrapper">
+            </div>
+        </div>
+    </footer>
+    
+    
+    <style>
+      div.fc-ccpa-root {
+        position: absolute !important;
+        bottom: 93px !important;
+        margin: auto !important;
+        width: 100% !important;
+        z-index: 9999 !important;
+        overflow: hidden !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link p{
+        outline: none !important;
+        text-decoration: underline !important;
+        font-size: .7em !important;
+        font-family: sans-serif !important;
+      }
+      .fc-ccpa-root .fc-dns-dialog .fc-dns-link .fc-button-background {
+        background: none !important;
+      }
+    </style>
+
+        <div id="_pm_videoViewer" class="full-screen">
+
+  <a href="#close" class="close" id="_pm_videoViewer-close"></a>
+
+  <div class="_pmvv-body">
+
+    <div class="_pmvv-vidbox">
+
+        
+    </div>
+
+  </div>
+
+  
+</div>
+
+        
+    
+    
+        <script type="text/javascript">
+
+        var cleanCreativeEnabled = "";
+        var donation = "";
+        var live_ads = "1";
+        var img_domain = "https://static.tvtropes.org";
+        var snoozed = cookies.read('snoozedabm');
+        var snoozable = "";
+
+        var elem = document.createElement('script');
+        elem.async = true;
+
+        elem.src = 'https://assets.tvtropes.org/design/assets/bundle.js?rev=d77d98b7671da37d9a794abba2c9266166e994c0';
+
+        elem.onload = function() {
+                                 }
+        document.getElementsByTagName('head')[0].appendChild(elem);
+
+    </script>
+
+
+    
+    
+
+    
+    
+  <script type="text/javascript">
+      function send_analytics_event(user_type, donation){
+          // if(user_type == 'uncached' || user_type == 'cached'){
+          //   ga('send', 'event', 'caching', 'load', user_type, {'nonInteraction': 1});
+          //   return;
+          // }
+          var event_name = user_type;
+
+          if(donation == 'true'){
+              event_name += "_donation"
+          }else if(typeof(valid_user) == 'undefined'){
+              event_name += "_blocked"
+          }else if(valid_user == true){
+              event_name += "_unblocked";
+          }else{
+              event_name = "_unknown"
+          }
+          ga('send', 'event', 'ads', 'load', event_name, {'nonInteraction': 1});
+      }
+
+    
+    send_analytics_event("guest", "false");
+      </script>
+
+
+<script>
+    ga('send', 'event', 'ab_test_type', "1", 'ab_testing', {'nonInteraction': 1});
+</script>
+
+
+
+<!-- Quantcast Tag -->
+<script type="text/javascript">
+  window._qevents = window._qevents || [];
+
+  (function() {
+    var elem = document.createElement('script');
+    elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+    elem.async = true;
+    elem.type = "text/javascript";
+    var scpt = document.getElementsByTagName('script')[0];
+    scpt.parentNode.insertBefore(elem, scpt);
+  })();
+
+  window._qevents.push({
+      qacct:"p-mEzuYq24VEJ-3"
+  });
+</script>
+
+<noscript>
+  <div style="display:none;">
+    <img src="//pixel.quantserve.com/pixel/p-mEzuYq24VEJ-3.gif" border="0" height="1" width="1" alt="Quantcast"/>
+  </div>
+</noscript>
+<!-- End Quantcast tag -->
+
+
+<!-- Begin comScore Tag -->
+<script>
+  var _comscore = _comscore || [];
+  _comscore.push({ c1: "2", c2: "38282685" });
+  (function() {
+    var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+    s.src = "https://sb.scorecardresearch.com/cs/38282685/beacon.js";
+    el.parentNode.insertBefore(s, el);
+  })();
+</script>
+<noscript>
+  <img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=38282685&amp;cv=3.6.0&amp;cj=1">
+</noscript>
+<!-- End comScore Tag -->
+</body>
+</html>

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -279,7 +279,9 @@ func (scraper *ServiceScraper) ScrapeTvTropes(tvtropespages *tropestogo.TvTropes
 	for page, tvtropessubpages := range tvtropespages.Pages {
 		var subPages []tropestogo.Page
 		for subPage := range tvtropessubpages.Subpages {
-			subPages = append(subPages, subPage)
+			if subPage.GetPageType() == tropestogo.WorkPage {
+				subPages = append(subPages, subPage)
+			}
 		}
 
 		scraper.ScrapeTvTropesPage(page, subPages)

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -263,7 +263,11 @@ func (scraper *ServiceScraper) CheckIsSubWiki(doc *goquery.Document) bool {
 	namespace := strings.ToLower(scraper.ScrapeNamespace(doc))
 	title, year, _, errMediatype := scraper.ScrapeWorkTitleAndYear(doc)
 
-	r, _ := regexp.Compile(strings.ToLower(strings.ReplaceAll(`\/`+namespace+`\/`+title+year, " ", "")))
+	// Remove all non-alphanumeric characters from the title
+	r, _ := regexp.Compile(`[^\p{L}\p{N} ]+`)
+	title = r.ReplaceAllString(title, "")
+
+	r, _ = regexp.Compile(strings.ToLower(strings.ReplaceAll(`\/`+namespace+`\/`+title+year, " ", "")))
 	matchUri := r.MatchString(strings.ToLower(subpageUri))
 
 	articleTitle := strings.ReplaceAll(scraper.ScrapeSubpageFullTitle(doc), "(", "")

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -424,6 +424,9 @@ func (scraper *ServiceScraper) ScrapeTropes(doc *goquery.Document, selector stri
 	doc.Find(selector).Each(func(_ int, selection *goquery.Selection) {
 		tropeUri, tropeUriExists := selection.Attr("href")
 		if tropeUriExists {
+			// Get only the URI (if the href has the full URL, which happens sometimes)
+			tropeUri = strings.ReplaceAll(tropeUri, TvTropesWeb, "")
+
 			subPage := ""
 			if scraper.CheckIsSubWiki(doc) {
 				subPage = scraper.ScrapeNamespace(doc)

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -228,8 +228,12 @@ func (scraper *ServiceScraper) CheckIsMainSubpage(doc *goquery.Document) bool {
 	title := scraper.ScrapeNamespace(doc)
 	currentUrl := doc.Find(CurrentUrlSelector).Text()
 
+	// Remove all non-alphanumeric characters from the title
+	r, _ := regexp.Compile(`[^\p{L}\p{N} ]+`)
+	title = r.ReplaceAllString(title, "")
+
 	title = strings.ToLower(strings.ReplaceAll(title, " ", ""))
-	r, _ := regexp.Compile(`\/` + title + `\/tropes[a-z]to[a-z]`)
+	r, _ = regexp.Compile(`\/` + title + `\/tropes[a-z]to[a-z]`)
 	matchUri := scraper.CheckSubpageUri(currentUrl, title)
 	matchTitle := r.MatchString(strings.ToLower(scraper.ScrapeSubpageFullTitle(doc)))
 
@@ -240,8 +244,12 @@ func (scraper *ServiceScraper) CheckIsMainSubpage(doc *goquery.Document) bool {
 // Checks if the elements of the list are anchors to a subpage inside the work
 // A regex matches if the last part of the URL is of the type TropesXtoY and is preceded by the work title name, returning true or false
 func (scraper *ServiceScraper) CheckSubpageUri(URI, title string) bool {
+	// Remove all non-alphanumeric characters from the title
+	r, _ := regexp.Compile(`[^\p{L}\p{N} ]+`)
+	title = r.ReplaceAllString(title, "")
+
 	title = strings.ToLower(strings.ReplaceAll(title, " ", ""))
-	r, _ := regexp.Compile(`\/` + title + `\/tropes[a-z]to[a-z]`)
+	r, _ = regexp.Compile(`\/` + title + `\/tropes[a-z]to[a-z]`)
 	match := r.MatchString(strings.ToLower(URI))
 
 	return match

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -229,7 +229,7 @@ func (scraper *ServiceScraper) CheckIsMainSubpage(doc *goquery.Document) bool {
 	currentUrl := doc.Find(CurrentUrlSelector).Text()
 
 	// Remove all non-alphanumeric characters from the title
-	r, _ := regexp.Compile(`[^\p{L}\p{N} ]+`)
+	r, _ := regexp.Compile(`[^\/\p{L}\p{N} ]+`)
 	title = r.ReplaceAllString(title, "")
 
 	title = strings.ToLower(strings.ReplaceAll(title, " ", ""))
@@ -245,7 +245,7 @@ func (scraper *ServiceScraper) CheckIsMainSubpage(doc *goquery.Document) bool {
 // A regex matches if the last part of the URL is of the type TropesXtoY and is preceded by the work title name, returning true or false
 func (scraper *ServiceScraper) CheckSubpageUri(URI, title string) bool {
 	// Remove all non-alphanumeric characters from the title
-	r, _ := regexp.Compile(`[^\p{L}\p{N} ]+`)
+	r, _ := regexp.Compile(`[^\/\p{L}\p{N} ]+`)
 	title = r.ReplaceAllString(title, "")
 
 	title = strings.ToLower(strings.ReplaceAll(title, " ", ""))
@@ -264,14 +264,13 @@ func (scraper *ServiceScraper) CheckIsSubWiki(doc *goquery.Document) bool {
 	title, year, _, errMediatype := scraper.ScrapeWorkTitleAndYear(doc)
 
 	// Remove all non-alphanumeric characters from the title
-	r, _ := regexp.Compile(`[^\p{L}\p{N} ]+`)
-	title = r.ReplaceAllString(title, "")
+	alphanumericRegex, _ := regexp.Compile(`[^\/\p{L}\p{N} ]+`)
+	title = alphanumericRegex.ReplaceAllString(title, "")
 
-	r, _ = regexp.Compile(strings.ToLower(strings.ReplaceAll(`\/`+namespace+`\/`+title+year, " ", "")))
+	r, _ := regexp.Compile(strings.ToLower(strings.ReplaceAll(`\/`+namespace+`\/`+title+year, " ", "")))
 	matchUri := r.MatchString(strings.ToLower(subpageUri))
 
-	articleTitle := strings.ReplaceAll(scraper.ScrapeSubpageFullTitle(doc), "(", "")
-	articleTitle = strings.ReplaceAll(articleTitle, ")", "")
+	articleTitle := alphanumericRegex.ReplaceAllString(scraper.ScrapeSubpageFullTitle(doc), "")
 	matchTitle := r.MatchString(strings.ToLower(articleTitle))
 
 	return matchUri && matchTitle && errMediatype != nil


### PR DESCRIPTION
Con este PR se da una primera versión del crawler completamente funcional que realiza lo siguiente:

- Empieza el crawling en la pagina https://tvtropes.org/pmwiki/pagelist_having_pagetype_in_namespace.php?n=Film&t=work&page=1 donde están todas las películas de TvTropes y extrae cada una de ellas y las sub páginas que pueda tener dentro (tanto subwikis como sub paginas con tropos principales, si las hubiera). Explora todas las páginas del índice, encontrando todas las películas y las almacena en la entidad TvTropesPages, que tiene todas las pelis con sus sub paginas, y que es con lo que luego puede trabajar el scraper para hacer la propia extraccion de informacion (closes #55 closes #89)
- Se da la opción de poder hacer crawling de un número limitado de películas, en lugar de sacarlas todas, lo cual facilita hacer tests y demos y no sobrecargar TvTropes (closes #91)
- Se realizan cambios para intentar solucionar #35, principalmente dando un delay de medio segundo entre cada peticion HTTP para no agobiar TvTropes, y en caso de denegación temporal de acceso se hace una espera mas larga. No se termina de resolver el issue por completo, ya que tal y como está ahora el crawler hace peticiones HTTP a cada página de índice de películas y a la propia página, sacando sus URLs, pero luego el scraper volvería a hacerles peticiones al tener solo las URLs. El decidir si almacenar en variables el documento HTML extraído, cachearlo, usar un reverse proxy o alguna otra forma de no repetir peticiones se deja para el proximo PR

Adicionalmente, se arreglan unos pequeños problemas del scraper, por el cual no extraia peliculas que tenian caracteres no alfanumericos, como los dos puntos. Ahora es capaz de extraer ese tipo de paginas tambien (closes #92)