### PR TITLE
Milestone6 updates scraper

### DIFF
--- a/tropestogo/media/csv_dataset/csv_dataset_test.go
+++ b/tropestogo/media/csv_dataset/csv_dataset_test.go
@@ -210,6 +210,31 @@ var _ = Describe("CsvDataset", func() {
 			Expect(len(records)).To(Equal(2))
 		})
 	})
+
+	Context("Get all the URLs of the persisted Media and its last updated time", func() {
+		var workPages map[string]time.Time
+		var errGetWorkPages error
+
+		BeforeEach(func() {
+			errAddMedia = repository.AddMedia(mediaEntry)
+			Expect(errAddMedia).To(BeNil())
+			errPersist = repository.Persist()
+			Expect(errPersist).To(BeNil())
+
+			workPages, errGetWorkPages = repository.GetWorkPages()
+		})
+
+		It("Shouldn't return an error", func() {
+			Expect(errGetWorkPages).To(BeNil())
+		})
+
+		It("Should return an URL and its last updated time", func() {
+			for workUrl, workLastUpdated := range workPages {
+				Expect(workUrl).To(Not(BeEmpty()))
+				Expect(workLastUpdated).To(Not(Equal(time.Time{})))
+			}
+		})
+	})
 })
 
 var _ = AfterSuite(func() {

--- a/tropestogo/media/json_dataset/json_dataset_test.go
+++ b/tropestogo/media/json_dataset/json_dataset_test.go
@@ -197,6 +197,31 @@ var _ = Describe("JsonDataset", func() {
 			Expect(len(dataset.Tropestogo)).To(Equal(1))
 		})
 	})
+
+	Context("Get all the URLs of the persisted Media and its last updated time", func() {
+		var workPages map[string]time.Time
+		var errGetWorkPages error
+
+		BeforeEach(func() {
+			errAddMedia = repository.AddMedia(mediaEntry)
+			Expect(errAddMedia).To(BeNil())
+			errPersist = repository.Persist()
+			Expect(errPersist).To(BeNil())
+
+			workPages, errGetWorkPages = repository.GetWorkPages()
+		})
+
+		It("Shouldn't return an error", func() {
+			Expect(errGetWorkPages).To(BeNil())
+		})
+
+		It("Should return an URL and its last updated time", func() {
+			for workUrl, workLastUpdated := range workPages {
+				Expect(workUrl).To(Not(BeEmpty()))
+				Expect(workLastUpdated).To(Not(Equal(time.Time{})))
+			}
+		})
+	})
 })
 
 var _ = AfterSuite(func() {

--- a/tropestogo/media/repository.go
+++ b/tropestogo/media/repository.go
@@ -1,5 +1,7 @@
 package media
 
+import "time"
+
 // RepositoryMedia defines an interface for all kinds of repositories of media tropes in TvTropes
 // The interface allows us to implement multiple structs that handle different data formats like CSV or JSON
 // sharing common methods
@@ -16,4 +18,7 @@ type RepositoryMedia interface {
 
 	// Persist adds all repository Media objects to the proper dataset
 	Persist() error
+
+	// GetWorkPages retrieves all persisted Work urls on the dataset and the last time they were updated
+	GetWorkPages() (map[string]time.Time, error)
 }

--- a/tropestogo/service/scraper/scraper.go
+++ b/tropestogo/service/scraper/scraper.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var (
@@ -455,6 +456,12 @@ func (scraper *ServiceScraper) ScrapeSubpageTropes(subDocs []*goquery.Document) 
 // It returns the namespace string
 func (scraper *ServiceScraper) ScrapeNamespace(doc *goquery.Document) string {
 	return strings.Trim(doc.Find(WorkIndexSelector).First().Text(), " /")
+}
+
+// GetScrapedPages returns a map of all the string URLs of the and the last time they were updated
+// To be used for searching updates on those pages
+func (scraper *ServiceScraper) GetScrapedPages() (map[string]time.Time, error) {
+	return scraper.data.GetWorkPages()
 }
 
 // UpdateDataset receives an array of TvTropes changes pages and updates all Media in the existing dataset that have had changes


### PR DESCRIPTION
Con este tercer y último PR se termina de implementar la funcionalidad de actualización de los datasets

Se implementa un nuevo método en los repositorios para que se lea el dataset y se obtenga un map con todas las URLs de las páginas extraídas y la última vez que se actualizaron. Esto permitirá al crawler saber qué páginas comprobar si se han actualizado, con lo desarrollado en el anterior PR

Se implementa un método nuevo en el scraper para que reciba una entidad TvTropesPages con las páginas que se han crawleado porque tienen cambios nuevos y por tanto hay que actualizar los datos. Hace scraping de cada una de ellas y actualiza los datos directamente en el dataset, ignorando aquellas peliculas que no han tenido ningun cambio. 

Se testea esta funcionalidad del scraper haciendo scraping de una página que ya se tiene pero quitándole los subtropos, de esta forma se actualiza en el fichero de datos la película con todo igual pero sin subtropos, comprobando que funciona correctamente

closes #100 