### PR TITLE
Flag en CLI para actualización de datasets

### DIFF
--- a/maskfile.md
+++ b/maskfile.md
@@ -10,6 +10,79 @@ cd tropestogo
 go run ./main.go
 ~~~
 
+### scrape
+> Command for scraping data with the TropesToGo CLI
+
+**OPTIONS**
+* format
+  * flags: -f --format
+  * type: string
+  * desc: The format of the generated dataset, CSV or JSON\
+* limit
+  * flags: -l --limit
+  * type: number
+  * desc: Limit the crawled works; is ignored if the -a flag is passed
+* media
+  * flags: -m --media
+  * type: string
+  * desc: The media type from which to scrape works
+* output
+  * flags: -o --output
+  * type: string
+  * desc: The name of the output dataset
+* all
+  * flags: -a -all
+  * desc: Scrape all works in the media type
+
+~~~sh
+cd tropestogo
+if [[ ! -z "$format" ]]; then 
+    format="-f ${format}" 
+else
+    format=""
+fi
+
+    
+if [[ ! -z "$media" ]]; then 
+    media="-m ${media}"
+else
+    media=""
+fi
+
+
+if [[ ! -z "$output" ]]; then 
+    output="-o ${output}"
+else
+    otuput=""
+fi
+
+if [[ ! -z "$limit" ]]; then
+    limit="-l ${limit}"
+else
+    limit=""
+fi
+
+if [[ $all == "true" ]]; then
+    go run ./main.go scrape -a $format $media $output $limit
+else
+    go run ./main.go scrape $format $media $output $limit
+fi
+~~~
+
+### update
+> Command for updating an scraped dataset with the TropesToGo CLI
+
+**OPTIONS**
+* dataset
+  * flags: -d --dataset
+  * type: string
+  * desc: Dataset name to update
+
+~~~sh
+cd tropestogo
+go run ./main.go update -d $dataset
+~~~
+
 ## build
 > Command for building the project
 ~~~sh

