### PR TITLE
La araña se encarga de parsear las paginas relevantes y almacenar una referencia al documento

### DIFF
--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -41,7 +41,7 @@ var _ = BeforeSuite(func() {
 		tropes[subTrope] = struct{}{}
 	}
 
-	tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
+	tvTropesPage, _ := tropestogo.NewPage(oldboyUrl, false)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
 
@@ -168,7 +168,7 @@ var _ = Describe("CsvDataset", func() {
 			for subTrope := range newSubTropes {
 				newTropes[subTrope] = struct{}{}
 			}
-			tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
+			tvTropesPage, _ := tropestogo.NewPage(oldboyUrl, false)
 			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), newTropes, tvTropesPage, media.Film)
 
 			errUpdate = repository.UpdateMedia("Oldboy", "2003", updatedMediaEntry)

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 		tropes[subTrope] = struct{}{}
 	}
 
-	tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
+	tvTropesPage, _ := tropestogo.NewPage(oldboyUrl, false)
 	mediaEntry, _ = media.NewMedia("Oldboy", "2003", time.Now(), tropes, tvTropesPage, media.Film)
 })
 
@@ -163,7 +163,7 @@ var _ = Describe("JsonDataset", func() {
 				newTropes[subTrope] = struct{}{}
 			}
 
-			tvTropesPage, _ := tropestogo.NewPage(oldboyUrl)
+			tvTropesPage, _ := tropestogo.NewPage(oldboyUrl, false)
 			updatedMediaEntry, _ := media.NewMedia("Oldboy", "2013", time.Now(), newTropes, tvTropesPage, media.Film)
 
 			errUpdate = repository.UpdateMedia("Oldboy", "2003", updatedMediaEntry)

--- a/tropestogo/media/media_test.go
+++ b/tropestogo/media/media_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Media", func() {
 		tropes[trope2] = struct{}{}
 		lastUpdated = time.Now()
 
-		tvTropesPage, _ = tropestogo.NewPage(avengersUrl)
+		tvTropesPage, _ = tropestogo.NewPage(avengersUrl, false)
 	})
 
 	AfterEach(func() {

--- a/tropestogo/page.go
+++ b/tropestogo/page.go
@@ -75,7 +75,7 @@ func NewPage(pageUrl string, requestPage bool) (Page, error) {
 			return Page{}, fmt.Errorf("%w: "+newUrl.String(), ErrNotFound)
 		}
 
-		if httpResponse.StatusCode == 403 {
+		if httpResponse.StatusCode == 403 || httpResponse.StatusCode == 429 {
 			return Page{}, fmt.Errorf("%w: "+newUrl.String(), ErrForbidden)
 		}
 

--- a/tropestogo/page_test.go
+++ b/tropestogo/page_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Page", func() {
 
 	Context("Create a TvTropes Page object of a Film page", func() {
 		BeforeEach(func() {
-			validPage, errValidPage = tropestogo.NewPage(oldboyUrl)
+			validPage, errValidPage = tropestogo.NewPage(oldboyUrl, false)
 		})
 
 		It("Shouldn't return an error", func() {
@@ -40,7 +40,7 @@ var _ = Describe("Page", func() {
 
 	Context("Create a TvTropes Page object of a Trope page", func() {
 		BeforeEach(func() {
-			validPage, errValidPage = tropestogo.NewPage(tropeUrl)
+			validPage, errValidPage = tropestogo.NewPage(tropeUrl, false)
 		})
 
 		It("Shouldn't return an error", func() {
@@ -60,7 +60,7 @@ var _ = Describe("Page", func() {
 
 	Context("Create a TvTropes Page object of a Index page", func() {
 		BeforeEach(func() {
-			validPage, errValidPage = tropestogo.NewPage(indexUrl)
+			validPage, errValidPage = tropestogo.NewPage(indexUrl, false)
 		})
 
 		It("Shouldn't return an error", func() {
@@ -80,7 +80,7 @@ var _ = Describe("Page", func() {
 
 	Context("Create a Page object of a web that isn't TvTropes", func() {
 		BeforeEach(func() {
-			invalidPage, errInvalidPage = tropestogo.NewPage(googleUrl)
+			invalidPage, errInvalidPage = tropestogo.NewPage(googleUrl, false)
 		})
 
 		It("Should return an error", func() {
@@ -95,7 +95,7 @@ var _ = Describe("Page", func() {
 
 	Context("Create a Page with an empty URL", func() {
 		BeforeEach(func() {
-			nullPage, errNullPage = tropestogo.NewPage("")
+			nullPage, errNullPage = tropestogo.NewPage("", false)
 		})
 
 		It("Should return an error", func() {

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -69,27 +69,33 @@ func (crawler *ServiceCrawler) CrawlWorkPages(crawlLimit int) (*tropestogo.TvTro
 		}
 
 		var errAddPage error
-		var pageReader *http.Response
+		var workPage tropestogo.Page
 		pageSelector.EachWithBreak(func(i int, selection *goquery.Selection) bool {
 			if limitedCrawling && len(crawledPages.Pages) == crawlLimit {
 				return false
 			}
 
 			workUrl, urlExists := selection.Attr("href")
-			pageReader, errAddPage = http.Get(workUrl)
-			if pageReader.StatusCode == 403 {
-				time.Sleep(time.Minute)
-			}
-
-			if errAddPage != nil || !urlExists {
+			if !urlExists {
 				return false
 			}
 
-			pageDoc, _ := goquery.NewDocumentFromReader(pageReader.Body)
-			subPagesUrls := crawler.CrawlWorkSubpages(pageDoc)
+			// Create the Work Page
+			workPage, errAddPage = crawledPages.AddTvTropesPage(workUrl, true)
+			if errors.Is(errAddPage, tropestogo.ErrForbidden) {
+				time.Sleep(time.Minute)
+			}
 
-			errAddPage = crawledPages.AddTvTropesPage(workUrl, subPagesUrls)
-			time.Sleep(time.Second / 2)
+			// Search for subpages on the new Work Page
+			subPagesUrls := crawler.CrawlWorkSubpages(workPage.GetDocument())
+
+			// Add its subpages to the Work Page
+			errAddPage = crawledPages.AddSubpages(workUrl, subPagesUrls, true)
+
+			// If there's been too many requests to TvTropes, wait longer
+			if errors.Is(errAddPage, tropestogo.ErrForbidden) {
+				time.Sleep(time.Minute)
+			}
 
 			return true
 		})
@@ -200,8 +206,8 @@ func (crawler *ServiceCrawler) CrawlWorkPagesFromReaders(indexReader io.Reader, 
 			pageDoc, _ := goquery.NewDocumentFromReader(workReaders[i])
 			subPagesUrls := crawler.CrawlWorkSubpages(pageDoc)
 
-			errAddPage = crawledPages.AddTvTropesPage(workUrl, subPagesUrls)
-			time.Sleep(time.Second / 2)
+			_, errAddPage = crawledPages.AddTvTropesPage(workUrl, false)
+			errAddPage = crawledPages.AddSubpages(workUrl, subPagesUrls, false)
 
 			return true
 		})

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -156,13 +156,17 @@ func (crawler *ServiceCrawler) CrawlWorkSubpages(doc *goquery.Document) []string
 	})
 
 	// Get all main trope subpages (if there are any)
-	doc.Find(SubPageSelector).Each(func(_ int, selection *goquery.Selection) {
+	doc.Find(SubPageSelector).EachWithBreak(func(_ int, selection *goquery.Selection) bool {
 		subPageUri, subPageExists := selection.Attr("href")
 		r, _ := regexp.Compile(`\/tropes[a-z]to[a-z]`)
 		matchUri := r.MatchString(strings.ToLower(subPageUri))
 
 		if subPageExists && matchUri {
 			subPagesUrls = append(subPagesUrls, TvTropesWeb+subPageUri)
+
+			return true
+		} else {
+			return false
 		}
 	})
 

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -171,6 +171,7 @@ func (scraper *ServiceScraper) CheckIsWorkPage(doc *goquery.Document, url *url.U
 }
 
 // CheckTropeSection checks the received goquery Document DOM Tree
+// CheckTropeSection checks the received goquery Document DOM Tree
 // and validates if the tropes on the TvTropes Work Page are arranged in a known way that can be scraped
 // First it checks if there are folders, then if the list redirects to trope subpages and last if there's a list with only tropes
 // If the trope section isn't of the recognized types, it returns an ErrUnknownPageStructure, so it can't be scraped
@@ -330,7 +331,7 @@ func (scraper *ServiceScraper) ScrapeFromReaders(reader io.Reader, subReaders []
 	var subDocs []*goquery.Document
 	doc, _ := goquery.NewDocumentFromReader(reader)
 
-	page, errNewPage := tropestogo.NewPage(url.String())
+	page, errNewPage := tropestogo.NewPage(url.String(), false)
 	if errNewPage != nil {
 		return media.Media{}, fmt.Errorf("Error creating Page object \n%w", errNewPage)
 	}

--- a/tropestogo/service/scraper/scraper_test.go
+++ b/tropestogo/service/scraper/scraper_test.go
@@ -4,12 +4,12 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	"github.com/PuerkitoBio/goquery"
 	tropestogo "github.com/jlgallego99/TropesToGo"
 	"github.com/jlgallego99/TropesToGo/media"
 	"github.com/jlgallego99/TropesToGo/media/csv_dataset"
 	"github.com/jlgallego99/TropesToGo/media/json_dataset"
 	"github.com/jlgallego99/TropesToGo/service/scraper"
-	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -101,8 +101,11 @@ var _ = Describe("Scraper", func() {
 				pageReaderJson, _ = os.Open(oldboyResource)
 				pageReaderCsv, _ = os.Open(oldboyResource)
 
-				validTvTropesPageJson, errTvTropesJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl)
-				validTvTropesPageCsv, errTvTropesCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl)
+				docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+				docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+
+				validTvTropesPageJson, errTvTropesJson = serviceScraperJson.CheckValidWorkPage(docJson, tvTropesUrl)
+				validTvTropesPageCsv, errTvTropesCsv = serviceScraperCsv.CheckValidWorkPage(docCsv, tvTropesUrl)
 			})
 
 			It("Should mark the page as valid", func() {
@@ -125,8 +128,11 @@ var _ = Describe("Scraper", func() {
 				pageReaderJson, _ = os.Open(avengersResource)
 				pageReaderCsv, _ = os.Open(avengersResource)
 
-				validTvTropesPage2Json, errTvTropes2Json = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl2)
-				validTvTropesPage2Csv, errTvTropes2Csv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl2)
+				docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+				docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+
+				validTvTropesPage2Json, errTvTropes2Json = serviceScraperJson.CheckValidWorkPage(docJson, tvTropesUrl2)
+				validTvTropesPage2Csv, errTvTropes2Csv = serviceScraperCsv.CheckValidWorkPage(docCsv, tvTropesUrl2)
 			})
 
 			It("Should mark the page as valid", func() {
@@ -149,8 +155,11 @@ var _ = Describe("Scraper", func() {
 				pageReaderCsv, _ = os.Open(anewhopeResource)
 				pageReaderJson, _ = os.Open(anewhopeResource)
 
-				validTvTropesPage3Json, errTvTropes3Json = serviceScraperJson.CheckValidWorkPage(pageReaderJson, tvTropesUrl3)
-				validTvTropesPage3Csv, errTvTropes3Json = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, tvTropesUrl3)
+				docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+				docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+
+				validTvTropesPage3Json, errTvTropes3Json = serviceScraperJson.CheckValidWorkPage(docJson, tvTropesUrl3)
+				validTvTropesPage3Csv, errTvTropes3Json = serviceScraperCsv.CheckValidWorkPage(docCsv, tvTropesUrl3)
 			})
 
 			It("Should mark the page as valid", func() {
@@ -173,8 +182,11 @@ var _ = Describe("Scraper", func() {
 				pageReaderJson, _ = os.Open(emptyResource)
 				pageReaderCsv, _ = os.Open(emptyResource)
 
-				validNotWorkPageJson, errNotWorkPageJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, notWorkUrl)
-				validNotWorkPageCsv, errNotWorkPageCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, notWorkUrl)
+				docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+				docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+
+				validNotWorkPageJson, errNotWorkPageJson = serviceScraperJson.CheckValidWorkPage(docJson, notWorkUrl)
+				validNotWorkPageCsv, errNotWorkPageCsv = serviceScraperCsv.CheckValidWorkPage(docCsv, notWorkUrl)
 			})
 
 			It("Should mark the page as invalid", func() {
@@ -197,8 +209,11 @@ var _ = Describe("Scraper", func() {
 				pageReaderJson, _ = os.Open(emptyResource)
 				pageReaderCsv, _ = os.Open(emptyResource)
 
-				validDifferentPageJson, errDifferentJson = serviceScraperJson.CheckValidWorkPage(pageReaderJson, differentUrl)
-				validDifferentPageCsv, errDifferentCsv = serviceScraperCsv.CheckValidWorkPage(pageReaderCsv, differentUrl)
+				docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+				docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+
+				validDifferentPageJson, errDifferentJson = serviceScraperJson.CheckValidWorkPage(docJson, differentUrl)
+				validDifferentPageCsv, errDifferentCsv = serviceScraperCsv.CheckValidWorkPage(docCsv, differentUrl)
 			})
 
 			It("Should mark the page as invalid", func() {
@@ -222,8 +237,12 @@ var _ = Describe("Scraper", func() {
 			pageReaderCsv, _ = os.Open(attackontitanResource)
 			pageReaderJson, _ = os.Open(attackontitanResource)
 
-			filminvalidtypeJson, errorfilminvalidtypeJson = serviceScraperJson.ScrapeFromReaders(pageReaderCsv, []io.Reader{}, tvTropesUrlUnknown)
-			filminvalidtypeCsv, errorfilminvalidtypeCsv = serviceScraperCsv.ScrapeFromReaders(pageReaderJson, []io.Reader{}, tvTropesUrlUnknown)
+			docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+			docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+			subDocs := make([]*goquery.Document, 0)
+
+			filminvalidtypeJson, errorfilminvalidtypeJson = serviceScraperJson.ScrapeFromDocuments(docJson, subDocs, tvTropesUrlUnknown)
+			filminvalidtypeCsv, errorfilminvalidtypeCsv = serviceScraperCsv.ScrapeFromDocuments(docCsv, subDocs, tvTropesUrlUnknown)
 			errPersistCsv = serviceScraperCsv.Persist()
 			errPersistJson = serviceScraperJson.Persist()
 		})
@@ -278,28 +297,35 @@ var _ = Describe("Scraper", func() {
 			tvTropesUrl2, _ := url.Parse(avengersUrl)
 			tvTropesUrl3, _ := url.Parse(anewhopeUrl)
 
-			var subpageReadersCsv []io.Reader
-			var subpageReadersJson []io.Reader
+			var subpageDocsCsv []*goquery.Document
+			var subpageDocsJson []*goquery.Document
 
 			// Scrape Oldboy
-			subpageReadersJson, subpageReadersCsv = loadSubpageFiles(oldboySubpageFiles)
+			subpageDocsJson, subpageDocsCsv = loadSubpageFiles(oldboySubpageFiles)
 			pageReaderCsv, _ = os.Open(oldboyResource)
 			pageReaderJson, _ = os.Open(oldboyResource)
-			validfilm1Json, errorfilm1Json = serviceScraperJson.ScrapeFromReaders(pageReaderJson, subpageReadersJson, tvTropesUrl)
-			validfilm1Csv, errorfilm1Csv = serviceScraperCsv.ScrapeFromReaders(pageReaderCsv, subpageReadersCsv, tvTropesUrl)
+			docJson, _ := goquery.NewDocumentFromReader(pageReaderJson)
+			docCsv, _ := goquery.NewDocumentFromReader(pageReaderCsv)
+			validfilm1Json, errorfilm1Json = serviceScraperJson.ScrapeFromDocuments(docJson, subpageDocsJson, tvTropesUrl)
+			validfilm1Csv, errorfilm1Csv = serviceScraperCsv.ScrapeFromDocuments(docCsv, subpageDocsCsv, tvTropesUrl)
 
 			// Scrape The Avengers
-			subpageReadersJson, subpageReadersCsv = loadSubpageFiles(avengersSubpageFiles)
+			subpageDocsJson, subpageDocsCsv = loadSubpageFiles(avengersSubpageFiles)
 			pageReaderCsv, _ = os.Open(avengersResource)
 			pageReaderJson, _ = os.Open(avengersResource)
-			validfilm2Csv, errorfilm2Json = serviceScraperJson.ScrapeFromReaders(pageReaderJson, subpageReadersJson, tvTropesUrl2)
-			validfilm2Json, errorfilm2Csv = serviceScraperCsv.ScrapeFromReaders(pageReaderCsv, subpageReadersCsv, tvTropesUrl2)
+			docJson, _ = goquery.NewDocumentFromReader(pageReaderJson)
+			docCsv, _ = goquery.NewDocumentFromReader(pageReaderCsv)
+			validfilm2Csv, errorfilm2Json = serviceScraperJson.ScrapeFromDocuments(docCsv, subpageDocsCsv, tvTropesUrl2)
+			validfilm2Json, errorfilm2Csv = serviceScraperCsv.ScrapeFromDocuments(docJson, subpageDocsJson, tvTropesUrl2)
 
 			// Scrape A New Hope
 			pageReaderCsv, _ = os.Open(anewhopeResource)
 			pageReaderJson, _ = os.Open(anewhopeResource)
-			validfilm3Json, errorfilm3Json = serviceScraperJson.ScrapeFromReaders(pageReaderJson, []io.Reader{}, tvTropesUrl3)
-			validfilm3Csv, errorfilm3Csv = serviceScraperCsv.ScrapeFromReaders(pageReaderCsv, []io.Reader{}, tvTropesUrl3)
+			docJson, _ = goquery.NewDocumentFromReader(pageReaderJson)
+			docCsv, _ = goquery.NewDocumentFromReader(pageReaderCsv)
+			subDocs := make([]*goquery.Document, 0)
+			validfilm3Json, errorfilm3Json = serviceScraperJson.ScrapeFromDocuments(docJson, subDocs, tvTropesUrl3)
+			validfilm3Csv, errorfilm3Csv = serviceScraperCsv.ScrapeFromDocuments(docCsv, subDocs, tvTropesUrl3)
 
 			// Persist all data
 			errPersistJson = serviceScraperJson.Persist()
@@ -448,17 +474,20 @@ func areRepositorySubTropesUnique(subTropes []string, subPages []string) bool {
 	return true
 }
 
-func loadSubpageFiles(fileNames []string) ([]io.Reader, []io.Reader) {
-	var subpageReadersCsv []io.Reader
-	var subpageReadersJson []io.Reader
+func loadSubpageFiles(fileNames []string) ([]*goquery.Document, []*goquery.Document) {
+	var subpageDocsCsv []*goquery.Document
+	var subpageDocsJson []*goquery.Document
 
 	for _, subpageFile := range fileNames {
 		subpageReaderCsv, _ := os.Open(subpageFile)
 		subpageReaderJson, _ := os.Open(subpageFile)
 
-		subpageReadersCsv = append(subpageReadersCsv, subpageReaderCsv)
-		subpageReadersJson = append(subpageReadersJson, subpageReaderJson)
+		docCsv, _ := goquery.NewDocumentFromReader(subpageReaderCsv)
+		docJson, _ := goquery.NewDocumentFromReader(subpageReaderJson)
+
+		subpageDocsCsv = append(subpageDocsCsv, docCsv)
+		subpageDocsJson = append(subpageDocsJson, docJson)
 	}
 
-	return subpageReadersJson, subpageReadersCsv
+	return subpageDocsJson, subpageDocsCsv
 }

--- a/tropestogo/tvtropespages.go
+++ b/tropestogo/tvtropespages.go
@@ -3,12 +3,17 @@ package tropestogo
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"time"
 )
 
 var (
 	ErrDuplicatedPage = errors.New("the page already exists")
+	seededRand        = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
+
+const minWaitingSeconds = 0
+const maxWaitingSeconds = 4
 
 // TvTropesPages is an entity that manages all relevant pages in TvTropes for its extraction
 // Each Page has a last updated date, for checking future TvTropes updates on its Pages
@@ -36,10 +41,12 @@ func NewTvTropesPages() *TvTropesPages {
 
 // AddTvTropesPage creates a valid TvTropes Page from a string pageUrl and adds it to the internal structure of all pages
 // except if the page has already been added before, then it will return an ErrDuplicatedPage error
+// If the requestPages argument is true, it makes http requests to all pages with a random waiting time between requests
 // If the url is empty or has an invalid format, it will return either an ErrEmptyUrl or ErrBadUrl error
 // If the url does not belong to a TvTropes page, it will return an ErrNotTvTropes error
-func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string, subpageUrls []string) error {
-	newPage, errNewPage := NewPage(pageUrl)
+// If TvTropes denies access because of too many requests, it will not create the Page and return an ErrForbidden error for the crawler to manage
+func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string, subpageUrls []string, requestPages bool) error {
+	newPage, errNewPage := NewPage(pageUrl, requestPages)
 	if errNewPage != nil {
 		return errNewPage
 	}
@@ -55,12 +62,18 @@ func (tvtropespages *TvTropesPages) AddTvTropesPage(pageUrl string, subpageUrls 
 		Subpages:    make(map[Page]time.Time, 0),
 	}
 	for _, subpageUrl := range subpageUrls {
-		newSubpage, errSubpage := NewPage(subpageUrl)
+		newSubpage, errSubpage := NewPage(subpageUrl, requestPages)
 		if errSubpage != nil {
 			return errSubpage
 		}
 
 		subPages.Subpages[newSubpage] = time.Now()
+
+		// Wait random time between HTTP requests
+		if requestPages {
+			waitingFactor := seededRand.Intn(maxWaitingSeconds-minWaitingSeconds) + minWaitingSeconds
+			time.Sleep(time.Second * time.Duration(waitingFactor))
+		}
 	}
 
 	tvtropespages.Pages[newPage] = subPages

--- a/tropestogo/tvtropespages.go
+++ b/tropestogo/tvtropespages.go
@@ -15,7 +15,7 @@ var (
 )
 
 const minWaitingSeconds = 0
-const maxWaitingSeconds = 4
+const maxWaitingSeconds = 3
 
 // TvTropesPages is an entity that manages all relevant pages in TvTropes for its extraction
 // Each Page has a last updated date, for checking future TvTropes updates on its Pages

--- a/tropestogo/tvtropespages_test.go
+++ b/tropestogo/tvtropespages_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Tvtropespages", func() {
 		var errAddValid error
 
 		BeforeEach(func() {
-			errAddValid = tvtropespages.AddTvTropesPage(oldboyUrl, oldboySuburls)
+			errAddValid = tvtropespages.AddTvTropesPage(oldboyUrl, oldboySuburls, false)
 		})
 
 		It("Shouldn't return an error", func() {
@@ -58,8 +58,8 @@ var _ = Describe("Tvtropespages", func() {
 		var errAddValid2, errAddValid3 error
 
 		BeforeEach(func() {
-			errAddValid2 = tvtropespages.AddTvTropesPage(tropeUrl, []string{})
-			errAddValid3 = tvtropespages.AddTvTropesPage(indexUrl, []string{})
+			errAddValid2 = tvtropespages.AddTvTropesPage(tropeUrl, []string{}, false)
+			errAddValid3 = tvtropespages.AddTvTropesPage(indexUrl, []string{}, false)
 		})
 
 		It("Shouldn't return an error", func() {
@@ -82,8 +82,8 @@ var _ = Describe("Tvtropespages", func() {
 		var errAddDuplicated error
 
 		BeforeEach(func() {
-			errAddDuplicated = tvtropespages.AddTvTropesPage(oldboyUrl, oldboySuburls)
-			errAddDuplicated = tvtropespages.AddTvTropesPage(oldboyUrl, oldboySuburls)
+			errAddDuplicated = tvtropespages.AddTvTropesPage(oldboyUrl, oldboySuburls, false)
+			errAddDuplicated = tvtropespages.AddTvTropesPage(oldboyUrl, oldboySuburls, false)
 		})
 
 		It("Should return an error", func() {
@@ -99,7 +99,7 @@ var _ = Describe("Tvtropespages", func() {
 		var errAddEmpty error
 
 		BeforeEach(func() {
-			errAddEmpty = tvtropespages.AddTvTropesPage("", []string{})
+			errAddEmpty = tvtropespages.AddTvTropesPage("", []string{}, false)
 		})
 
 		It("Should return an error", func() {
@@ -115,7 +115,7 @@ var _ = Describe("Tvtropespages", func() {
 		var errAddEmpty error
 
 		BeforeEach(func() {
-			errAddEmpty = tvtropespages.AddTvTropesPage("htp$p%^^^&&***!!!!!", []string{})
+			errAddEmpty = tvtropespages.AddTvTropesPage("htp$p%^^^&&***!!!!!", []string{}, false)
 		})
 
 		It("Should return an error", func() {


### PR DESCRIPTION
Con este PR se mejora el crawler para almacenar el contenido de las páginas de forma temporal y que ni este ni el scraper dupliquen las peticiones HTTP o el parsing del HTML 

Ahora la entidad TvTropesPages se encarga de crear las páginas haciendo él mismo las peticiones HTTP y parseando el contenido a un documento Goquery, que se guarda en cada objeto Pagina como un puntero para poder reutilizarlos. De esta forma en todo el proceso de crawling se hacen todas las peticiones necesarias y luego el scraper no tiene que hacer ninguna, solo coger los documentos Goquery para hacer el scraping

Aunque sean 10 ficheros cambiados, la mayoría son cambios muy menores de pocas líneas para adaptarse al nuevo constructor de Page; el principal cambio está en Page, TvTropesPages, Scraper y Crawler, con cambios relativos a pasar todos los http.Get a los objetos pagina y liberar al scraper y crawler de hacerlos

closes #35 