### PR TITLE
Pequeña refactorización de la función de scraping

### DIFF
--- a/tropestogo/page.go
+++ b/tropestogo/page.go
@@ -94,6 +94,27 @@ func NewPage(pageUrl string, requestPage bool, req *http.Request) (Page, error) 
 	}, nil
 }
 
+// NewPageWithDocument creates a valid Page value-object that represents a generic and immutable TvTropes web page
+// FOR TEST PURPOSES ONLY: It accepts an already parsed goquery Document of the page contents for later scraping
+func NewPageWithDocument(pageUrl string, doc *goquery.Document) (Page, error) {
+	if pageUrl == "" {
+		return Page{}, ErrEmptyUrl
+	}
+
+	parsedUrl, errParse := parseTvTropesUrl(pageUrl)
+	if errParse != nil {
+		return Page{}, errParse
+	}
+
+	pageType := inferPageType(parsedUrl)
+
+	return Page{
+		url:      parsedUrl,
+		document: doc,
+		pageType: pageType,
+	}, nil
+}
+
 // parseTvTropesUrl accepts a pageUrl string and parses it to a valid URL object, only if it belongs to TvTropes
 // If it can't be parsed it returns an ErrBadUrl error and if it's not a TvTropes page it returns an ErrNotTvTropes error
 func parseTvTropesUrl(pageUrl string) (*url.URL, error) {


### PR DESCRIPTION
Se realiza una pequeña refactorización de la función principal de scraping para que funcione tanto con casos reales como con ficheros locales para test, utilizando ahora directamente los objetos Page, que son los objetos valor con los que siempre debe trabajar

closes #101 