--- a/tropestogo/cmd/root.go
+++ b/tropestogo/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -20,6 +22,11 @@ this will extract 10 works with its tropes from TvTropes, and store them on a my
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	logFile, _ := os.OpenFile("log.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0664)
+	multiWriter := zerolog.MultiLevelWriter(zerolog.ConsoleWriter{Out: os.Stderr}, logFile)
+	log.Logger = zerolog.New(multiWriter).With().Timestamp().Logger()
+	log.Info().Msg("TropesToGo: A scraper for TvTropes")
+
 	err := rootCmd.Execute()
 	if err != nil {
 		log.Error().Err(err).Msg("There was a problem on the CLI program")

--- a/tropestogo/cmd/scrape.go
+++ b/tropestogo/cmd/scrape.go
@@ -106,5 +106,5 @@ func scrape() {
 
 	log.Info().Msgf("Process finished in %s\n", time.Since(start))
 	log.Info().Msg("TropesToGo finished successfully!")
-	log.Info().Msg("The generated TvTropes dataset is available on: " + datasetPath + "service/" + datasetName)
+	log.Info().Msg("The generated TvTropes dataset is available on: " + datasetPath + "/" + datasetName)
 }

--- a/tropestogo/cmd/scrape.go
+++ b/tropestogo/cmd/scrape.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jlgallego99/TropesToGo/media/json_dataset"
 	"github.com/jlgallego99/TropesToGo/service/crawler"
 	"github.com/jlgallego99/TropesToGo/service/scraper"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
@@ -38,11 +37,6 @@ var (
 of any media type with its tropes from TvTropes.
 Generates a dataset of the specified format when done.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logFile, _ := os.OpenFile("log.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0664)
-			multiWriter := zerolog.MultiLevelWriter(zerolog.ConsoleWriter{Out: os.Stderr}, logFile)
-			log.Logger = zerolog.New(multiWriter).With().Timestamp().Logger()
-			log.Info().Msg("TropesToGo: A scraper for TvTropes")
-
 			if !strings.EqualFold(dataFormat, CSV) && !strings.EqualFold(dataFormat, JSON) {
 				return fmt.Errorf("unknown data format: %s", dataFormat)
 			}

--- a/tropestogo/cmd/update.go
+++ b/tropestogo/cmd/update.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"github.com/jlgallego99/TropesToGo/media"
+	"github.com/jlgallego99/TropesToGo/media/csv_dataset"
+	"github.com/jlgallego99/TropesToGo/media/json_dataset"
+	"github.com/jlgallego99/TropesToGo/service/crawler"
+	"github.com/jlgallego99/TropesToGo/service/scraper"
+	"github.com/rs/zerolog/log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command
+var (
+	updateDatasetName, updateFileFormat string
+
+	updateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Updates an already-extracted dataset with new updated data, if there's any on TvTropes",
+		Long: `The update command updates the local dataset file by providing its name with the -d flag.
+By default, searches for a file with the name "dataset.json".`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Info().Msg("Launching TropesToGo Updater")
+
+			_, errFileExists := os.Stat(datasetPath + "/" + updateDatasetName)
+			if errFileExists != nil {
+				log.Error().Err(errFileExists).Msg("Couldn't retrieve the dataset file " + updateDatasetName)
+				return errFileExists
+			}
+
+			scrapeUpdates()
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+	updateCmd.PersistentFlags().StringVarP(&updateDatasetName, "dataset", "d", "dataset.json", "must specify a name for the dataset to update with the extension (-d <datasetfile>)")
+}
+
+func scrapeUpdates() {
+	start := time.Now()
+
+	// Call scraper to extract the persisted changedPages on the dataset
+	var repository media.RepositoryMedia
+	updateFileFormat = strings.ReplaceAll(filepath.Ext(updateDatasetName), ".", "")
+	if strings.EqualFold(updateFileFormat, CSV) {
+		repository, _ = csv_dataset.NewCSVRepository(updateDatasetName)
+	} else if strings.EqualFold(updateFileFormat, JSON) {
+		repository, _ = json_dataset.NewJSONRepository(updateDatasetName)
+	}
+
+	serviceScraper, err := scraper.NewServiceScraper(scraper.ConfigMediaRepository(repository))
+	if err != nil {
+		log.Error().Err(err).Msg("Error creating TropesToGo scraper")
+		return
+	}
+
+	pagesToBeUpdated, errScrapedPages := serviceScraper.GetScrapedPages()
+	if errScrapedPages != nil {
+		log.Error().Err(errScrapedPages).Msg("Scraping changedPages error")
+		return
+	}
+
+	// Crawling Pages with updates
+	serviceCrawler := crawler.NewCrawler()
+	changedPages, err := serviceCrawler.CrawlChanges(pagesToBeUpdated)
+	if err != nil && changedPages == nil {
+		log.Error().Err(err).Msg("Error in TropesToGo crawling changes")
+		return
+	}
+
+	// Updating changedPages
+	if len(changedPages.Pages) > 0 {
+		serviceScraper.UpdateDataset(changedPages)
+
+		log.Info().Msg(strconv.Itoa(len(changedPages.Pages)) + " have been updated in the dataset " + updateDatasetName)
+		log.Info().Msg("The updated TvTropes dataset is available on: " + datasetPath + "service/" + updateDatasetName)
+	} else {
+		log.Info().Msg("The dataset " + updateDatasetName + " is already up to date!")
+	}
+
+	log.Info().Msgf("Process finished in %s\n", time.Since(start))
+	log.Info().Msg("TropesToGo finished successfully!")
+}

--- a/tropestogo/media/json_dataset/json_dataset.go
+++ b/tropestogo/media/json_dataset/json_dataset.go
@@ -52,12 +52,15 @@ func Error(message string, err error, subErr error) error {
 // It receives the name that the JSON dataset file will have and creates the file with a "tropestogo" key with an empty array
 // It will return an ErrCreateJson error if the file couldn't be created
 func NewJSONRepository(name string) (*JSONRepository, error) {
-	f, err := os.Create(name + ".json")
-	if err != nil {
-		return nil, Error(name, ErrCreateJson, err)
-	}
+	// If the file doesn't exist, create it
+	if _, errStat := os.Stat(name + ".json"); errStat != nil {
+		f, errCreate := os.Create(name + ".json")
+		if errCreate != nil {
+			return nil, Error(name, ErrCreateJson, errCreate)
+		}
 
-	f.WriteString("{\"tropestogo\": []}")
+		f.WriteString("{\"tropestogo\": []}")
+	}
 
 	repository := &JSONRepository{
 		name: name + ".json",

--- a/tropestogo/service/crawler/crawler.go
+++ b/tropestogo/service/crawler/crawler.go
@@ -310,6 +310,9 @@ func (crawler *ServiceCrawler) CrawlChanges(crawledWorks map[string]time.Time) (
 			if errCrawlSubpages != nil {
 				return nil, errCrawlSubpages
 			}
+		} else {
+			// Delete from crawled because it hasn't been updated
+			delete(crawledPages.Pages, newPage)
 		}
 	}
 


### PR DESCRIPTION
Se termina la herramienta CLI para llamar a los métodos del crawler y scraper y que actualicen el dataset persistido

Se hace un pequeño cambio en los repositorios para que, al instanciarlos, no se elimine el dataset si ya ha sido creado de antemano, para poder actualizarlo c

Ademas se configura el logger en el punto de entrada del CLI

closes #108 